### PR TITLE
Promote CI setup to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    # Vendored third-party code (see PROJECT_OVERVIEW.md, issue B3).
+    - lib/internal/positioned_tap_detector_2.dart
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/lib/data.dart
+++ b/example/lib/data.dart
@@ -25,7 +25,7 @@ class DataEntry {
       required this.content,
       required this.type});
 
-  static List<DataEntry> CreateSampleData() {
+  static List<DataEntry> createSampleData() {
     List<DataEntry> entries = [
       DataEntry(
           id: 0,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,13 +51,13 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  var dataEntries = DataEntry.CreateSampleData();
+  var dataEntries = DataEntry.createSampleData();
 
   @override
   Widget build(BuildContext context) {
     // create planner entries from the data set
     List<PlannerEntry> entries = [];
-    dataEntries.forEach((element) {
+    for (final element in dataEntries) {
       entries.add(PlannerEntry(
           id: element.id.toString(),
           time: PlannerTime(
@@ -72,7 +72,7 @@ class _MyHomePageState extends State<MyHomePage> {
               element.title,
           content: element.content,
           color: element.type == DataType.A ? Colors.green : Colors.blue));
-    });
+    }
 
     return Scaffold(
         appBar: AppBar(
@@ -109,14 +109,14 @@ class _MyHomePageState extends State<MyHomePage> {
                 }
               },
               onEntryEdit: (entry) {
-                print('entry: ' + entry.title);
+                debugPrint('entry: ' + entry.title);
               },
               onEntryCreate: (time) {
-                print(
+                debugPrint(
                     'day: ${time.day} hour: ${time.hour} minutes: ${time.minutes}');
               },
               onEntryDelete: (entry) {
-                print('deleting entry: ' + entry.title);
+                debugPrint('deleting entry: ' + entry.title);
               }),
           entries: entries,
         )

--- a/test/planner_test.dart
+++ b/test/planner_test.dart
@@ -1,12 +1,55 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
 
 void main() {
-  test('adds one to input values', () {
-    //final calculator = Calculator();
-    //expect(calculator.addOne(2), 3);
-    //expect(calculator.addOne(-7), -6);
-    //expect(calculator.addOne(0), 1);
+  group('PlannerTime', () {
+    test('has sensible defaults', () {
+      final time = PlannerTime();
+      expect(time.day, 0);
+      expect(time.hour, 0);
+      expect(time.minutes, 0);
+      expect(time.duration, 60);
+    });
+
+    test('stores provided values', () {
+      final time = PlannerTime(day: 2, hour: 9, minutes: 30, duration: 90);
+      expect(time.day, 2);
+      expect(time.hour, 9);
+      expect(time.minutes, 30);
+      expect(time.duration, 90);
+    });
+  });
+
+  group('PlannerEntry', () {
+    test('stores its fields', () {
+      final entry = PlannerEntry(
+        id: 'a1',
+        time: PlannerTime(day: 1, hour: 8),
+        title: 'Stand-up',
+        content: 'Daily sync',
+        color: const Color(0xFF00FF00),
+      );
+
+      expect(entry.id, 'a1');
+      expect(entry.time.day, 1);
+      expect(entry.time.hour, 8);
+      expect(entry.title, 'Stand-up');
+      expect(entry.content, 'Daily sync');
+      expect(entry.color, const Color(0xFF00FF00));
+    });
+  });
+
+  group('PlannerConfig', () {
+    test('applies documented defaults', () {
+      final config = PlannerConfig(labels: const ['Mon', 'Tue']);
+      expect(config.labels, ['Mon', 'Tue']);
+      expect(config.minHour, 0);
+      expect(config.maxHour, 24);
+      expect(config.blockWidth, 200);
+      expect(config.blockHeight, 40);
+    });
   });
 }


### PR DESCRIPTION
## Summary
First `develop` → `main` promotion under the new branch workflow. Brings the CI pipeline and the analysis/test cleanup into `main`.

## Linked issue
N/A

## Changes
- Add GitHub Actions CI (`verify` job: format check, `flutter analyze`, `flutter test`) on pushes/PRs to `main`/`develop`.
- Replace the empty test stub with real `PlannerTime`/`PlannerEntry`/`PlannerConfig` tests.
- Exclude the vendored `positioned_tap_detector_2.dart` from the lint gate (PROJECT_OVERVIEW B3).
- Fix example lints (`createSampleData`, `for` loop, `debugPrint`).

## Test plan
- [x] CI `verify` job passed on `develop`
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `flutter analyze` reports no issues
- [x] `flutter test` passes (4 tests)

## Notes / screenshots
This PR is itself gated by the required `verify` check on `main`.