### PR TITLE
fix: instance-scope controller state and persist Manager (#9)

### DIFF
--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -14,14 +14,14 @@ enum MenuType {
 class Controller {
   final triggerUpdate = ValueNotifier<int>(0);
 
-  static double _x = 0;
+  double _x = 0;
   double get x => _x;
   set x(double value) {
     _x = value;
     triggerUpdate.value++;
   }
 
-  static double _y = 0;
+  double _y = 0;
   double get y => _y;
   set y(double value) {
     _y = value;
@@ -37,12 +37,12 @@ class Controller {
 
   Offset get offset => Offset(x, y);
 
-  static double _previousZoom = 1;
-  static double _zoom = 1;
+  double _previousZoom = 1;
+  double _zoom = 1;
   double get zoom => _zoom;
 
-  static double _hDragStart = 0;
-  static double _hDrag = 0;
+  double _hDragStart = 0;
+  double _hDrag = 0;
 
   double _vDragStart = 0;
   double _vDrag = 0;
@@ -59,9 +59,17 @@ class Controller {
   PlannerTime? menuTime;
   Function? _onCloseMenu;
 
-  final PlannerConfig config;
+  PlannerConfig config;
 
   Controller(this.config) {
+    _calculateOffsets();
+  }
+
+  /// Adopts a new [config] (e.g. when the host `Planner` is rebuilt with
+  /// different settings) and recomputes the scroll bounds, while leaving the
+  /// current scroll/zoom position untouched.
+  void updateConfig(PlannerConfig config) {
+    this.config = config;
     _calculateOffsets();
   }
 

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -6,16 +6,34 @@ import '../planner_time.dart';
 import 'controller.dart';
 
 class Manager {
-  final PlannerConfig config;
-  final List<PlannerEntry> entries;
-  late Controller controller;
+  PlannerConfig config;
+  List<PlannerEntry> entries;
+  final Controller controller;
   final List<Event> events = [];
 
   Manager({
     required this.config,
     required this.entries,
+  }) : controller = Controller(config) {
+    _buildEvents();
+  }
+
+  /// Refreshes the planner data in place when the host `Planner` widget is
+  /// rebuilt with new [config] or [entries]. The [controller] is preserved, so
+  /// the current scroll/zoom position survives the rebuild instead of being
+  /// reset — which is what the previous `static` controller state hacked around.
+  void update({
+    required PlannerConfig config,
+    required List<PlannerEntry> entries,
   }) {
-    controller = Controller(config);
+    this.config = config;
+    this.entries = entries;
+    controller.updateConfig(config);
+    _buildEvents();
+  }
+
+  void _buildEvents() {
+    events.clear();
     for (PlannerEntry entry in entries) {
       events.add(Event(entry: entry, manager: this));
     }

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -13,24 +13,43 @@ import 'planner_config.dart';
 class Planner extends StatefulWidget {
   final List<PlannerEntry> entries;
   final PlannerConfig config;
-  final Manager data;
 
-  Planner({
+  const Planner({
     Key? key,
     required this.config,
     required this.entries,
-  })  : data = Manager(config: config, entries: entries),
-        super(key: key);
+  }) : super(key: key);
 
   @override
   _PlannerState createState() => _PlannerState();
 }
 
 class _PlannerState extends State<Planner> {
+  // Owned by the State so it survives parent rebuilds: building it in the widget
+  // constructor recreated the Manager (every Event, every TextPainter, the whole
+  // Grid) on every parent build and forced the Controller's scroll/zoom to be
+  // static to survive that churn.
+  late Manager _data;
+
+  @override
+  void initState() {
+    super.initState();
+    _data = Manager(config: widget.config, entries: widget.entries);
+  }
+
+  @override
+  void didUpdateWidget(covariant Planner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.config, widget.config) ||
+        !identical(oldWidget.entries, widget.entries)) {
+      _data.update(config: widget.config, entries: widget.entries);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-      widget.data.controller.setSize(constraints.biggest);
+      _data.controller.setSize(constraints.biggest);
       return Column(
         children: [
           paintDates(),
@@ -46,16 +65,14 @@ class _PlannerState extends State<Planner> {
                           if (position.relative == null) {
                             return;
                           }
-                          var event =
-                              widget.data.getEventAtPos(position.relative!);
+                          var event = _data.getEventAtPos(position.relative!);
                           if (event != null &&
-                              widget.data.config.onEntryEdit != null) {
-                            widget.data.config.onEntryEdit!(event.entry);
+                              _data.config.onEntryEdit != null) {
+                            _data.config.onEntryEdit!(event.entry);
                           } else if (event == null &&
-                              widget.data.config.onEntryCreate != null) {
-                            var time =
-                                widget.data.getTimeAtPos(position.relative!);
-                            widget.data.config.onEntryCreate!(time);
+                              _data.config.onEntryCreate != null) {
+                            var time = _data.getTimeAtPos(position.relative!);
+                            _data.config.onEntryCreate!(time);
                           }
                         },
                         child: paintEvents(),
@@ -75,7 +92,7 @@ class _PlannerState extends State<Planner> {
 
   List<Widget> paintMenu() {
     List<Widget> result = [];
-    if (widget.data.controller.menuType != MenuType.none) {
+    if (_data.controller.menuType != MenuType.none) {
       result.add(
         Positioned.fill(child: Container(color: Colors.transparent)),
       );
@@ -83,17 +100,17 @@ class _PlannerState extends State<Planner> {
       result.add(
         GestureDetector(
           behavior: HitTestBehavior.translucent,
-          onPanStart: (_) => widget.data.controller.hideMenu(),
-          onTap: () => widget.data.controller.hideMenu(),
-          onSecondaryTapDown: (_) => widget.data.controller.hideMenu(),
+          onPanStart: (_) => _data.controller.hideMenu(),
+          onTap: () => _data.controller.hideMenu(),
+          onSecondaryTapDown: (_) => _data.controller.hideMenu(),
           child: Container(),
         ),
       );
 
       result.add(
         Transform.translate(
-          offset: widget.data.controller.menuPos!,
-          child: ContextMenu(manager: widget.data),
+          offset: _data.controller.menuPos!,
+          child: ContextMenu(manager: _data),
         ),
       );
     }
@@ -103,17 +120,17 @@ class _PlannerState extends State<Planner> {
   GestureDetector paintDates() {
     return GestureDetector(
       onHorizontalDragStart: (detail) =>
-          widget.data.controller.startHorizontalDrag(detail.globalPosition.dx),
+          _data.controller.startHorizontalDrag(detail.globalPosition.dx),
       onHorizontalDragUpdate: (detail) =>
-          widget.data.controller.updateHorizontalDrag(detail.globalPosition.dx),
+          _data.controller.updateHorizontalDrag(detail.globalPosition.dx),
       child: ClipRect(
         child: Container(
-          height: widget.data.config.dateRowHeight,
-          color: widget.data.config.dateBackground,
+          height: _data.config.dateRowHeight,
+          color: _data.config.dateBackground,
           child: CustomPaint(
             painter: DateRow(
-              manager: widget.data,
-              repaint: widget.data.controller.triggerUpdate,
+              manager: _data,
+              repaint: _data.controller.triggerUpdate,
             ),
             child: Container(),
           ),
@@ -131,8 +148,8 @@ class _PlannerState extends State<Planner> {
           padding: const EdgeInsets.only(top: 8.0),
           child: RawMaterialButton(
             onPressed: () {
-              widget.data.controller.startZoom();
-              widget.data.controller.updateZoom(0.9);
+              _data.controller.startZoom();
+              _data.controller.updateZoom(0.9);
             },
             elevation: 2.0,
             constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
@@ -150,8 +167,8 @@ class _PlannerState extends State<Planner> {
           padding: const EdgeInsets.only(top: 8.0),
           child: RawMaterialButton(
             onPressed: () {
-              widget.data.controller.startZoom();
-              widget.data.controller.updateZoom(1.1);
+              _data.controller.startZoom();
+              _data.controller.updateZoom(1.1);
             },
             elevation: 2.0,
             constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
@@ -172,23 +189,23 @@ class _PlannerState extends State<Planner> {
   GestureDetector paintEvents() {
     return GestureDetector(
       onHorizontalDragStart: (detail) =>
-          widget.data.controller.startHorizontalDrag(detail.globalPosition.dx),
+          _data.controller.startHorizontalDrag(detail.globalPosition.dx),
       onHorizontalDragUpdate: (detail) =>
-          widget.data.controller.updateHorizontalDrag(detail.globalPosition.dx),
-      onScaleStart: ((details) => widget.data.controller.startZoom()),
+          _data.controller.updateHorizontalDrag(detail.globalPosition.dx),
+      onScaleStart: ((details) => _data.controller.startZoom()),
       onScaleUpdate: (details) =>
-          widget.data.controller.updateZoom(details.verticalScale),
+          _data.controller.updateZoom(details.verticalScale),
       onLongPressStart: (details) {
-        widget.data.controller.touchPos = details.localPosition;
+        _data.controller.touchPos = details.localPosition;
       },
       onLongPressMoveUpdate: (details) {
-        widget.data.controller.touchPos = details.localPosition;
+        _data.controller.touchPos = details.localPosition;
       },
       onLongPressEnd: (details) {
-        widget.data.controller.touchPos = null;
+        _data.controller.touchPos = null;
       },
       onTap: () {
-        widget.data.controller.hideMenu();
+        _data.controller.hideMenu();
       },
       onSecondaryTapDown: (details) {
         showMenu(details);
@@ -197,17 +214,17 @@ class _PlannerState extends State<Planner> {
           child: ScrollDetector(
         onPointerScroll: (event) {
           if (event.scrollDelta.dy > 0) {
-            widget.data.controller.verticalScroll(true);
+            _data.controller.verticalScroll(true);
           } else {
-            widget.data.controller.verticalScroll(false);
+            _data.controller.verticalScroll(false);
           }
         },
         child: Container(
-            color: widget.data.config.plannerBackground,
+            color: _data.config.plannerBackground,
             child: CustomPaint(
               painter: EventsPainter(
-                manager: widget.data,
-                repaint: widget.data.controller.triggerUpdate,
+                manager: _data,
+                repaint: _data.controller.triggerUpdate,
               ),
               child: Container(),
             )),
@@ -218,25 +235,25 @@ class _PlannerState extends State<Planner> {
   GestureDetector paintHours() {
     return GestureDetector(
       onVerticalDragStart: ((details) =>
-          widget.data.controller.startVerticalDrag(details.globalPosition.dy)),
+          _data.controller.startVerticalDrag(details.globalPosition.dy)),
       onVerticalDragUpdate: ((details) =>
-          widget.data.controller.updateVerticalDrag(details.globalPosition.dy)),
+          _data.controller.updateVerticalDrag(details.globalPosition.dy)),
       child: ClipRect(
         child: ScrollDetector(
           onPointerScroll: (event) {
             if (event.scrollDelta.dy > 0) {
-              widget.data.controller.verticalScroll(true);
+              _data.controller.verticalScroll(true);
             } else {
-              widget.data.controller.verticalScroll(false);
+              _data.controller.verticalScroll(false);
             }
           },
           child: Container(
-            width: widget.data.config.hourColumnWidth,
-            color: widget.data.config.hourBackground,
+            width: _data.config.hourColumnWidth,
+            color: _data.config.hourBackground,
             child: CustomPaint(
               painter: HourColumn(
-                manager: widget.data,
-                repaint: widget.data.controller.triggerUpdate,
+                manager: _data,
+                repaint: _data.controller.triggerUpdate,
               ),
               child: Container(),
             ),
@@ -251,14 +268,12 @@ class _PlannerState extends State<Planner> {
   }
 
   void showMenu(TapDownDetails details) {
-    var event = widget.data.getEventAtPos(details.localPosition);
+    var event = _data.getEventAtPos(details.localPosition);
     if (event != null) {
-      widget.data.controller
-          .showEventMenu(details.localPosition, event, hideMenu);
+      _data.controller.showEventMenu(details.localPosition, event, hideMenu);
     } else {
-      var time = widget.data.getTimeAtPos(details.localPosition);
-      widget.data.controller
-          .showPlannerMenu(details.localPosition, time, hideMenu);
+      var time = _data.getTimeAtPos(details.localPosition);
+      _data.controller.showPlannerMenu(details.localPosition, time, hideMenu);
     }
 
     setState(() {});

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/controller.dart';
+import 'package:planner/planner.dart';
+
+void main() {
+  PlannerConfig makeConfig() => PlannerConfig(labels: const ['A', 'B', 'C']);
+
+  group('Controller scroll/zoom state is per-instance', () {
+    // Regression for D1: these fields used to be `static`, so two controllers
+    // (i.e. two Planners in the same app) shared one scroll/zoom position.
+    test('horizontal/vertical offset does not leak between controllers', () {
+      final a = Controller(makeConfig());
+      final b = Controller(makeConfig());
+
+      a.x = -120;
+      a.y = -80;
+
+      expect(a.x, -120);
+      expect(a.y, -80);
+      expect(b.x, 0, reason: 'b must keep its own offset');
+      expect(b.y, 0, reason: 'b must keep its own offset');
+    });
+
+    test('zoom does not leak between controllers', () {
+      final a = Controller(makeConfig());
+      final b = Controller(makeConfig());
+
+      a.startZoom();
+      a.updateZoom(2.0);
+
+      expect(a.zoom, 2.0);
+      expect(b.zoom, 1.0, reason: 'b must keep its own zoom');
+    });
+
+    test('drag state does not leak between controllers', () {
+      final config = makeConfig();
+      final a = Controller(config);
+      final b = Controller(config);
+
+      a.startHorizontalDrag(100);
+      a.updateHorizontalDrag(80); // drag left by 20px
+
+      expect(a.x, lessThan(0));
+      expect(b.x, 0, reason: 'dragging a must not move b');
+    });
+  });
+
+  test('updateConfig recomputes bounds but keeps current scroll/zoom', () {
+    final controller = Controller(makeConfig());
+    controller.x = -50;
+    controller.y = -30;
+    controller.startZoom();
+    controller.updateZoom(1.5);
+
+    controller.updateConfig(PlannerConfig(labels: const ['A', 'B', 'C', 'D']));
+
+    expect(controller.x, -50);
+    expect(controller.y, -30);
+    expect(controller.zoom, 1.5);
+  });
+}

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+void main() {
+  PlannerConfig makeConfig() => PlannerConfig(labels: const ['A', 'B']);
+
+  PlannerEntry makeEntry(String id, int day) => PlannerEntry(
+        id: id,
+        time: PlannerTime(day: day, hour: 9),
+        title: 'event $id',
+        content: '',
+        color: const Color(0xFF112233),
+      );
+
+  test('builds one Event per entry', () {
+    final manager = Manager(
+      config: makeConfig(),
+      entries: [makeEntry('1', 0), makeEntry('2', 1)],
+    );
+
+    expect(manager.events.length, 2);
+  });
+
+  // Regression for D2: previously a new Manager (and a new Controller) was built
+  // on every parent rebuild, so scroll/zoom only survived via static state.
+  // update() now refreshes the data in place while preserving the controller.
+  test(
+      'update() preserves the controller (and scroll/zoom) and refreshes events',
+      () {
+    final manager = Manager(
+      config: makeConfig(),
+      entries: [makeEntry('1', 0)],
+    );
+
+    final controllerBefore = manager.controller;
+    manager.controller.x = -75;
+    manager.controller.startZoom();
+    manager.controller.updateZoom(1.5);
+
+    manager.update(
+      config: makeConfig(),
+      entries: [makeEntry('1', 0), makeEntry('2', 1)],
+    );
+
+    expect(identical(manager.controller, controllerBefore), isTrue,
+        reason: 'the controller must persist across an update');
+    expect(manager.controller.x, -75, reason: 'scroll position is preserved');
+    expect(manager.controller.zoom, 1.5, reason: 'zoom is preserved');
+    expect(manager.events.length, 2, reason: 'events reflect the new entries');
+  });
+}

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+void main() {
+  // End-to-end against the *real* composed widget (real layout, real fonts, real
+  // gestures) — the layer where the static-state bug actually bit: two Planners
+  // on one screen sharing a single scroll/zoom position.
+
+  // A point inside a planner's event grid: skip the hour column (50) and date
+  // row (50), then +100px right / +200px down so it lands cleanly in the grid.
+  Offset gridPointFor(Rect planner) =>
+      planner.topLeft + const Offset(50 + 100, 50 + 200);
+
+  // Right-click a planner to open its context menu, then tap "Create Event". The
+  // menu's time is computed from the current scroll/zoom via getTimeAtPos, so the
+  // resulting onEntryCreate callback reveals where the tap mapped to. The finder
+  // is scoped to [plannerKey] so two planners on screen stay unambiguous.
+  Future<void> createViaMenu(
+      WidgetTester tester, Key plannerKey, Offset at) async {
+    final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    await tester.tap(find.descendant(
+      of: find.byKey(plannerKey),
+      matching: find.text('Create Event'),
+    ));
+    await tester.pump();
+  }
+
+  Future<void> wheelScroll(WidgetTester tester, Offset at, int notches) async {
+    final mouse = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(mouse.hover(at));
+    for (var i = 0; i < notches; i++) {
+      await tester.sendEventToBinding(mouse.scroll(const Offset(0, 20)));
+      await tester.pump();
+    }
+  }
+
+  testWidgets('two planners keep independent scroll state (D1)',
+      (tester) async {
+    const keyA = ValueKey('plannerA');
+    const keyB = ValueKey('plannerB');
+    PlannerTime? createdA;
+    PlannerTime? createdB;
+
+    PlannerConfig configFor(void Function(PlannerTime) onCreate) =>
+        PlannerConfig(
+          labels: const ['c1', 'c2', 'c3'],
+          minHour: 0,
+          maxHour: 23,
+          onEntryCreate: onCreate,
+        );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Row(
+          children: [
+            Expanded(
+              child: Planner(
+                key: keyA,
+                config: configFor((t) => createdA = t),
+                entries: const [],
+              ),
+            ),
+            Expanded(
+              child: Planner(
+                key: keyB,
+                config: configFor((t) => createdB = t),
+                entries: const [],
+              ),
+            ),
+          ],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final pointA = gridPointFor(tester.getRect(find.byKey(keyA)));
+    final pointB = gridPointFor(tester.getRect(find.byKey(keyB)));
+
+    // The chosen point maps to hour 5 in an unscrolled grid (200px / 40px).
+    const unscrolledHour = 5;
+
+    // Scroll ONLY planner A (before opening any menu, which otherwise leaves a
+    // lingering overlay that blocks the wheel).
+    await wheelScroll(tester, pointA, 4);
+
+    await createViaMenu(tester, keyA, pointA);
+    await createViaMenu(tester, keyB, pointB);
+    expect(createdA, isNotNull);
+    expect(createdB, isNotNull);
+
+    // A scrolled down, so the same screen point now maps to a later hour; B was
+    // never touched and still maps to the unscrolled hour. Under the old static
+    // state, scrolling A also moved B and both would report the later hour.
+    expect(createdA!.hour, greaterThan(unscrolledHour),
+        reason: 'scrolling A must change what A hit-tests');
+    expect(createdB!.hour, unscrolledHour,
+        reason: 'scrolling A must NOT change what B hit-tests');
+  });
+
+  testWidgets('scroll position survives a parent rebuild (D2)', (tester) async {
+    const key = ValueKey('planner');
+    PlannerTime? created;
+    var tick = 0;
+    late StateSetter rebuild;
+
+    PlannerConfig makeConfig() => PlannerConfig(
+          labels: const ['c1', 'c2', 'c3'],
+          minHour: 0,
+          maxHour: 23,
+          onEntryCreate: (t) => created = t,
+        );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            // Fresh config + entries list each build, like a real parent that
+            // rebuilds for an unrelated reason. The Manager must NOT be torn down
+            // and the scroll position must survive.
+            return Planner(
+              key: key,
+              config: makeConfig(),
+              entries: [
+                PlannerEntry(
+                  id: 'rebuild-$tick',
+                  time: PlannerTime(day: 0, hour: 1),
+                  title: 'e$tick',
+                  content: '',
+                  color: const Color(0xFF112233),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final point = gridPointFor(tester.getRect(find.byKey(key)));
+
+    await wheelScroll(tester, point, 4);
+    await createViaMenu(tester, key, point);
+    expect(created, isNotNull);
+    final scrolledHour = created!.hour;
+    // Confirm the scroll actually moved the grid (unscrolled this point is hour 5),
+    // otherwise the persistence check below would pass trivially.
+    expect(scrolledHour, greaterThan(5));
+
+    // Force a parent rebuild with fresh config/entries.
+    tick++;
+    rebuild(() {});
+    await tester.pumpAndSettle();
+
+    await createViaMenu(tester, key, point);
+    expect(created!.hour, scrolledHour,
+        reason: 'scroll position must survive a parent rebuild');
+  });
+}


### PR DESCRIPTION
## Summary
Removes the `static` scroll/zoom state from `Controller` and stops rebuilding `Manager` on every parent build. Previously every `Planner` in the app shared one scroll/zoom position (state leaked between unrelated screens / between two planners), because those fields were `static` — a workaround for `Manager` being constructed in the `Planner` widget constructor, which recreated the `Manager`, every `Event`, every `TextPainter`, and the whole `Grid` on each parent rebuild. The two were coupled, so they are fixed together.

## Linked issue
Closes #9

## Changes
- **`lib/internal/controller.dart`** — `_x, _y, _zoom, _previousZoom, _hDragStart, _hDrag` are now instance fields (were `static`). Added `updateConfig()` to refresh scroll bounds without resetting position.
- **`lib/internal/manager.dart`** — owns a persistent `Controller`; new `update()` refreshes `config`/`entries` in place, preserving scroll/zoom (instead of recreating the `Manager`).
- **`lib/planner_class.dart`** — `Manager` is created in `initState` and refreshed in `didUpdateWidget`, not in the widget constructor. `Planner` constructor is now `const`; `widget.data` → State-owned `_data`.

## Test plan
- [x] `flutter analyze` clean
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] unit/widget tests pass — `flutter test` (12 tests: 4 pre-existing + 8 new)
  - `test/controller_test.dart` — per-instance scroll/zoom/drag independence; `updateConfig` keeps position.
  - `test/manager_test.dart` — `update()` preserves the controller and refreshes events.
  - `test/planner_widget_test.dart` — **end-to-end**: two real `Planner`s, scroll one, assert the other is unaffected; and scroll survives a parent rebuild.
- [x] Regression confirmed: reverting only the `lib/` changes makes the end-to-end D1 test fail on the old static-state code (`Expected: <5> Actual: <7>` — planner B leaked planner A's scroll); it passes with the fix.

## Notes
- **On integration tests:** the D1 test is a genuine end-to-end run of the *composed* widget (real layout/fonts/gestures), which for a single-widget package is the meaningful end-to-end coverage. A device-level `integration_test` would add little for this bug, since it is pure object-lifecycle/state-scoping (fully reproduced and proven to fail in the widget harness) rather than a rendering/font/layout bug. Standing up real `integration_test` infrastructure + a CI device job is filed separately as **#30** (it pays off on the upcoming geometry/rendering work D3/D4/D10/D11).
- The e2e test drives creation via the real right-click → "Create Event" path; the `onDoubleTap` create path was unusable in the harness because the vendored `PositionedTapDetector2` loses the gesture arena to the inner detector, and the planner menu doesn't auto-dismiss — both pre-existing, out-of-scope quirks (D5/D12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)