### PR TITLE
chore: stand up integration_test infrastructure + Windows CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,27 @@ jobs:
 
       - name: Run tests
         run: flutter test
+
+  integration-windows:
+    name: integration (windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Enable Windows desktop
+        run: flutter config --enable-windows-desktop
+
+      - name: Install example dependencies
+        run: flutter pub get
+        working-directory: example
+
+      - name: Run integration tests on Windows
+        run: flutter test integration_test -d windows
+        working-directory: example

--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -1,0 +1,54 @@
+# Integration tests
+
+End-to-end tests that drive the planner on a **real device** (real fonts, real
+layout, real gestures) — the layer where the widget harness (Ahem font, fixed
+surface) can miss rendering/geometry bugs.
+
+| File | What it covers |
+|------|----------------|
+| [`app_test.dart`](app_test.dart) | The single entry point. Registers every scenario so the whole suite runs in **one** app launch (desktop can only launch one app per `flutter test` invocation). |
+| [`app_smoke_scenarios.dart`](app_smoke_scenarios.dart) | Boots the real example app; asserts a `Planner` renders and the real secondary-tap menu opens. |
+| [`multi_planner_scenarios.dart`](multi_planner_scenarios.dart) | Two planners on one screen keep independent scroll state (device-level counterpart of the #9 / D1 regression). |
+| [`planner_harness.dart`](planner_harness.dart) | Reusable `PlannerHarness` for multi-planner / multi-config flows, plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`). |
+
+## Running
+
+Run from the `example/` directory.
+
+### Windows (what CI runs)
+
+```sh
+flutter config --enable-windows-desktop   # once, if not already enabled
+flutter test integration_test -d windows
+```
+
+### Web (Chrome)
+
+Needs a matching [ChromeDriver](https://chromedriver.chromium.org/) on
+`--port=4444`, run per target file via the driver:
+
+```sh
+chromedriver --port=4444 &
+flutter drive \
+  --driver=test_driver/integration_test.dart \
+  --target=integration_test/app_test.dart \
+  -d chrome
+```
+
+## Adding a test
+
+Add scenarios as **functions called from [`app_test.dart`](app_test.dart)**, not
+as new `*_test.dart` files — desktop launches one app per test file and a second
+launch within an invocation is unreliable, so the suite is kept to a single
+entry point.
+
+Multi-planner or multi-config scenarios should build on `PlannerHarness` rather
+than the single-`Planner` example app:
+
+```dart
+await tester.pumpWidget(PlannerHarness(planners: [
+  PlannerSpec(config: configA, entries: entriesA),
+  PlannerSpec(config: configB),
+]));
+final pointA = gridPointFor(tester.getRect(find.byKey(PlannerHarness.keyFor(0))));
+```

--- a/example/integration_test/app_smoke_scenarios.dart
+++ b/example/integration_test/app_smoke_scenarios.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+import 'package:example/main.dart' as app;
+
+/// Drives the *real* example app end-to-end (real entrypoint, real fonts, real
+/// layout, real gestures) on the device under test. Event titles and hour/day
+/// labels are painted on the CustomPaint canvas rather than rendered as Text
+/// widgets, so assertions target the things that are real widgets: the app bar
+/// and the context menu.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void appSmokeScenarios() {
+  testWidgets('example app boots and renders a Planner', (tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Planner), findsOneWidget);
+    expect(find.text('Planner Demo'), findsOneWidget);
+  });
+
+  testWidgets('right-click on empty grid opens the create-event menu',
+      (tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    // An empty spot in column 0: +100px right (into the grid) and +120px down
+    // from the grid top maps to hour 3, which the sample data leaves free
+    // (entries sit at 08:00 and 13:30). This exercises the real secondary-tap
+    // gesture path the widget harness can't always reach.
+    final rect = tester.getRect(find.byType(Planner));
+    final at = rect.topLeft + const Offset(50 + 100, 50 + 120);
+
+    final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Create Event'), findsOneWidget);
+  });
+}

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -1,0 +1,18 @@
+import 'package:integration_test/integration_test.dart';
+
+import 'app_smoke_scenarios.dart';
+import 'multi_planner_scenarios.dart';
+
+/// Single entry point for the integration suite.
+///
+/// On desktop, `flutter test` launches a fresh app per *test file*, and a second
+/// launch within one invocation is unreliable. So every scenario is registered
+/// here and runs in one app launch. Add new scenarios as functions (see
+/// [app_smoke_scenarios.dart]) and call them below — do not add new
+/// `*_test.dart` files to this directory.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  appSmokeScenarios();
+  multiPlannerScenarios();
+}

--- a/example/integration_test/multi_planner_scenarios.dart
+++ b/example/integration_test/multi_planner_scenarios.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end demonstration of the multi-planner harness on a real device:
+/// two Planners on one screen must keep independent scroll positions. This is
+/// the device-level counterpart of the widget-harness regression for the former
+/// static controller state (#9 / PROJECT_OVERVIEW D1).
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void multiPlannerScenarios() {
+  testWidgets('two planners keep independent scroll state', (tester) async {
+    PlannerTime? createdA;
+    PlannerTime? createdB;
+
+    PlannerConfig configFor(void Function(PlannerTime) onCreate) =>
+        PlannerConfig(
+          labels: const ['c1', 'c2', 'c3'],
+          minHour: 0,
+          maxHour: 23,
+          onEntryCreate: onCreate,
+        );
+
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        PlannerSpec(config: configFor((t) => createdA = t)),
+        PlannerSpec(config: configFor((t) => createdB = t)),
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    final keyA = PlannerHarness.keyFor(0);
+    final keyB = PlannerHarness.keyFor(1);
+    final pointA = gridPointFor(tester.getRect(find.byKey(keyA)));
+    final pointB = gridPointFor(tester.getRect(find.byKey(keyB)));
+
+    // The chosen point maps to hour 5 in an unscrolled grid (200px / 40px).
+    const unscrolledHour = 5;
+
+    // Scroll ONLY planner A (before opening any menu, which otherwise leaves a
+    // lingering overlay that blocks the wheel).
+    await wheelScroll(tester, pointA, 4);
+
+    await createViaMenu(tester, find.byKey(keyA), pointA);
+    await createViaMenu(tester, find.byKey(keyB), pointB);
+    expect(createdA, isNotNull);
+    expect(createdB, isNotNull);
+
+    // A scrolled down, so the same screen point now maps to a later hour; B was
+    // never touched and still maps to the unscrolled hour. With shared static
+    // state, scrolling A would also move B and both would report the later hour.
+    expect(createdA!.hour, greaterThan(unscrolledHour),
+        reason: 'scrolling A must change what A hit-tests');
+    expect(createdB!.hour, unscrolledHour,
+        reason: 'scrolling A must NOT change what B hit-tests');
+  });
+}

--- a/example/integration_test/planner_harness.dart
+++ b/example/integration_test/planner_harness.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+/// A reusable end-to-end harness for integration tests that need more than the
+/// single [Planner] the example app renders.
+///
+/// The example app intentionally renders one [Planner], so multi-planner
+/// (independence) and multi-config (composition) flows need their own driveable
+/// app. [PlannerHarness] lays out one [Planner] per [PlannerSpec] in an
+/// equal-width [Row] and tags each with a stable [ValueKey] ('planner-0',
+/// 'planner-1', …) so finders stay unambiguous when several are on screen.
+class PlannerHarness extends StatelessWidget {
+  const PlannerHarness({super.key, required this.planners});
+
+  final List<PlannerSpec> planners;
+
+  /// The key of the [Planner] at [index], for scoping finders.
+  static Key keyFor(int index) => ValueKey('planner-$index');
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Row(
+          children: [
+            for (var i = 0; i < planners.length; i++)
+              Expanded(
+                child: Planner(
+                  key: keyFor(i),
+                  config: planners[i].config,
+                  entries: planners[i].entries,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One planner's inputs for [PlannerHarness].
+class PlannerSpec {
+  const PlannerSpec({required this.config, this.entries = const []});
+
+  final PlannerConfig config;
+  final List<PlannerEntry> entries;
+}
+
+/// A point inside a planner's event grid: skip the hour column (default 50) and
+/// the date row (default 50), then move +100px right / +[downFromGridTop] down
+/// so it lands cleanly in the grid. With the default `blockHeight` of 40, the
+/// vertical offset maps to hour `downFromGridTop / 40` in an unscrolled grid.
+Offset gridPointFor(Rect planner, {double downFromGridTop = 200}) =>
+    planner.topLeft + Offset(50 + 100, 50 + downFromGridTop);
+
+/// Right-clicks [planner] to open its context menu, then taps "Create Event".
+///
+/// The menu's time is derived from the current scroll/zoom via `getTimeAtPos`,
+/// so the resulting `onEntryCreate` callback reveals where [at] mapped to. The
+/// "Create Event" finder is scoped to [planner] so two planners on screen stay
+/// unambiguous.
+Future<void> createViaMenu(
+    WidgetTester tester, Finder planner, Offset at) async {
+  final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+  await tester.pump();
+  await gesture.up();
+  await tester.pump();
+
+  await tester.tap(find.descendant(
+    of: planner,
+    matching: find.text('Create Event'),
+  ));
+  await tester.pump();
+}
+
+/// Sends [notches] mouse-wheel scroll events at [at] (one pump each), the way a
+/// user scrolls the time axis. Positive [notches] scroll the grid downward.
+Future<void> wheelScroll(WidgetTester tester, Offset at, int notches) async {
+  final mouse = TestPointer(1, PointerDeviceKind.mouse);
+  await tester.sendEventToBinding(mouse.hover(at));
+  for (var i = 0; i < notches; i++) {
+    await tester.sendEventToBinding(mouse.scroll(const Offset(0, 20)));
+    await tester.pump();
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,8 +57,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -71,6 +84,16 @@ packages:
     source: hosted
     version: "1.0.4"
   flutter_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  integration_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
@@ -146,6 +169,22 @@ packages:
       relative: true
     source: path
     version: "0.0.4"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -183,6 +222,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -215,6 +262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.1"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -42,6 +42,12 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  # Drives end-to-end tests in example/integration_test/ on a real device
+  # (`flutter test integration_test -d windows`, or the web `flutter drive`
+  # path). See example/integration_test/README.md.
+  integration_test:
+    sdk: flutter
+
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your

--- a/example/test_driver/integration_test.dart
+++ b/example/test_driver/integration_test.dart
@@ -1,0 +1,13 @@
+// Driver for the web `flutter drive` path. The Windows device path
+// (`flutter test integration_test -d windows`, used by CI) does not need this
+// file, but it is required to run the same suite against Chrome:
+//
+//   flutter drive \
+//     --driver=test_driver/integration_test.dart \
+//     --target=integration_test/app_test.dart \
+//     -d chrome
+//
+// See example/integration_test/README.md.
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## Summary
Stand up an end-to-end integration-test suite for the package, plus a reusable harness for multi-planner / multi-config scenarios, and a CI job that runs it on a real Windows desktop device. This is infrastructure — it unblocks the upcoming rendering/geometry work (D3/D4/D10/D11), where real fonts and real layout matter and the widget harness can miss bugs.

## Linked issue
Closes #30

## Changes
- **`example/pubspec.yaml`** — add the `integration_test` (sdk) dev dependency.
- **`example/test_driver/integration_test.dart`** — driver for the web `flutter drive` path.
- **`example/integration_test/`** (new):
  - `app_test.dart` — single entry point. Desktop launches one app per *test file* and a second launch within an invocation is unreliable, so every scenario is registered here and runs in one app launch.
  - `app_smoke_scenarios.dart` — boots the **real** example app; asserts a `Planner` renders and the real secondary-tap (right-click) context menu opens.
  - `multi_planner_scenarios.dart` — two planners on one screen keep independent scroll state. Device-level counterpart of the #9 / `PROJECT_OVERVIEW` D1 widget regression.
  - `planner_harness.dart` — reusable `PlannerHarness` / `PlannerSpec` (the example app only renders a single `Planner`) plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`).
  - `README.md` — Windows + web run commands and the convention to add scenarios as functions rather than new `*_test.dart` files.
- **`.github/workflows/ci.yml`** — new `integration-windows` job on `windows-latest` that enables Windows desktop and runs `flutter test integration_test -d windows`.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` clean (31 files, 0 changed)
- [x] `flutter analyze` clean at root and in `example/`
- [x] unit/widget tests pass — `flutter test` (12 tests)
- [x] integration tests pass — `flutter test integration_test -d windows` (3 tests, one app launch). This is a test-infra change, so the new suite *is* the deliverable; it was confirmed green locally on a real Windows device and is what the new CI job runs.

## Notes / screenshots
- **Out of scope (intentional):** the geometry/rendering tests (D3/D4/D10/D11) are the future work this infra unblocks, not part of this PR.
- The broken default counter test (`example/test/widget_test.dart`, C6) is left untouched — already tracked by #17.
- `example/pubspec.lock` updated as a side effect of adding the dependency.
- Targeting `develop` to match the repo's branch flow.
- Web `flutter drive` path is wired (driver + documented command) but not added to CI; the chosen CI device is Windows native, matching the local dev path and the desktop CustomPaint/real-font rendering the suite is meant to guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
