### PR TITLE
fix: derive event geometry from blockHeight, proportional minutes (#10)

### DIFF
--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -1,6 +1,7 @@
 import 'package:integration_test/integration_test.dart';
 
 import 'app_smoke_scenarios.dart';
+import 'event_geometry_scenarios.dart';
 import 'multi_planner_scenarios.dart';
 
 /// Single entry point for the integration suite.
@@ -14,5 +15,6 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   appSmokeScenarios();
+  eventGeometryScenarios();
   multiPlannerScenarios();
 }

--- a/example/integration_test/event_geometry_scenarios.dart
+++ b/example/integration_test/event_geometry_scenarios.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for event geometry (#10 / PROJECT_OVERVIEW D3 + D4): an
+/// event's painted rectangle — and therefore where it hit-tests — must derive
+/// from `config.blockHeight` and place minutes proportionally. The buggy code
+/// hardcoded a 40px block and snapped the minute offset to the 15-min grid, so
+/// with any other `blockHeight` every event mis-sized and mis-positioned.
+///
+/// This drives the *real* composed widget (real layout, real fonts, real
+/// secondary-tap gesture) with a non-default `blockHeight` and right-clicks a
+/// point that lands inside the event ONLY under the correct geometry. Right-
+/// clicking an event opens its menu ("Edit Event" / "Delete Event"); empty grid
+/// shows "Create Event" — which is what the buggy geometry produced at this
+/// point, because the event there was sized at 40px and its minute offset was
+/// quantized.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void eventGeometryScenarios() {
+  testWidgets(
+      'event hit-area derives from blockHeight and proportional minutes',
+      (tester) async {
+    PlannerEntry? edited;
+    PlannerTime? created;
+
+    final entry = PlannerEntry(
+      id: 'evt',
+      time: PlannerTime(day: 0, hour: 2, minutes: 30, duration: 60),
+      title: 'Geometry',
+      content: '',
+      color: const Color(0xFF2244AA),
+    );
+
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        PlannerSpec(
+          config: PlannerConfig(
+            labels: const ['col'],
+            minHour: 0,
+            maxHour: 23,
+            blockHeight: 80,
+            onEntryEdit: (e) => edited = e,
+            onEntryCreate: (t) => created = t,
+          ),
+          entries: [entry],
+        ),
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    // The event occupies, in grid coords (blockHeight 80):
+    //   correct:  top = 2*80 + 30/60*80 = 200, bottom = 200 + 60/60*80 = 280
+    //   buggy:    top = 2*80 + round(30/15)*10 = 180, bottom = 180 + 60/60*40 = 220
+    // y = 250 (grid) sits inside the correct rect but below the buggy one. Skip
+    // the hour column (50) and date row (50); +100px right lands in column 0.
+    final planner = tester.getRect(find.byKey(PlannerHarness.keyFor(0)));
+    final at = planner.topLeft + const Offset(50 + 100, 50 + 250);
+
+    final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit Event'), findsOneWidget,
+        reason: 'y=250 must fall inside the event under blockHeight-derived '
+            'geometry; the buggy 40px/quantized geometry left it empty');
+    expect(find.text('Create Event'), findsNothing);
+
+    await tester.tap(find.text('Edit Event'));
+    await tester.pumpAndSettle();
+
+    expect(edited, isNotNull);
+    expect(edited!.id, 'evt');
+    expect(created, isNull);
+  });
+}

--- a/lib/internal/event.dart
+++ b/lib/internal/event.dart
@@ -65,13 +65,13 @@ class Event {
   }
 
   void _calculateCanvasRect() {
+    final blockHeight = manager.config.blockHeight;
     Offset a = Offset(
         (entry.time.day * manager.config.blockWidth).toDouble(),
-        (entry.time.hour - manager.config.minHour) *
-                manager.config.blockHeight +
-            ((entry.time.minutes / 15).round() * 10.0));
-    Offset b = a.translate(
-        manager.config.blockWidth.toDouble(), entry.time.duration / 60 * 40.0);
+        (entry.time.hour - manager.config.minHour) * blockHeight +
+            entry.time.minutes / 60 * blockHeight);
+    Offset b = a.translate(manager.config.blockWidth.toDouble(),
+        entry.time.duration / 60 * blockHeight);
     canvasRect = Rect.fromPoints(a, b);
   }
 

--- a/test/event_geometry_test.dart
+++ b/test/event_geometry_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/event.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+void main() {
+  // Regression for D3 + D4 (#10): an event's canvasRect must derive its top
+  // offset and height from config.blockHeight, and place minutes proportionally
+  // — the old code hardcoded a 40px block (`duration / 60 * 40.0`) and snapped
+  // the minute offset to the 15-min grid (`(minutes / 15).round() * 10.0`).
+
+  Event onlyEventFor(PlannerConfig config, PlannerTime time) {
+    final manager = Manager(
+      config: config,
+      entries: [
+        PlannerEntry(
+          id: 'e',
+          time: time,
+          title: 'event',
+          content: '',
+          color: const Color(0xFF112233),
+        ),
+      ],
+    );
+    return manager.events.single;
+  }
+
+  test('top and height scale with a non-default blockHeight (D3)', () {
+    final rect = onlyEventFor(
+      PlannerConfig(labels: const ['A', 'B'], blockHeight: 80),
+      PlannerTime(day: 1, hour: 9, minutes: 30, duration: 90),
+    ).canvasRect;
+
+    // left = day * blockWidth; top = (hour - minHour) * blockHeight
+    //                                + minutes / 60 * blockHeight.
+    expect(rect.left, 1 * 200);
+    expect(rect.top, 9 * 80 + 30 / 60 * 80); // 720 + 40 = 760
+    expect(rect.width, 200);
+    expect(
+        rect.height, 90 / 60 * 80); // 120 — the old code gave 60 (40px block)
+  });
+
+  test('minute offset is proportional, not 15-min-quantized (D4)', () {
+    // 7 minutes is below the old rounding threshold, so the buggy code snapped
+    // it onto the hour line (offset 0). It must now offset proportionally, even
+    // at the default 40px block.
+    final rect = onlyEventFor(
+      PlannerConfig(labels: const ['A'], blockHeight: 40),
+      PlannerTime(day: 0, hour: 0, minutes: 7, duration: 60),
+    ).canvasRect;
+
+    expect(rect.top, 7 / 60 * 40);
+    expect(rect.top, greaterThan(0)); // the old code placed it at exactly 0
+  });
+
+  test('top accounts for minHour with a non-default blockHeight', () {
+    final rect = onlyEventFor(
+      PlannerConfig(labels: const ['A'], minHour: 8, blockHeight: 50),
+      PlannerTime(day: 0, hour: 10, minutes: 0, duration: 60),
+    ).canvasRect;
+
+    expect(rect.top, (10 - 8) * 50); // 100
+    expect(rect.height, 50);
+  });
+}


### PR DESCRIPTION
## Summary
`Event._calculateCanvasRect` hardcoded a 40px block, so any other `blockHeight` mis-sized and mis-positioned every event against the grid, and minute placement snapped to 15-min steps even when the data was exact. Geometry now derives from `config.blockHeight`. (PROJECT_OVERVIEW D3 + D4, P1.)

## Linked issue
Closes #10

## Changes
- `lib/internal/event.dart`: top minute offset `minutes / 60 * blockHeight` and height `duration / 60 * blockHeight`, replacing `(minutes / 15).round() * 10.0` and `duration / 60 * 40.0`.
- `test/event_geometry_test.dart`: unit coverage for blockHeight scaling, proportional minutes (the `:07` case the old code snapped to `:00`), and `minHour`.
- `example/integration_test/event_geometry_scenarios.dart` (+ registered in `app_test.dart`): end-to-end scenario on the real composed widget with `blockHeight: 80` — right-clicks a grid point that lands inside the event only under the corrected geometry and asserts the event menu ("Edit Event") opens rather than the empty-grid menu ("Create Event").

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `flutter analyze` clean (No issues found)
- [x] `flutter test` — 15/15 pass (3 new); confirmed the 3 new tests **fail on the unpatched code** (top 760 vs 740, minute offset 4.67 vs 0.0, height 50 vs 40)
- [x] `flutter test integration_test -d windows` (from `example/`) — 4/4 pass (1 new); confirmed the new scenario **fails on the unpatched code** ("Edit Event" not found because the buggy 40px geometry left the point empty)

## Notes / screenshots
Targets `develop` (feature → develop → main). Scope kept to the geometry bug; the related drag/resize math in `event.dart` already scales with `blockHeight` and was left unchanged.