### PR TITLE
Move drag logic and onEntryMove out of CustomPainter.paint() (#11)

### DIFF
--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -8,8 +8,10 @@ surface) can miss rendering/geometry bugs.
 |------|----------------|
 | [`app_test.dart`](app_test.dart) | The single entry point. Registers every scenario so the whole suite runs in **one** app launch (desktop can only launch one app per `flutter test` invocation). |
 | [`app_smoke_scenarios.dart`](app_smoke_scenarios.dart) | Boots the real example app; asserts a `Planner` renders and the real secondary-tap menu opens. |
+| [`drag_scenarios.dart`](drag_scenarios.dart) | Long-press-dragging an event moves it and fires `onEntryMove` with no paint-phase side effects (device-level counterpart of the #11 / D5 regression). |
+| [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
 | [`multi_planner_scenarios.dart`](multi_planner_scenarios.dart) | Two planners on one screen keep independent scroll state (device-level counterpart of the #9 / D1 regression). |
-| [`planner_harness.dart`](planner_harness.dart) | Reusable `PlannerHarness` for multi-planner / multi-config flows, plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`). |
+| [`planner_harness.dart`](planner_harness.dart) | Reusable `PlannerHarness` for multi-planner / multi-config flows, plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`, `longPressDrag`). |
 
 ## Running
 

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -1,6 +1,7 @@
 import 'package:integration_test/integration_test.dart';
 
 import 'app_smoke_scenarios.dart';
+import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
 import 'multi_planner_scenarios.dart';
 
@@ -15,6 +16,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   appSmokeScenarios();
+  dragScenarios();
   eventGeometryScenarios();
   multiPlannerScenarios();
 }

--- a/example/integration_test/drag_scenarios.dart
+++ b/example/integration_test/drag_scenarios.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for D5 (#11): dragging an event used to be detected, applied
+/// to the `Event`, and reported via `onEntryMove` *inside* `EventsPainter.paint()`.
+/// Firing a host callback during paint is fragile — a host's `onEntryMove`
+/// almost always updates state (`setState`), which is illegal mid-paint and
+/// throws "setState() called during build". Drag now lives in the widget layer's
+/// gesture handlers, so the same flow is safe.
+///
+/// This drives the *real* composed widget (real layout, real fonts, real
+/// long-press recognition over the competing pan/scale recognizers) and uses a
+/// stateful host whose `onEntryMove` rebuilds — exactly the pattern that crashed
+/// on the old paint-side-effect code.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void dragScenarios() {
+  testWidgets('long-press dragging an event moves it and fires onEntryMove',
+      (tester) async {
+    final moved = <PlannerEntry>[];
+
+    await tester.pumpWidget(_DragHostApp(onMoved: moved.add));
+    await tester.pumpAndSettle();
+
+    // The single event sits at day 0 / hour 4 -> grid rect (0,160)-(200,200)
+    // with the default 200x40 blocks. On screen it is offset by the hour column
+    // (50) and date row (50); its centre is therefore at planner-local (150, 230)
+    // — a body drag, clear of the 8px handle zones at the top/bottom edges.
+    final center =
+        tester.getRect(find.byType(Planner)).topLeft + const Offset(150, 230);
+
+    // Drag down exactly one block (40px == 1 hour): hour 4 -> hour 5.
+    await longPressDrag(tester, center, const Offset(0, 40));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull,
+        reason: 'the move callback must not fire during paint');
+    expect(moved, hasLength(1), reason: 'the drag committed exactly one move');
+    expect(moved.single.id, 'evt');
+    expect(moved.single.time.day, 0);
+    expect(moved.single.time.hour, 5,
+        reason: 'a one-block drag advances the event one hour');
+  });
+}
+
+/// A minimal real app hosting one [Planner], whose [onEntryMove] both records the
+/// move and rebuilds via [setState] — the everyday host pattern that exposed the
+/// old paint-phase callback bug.
+class _DragHostApp extends StatefulWidget {
+  const _DragHostApp({required this.onMoved});
+
+  final void Function(PlannerEntry) onMoved;
+
+  @override
+  State<_DragHostApp> createState() => _DragHostAppState();
+}
+
+class _DragHostAppState extends State<_DragHostApp> {
+  final List<PlannerEntry> _entries = [
+    PlannerEntry(
+      id: 'evt',
+      time: PlannerTime(day: 0, hour: 4),
+      title: 'Drag me',
+      content: '',
+      color: const Color(0xFF2244AA),
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryMove: (entry) => setState(() => widget.onMoved(entry)),
+          ),
+          entries: _entries,
+        ),
+      ),
+    );
+  }
+}

--- a/example/integration_test/planner_harness.dart
+++ b/example/integration_test/planner_harness.dart
@@ -85,3 +85,16 @@ Future<void> wheelScroll(WidgetTester tester, Offset at, int notches) async {
     await tester.pump();
   }
 }
+
+/// Drags an event the way a user does: press and hold at [from] until the
+/// long-press recognizer wins the gesture arena (over pan/scale), then move by
+/// [delta] and release.
+Future<void> longPressDrag(
+    WidgetTester tester, Offset from, Offset delta) async {
+  final gesture = await tester.startGesture(from);
+  await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+  await gesture.moveBy(delta);
+  await tester.pump();
+  await gesture.up();
+  await tester.pump();
+}

--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -28,13 +28,6 @@ class Controller {
     triggerUpdate.value++;
   }
 
-  Offset? _touchPos;
-  Offset? get touchPos => _touchPos;
-  set touchPos(Offset? value) {
-    _touchPos = value;
-    triggerUpdate.value++;
-  }
-
   Offset get offset => Offset(x, y);
 
   double _previousZoom = 1;

--- a/lib/internal/events_painter.dart
+++ b/lib/internal/events_painter.dart
@@ -8,41 +8,18 @@ class EventsPainter extends CustomPainter {
   final Grid _grid;
   final Manager manager;
 
-  Event? draggedEvent;
-
   EventsPainter({required this.manager, required Listenable repaint})
       : _grid = Grid(manager: manager),
         super(repaint: repaint);
 
+  // Pure rendering only: draw the grid, then each event using its own drag
+  // state. Drag detection and the onEntryMove callback live in the widget layer
+  // (gesture handlers -> Manager.start/update/endDrag), never here — a painter
+  // must not mutate state or fire callbacks while painting.
   @override
   void paint(Canvas canvas, Size size) {
     _grid.draw(canvas);
-
-    if (manager.controller.touchPos == null && draggedEvent != null) {
-      draggedEvent!.endDrag();
-      if (manager.config.onEntryMove != null) {
-        manager.config.onEntryMove!(draggedEvent!.entry);
-      }
-      draggedEvent = null;
-    }
     for (Event event in manager.events) {
-      if (manager.controller.touchPos != null && draggedEvent == null) {
-        Offset realPos = Offset(
-            manager.controller.touchPos!.dx - manager.controller.offset.dx,
-            (manager.controller.touchPos!.dy - manager.controller.offset.dy) /
-                manager.controller.zoom);
-
-        if (event.canvasRect.contains(realPos)) {
-          draggedEvent = event;
-          draggedEvent!.startDrag(realPos);
-        }
-      } else if (manager.controller.touchPos != null && draggedEvent == event) {
-        Offset realPos = Offset(
-            manager.controller.touchPos!.dx - manager.controller.offset.dx,
-            (manager.controller.touchPos!.dy - manager.controller.offset.dy) /
-                manager.controller.zoom);
-        draggedEvent!.updateDrag(realPos);
-      }
       event.paint(canvas);
     }
   }

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -39,9 +39,49 @@ class Manager {
     }
   }
 
+  Event? _draggedEvent;
+
+  /// The event currently being dragged, or `null` when no drag is in progress.
+  Event? get draggedEvent => _draggedEvent;
+
+  /// Translates a pointer position in the planner's local coordinates into the
+  /// grid's own coordinate space (undoing the current scroll offset and zoom).
+  Offset _toGridPos(Offset localPos) => Offset(
+      localPos.dx - controller.offset.dx,
+      (localPos.dy - controller.offset.dy) / controller.zoom);
+
+  /// Begins a drag at [localPos] (planner-local coordinates) if it lands on an
+  /// event. Called from the widget layer's gesture handlers — never from paint.
+  void startDrag(Offset localPos) {
+    if (_draggedEvent != null) return;
+    final event = getEventAtPos(localPos);
+    if (event == null) return;
+    _draggedEvent = event;
+    event.startDrag(_toGridPos(localPos));
+    controller.triggerUpdate.value++;
+  }
+
+  /// Updates the in-progress drag to follow [localPos]. No-op when nothing is
+  /// being dragged.
+  void updateDrag(Offset localPos) {
+    if (_draggedEvent == null) return;
+    _draggedEvent!.updateDrag(_toGridPos(localPos));
+    controller.triggerUpdate.value++;
+  }
+
+  /// Commits the in-progress drag: snaps the entry to its new time and fires
+  /// [PlannerConfig.onEntryMove]. No-op when nothing is being dragged.
+  void endDrag() {
+    if (_draggedEvent == null) return;
+    final dragged = _draggedEvent!;
+    _draggedEvent = null;
+    dragged.endDrag();
+    config.onEntryMove?.call(dragged.entry);
+    controller.triggerUpdate.value++;
+  }
+
   Event? getEventAtPos(Offset pos) {
-    Offset realPos = Offset(pos.dx - controller.offset.dx,
-        (pos.dy - controller.offset.dy) / controller.zoom);
+    Offset realPos = _toGridPos(pos);
 
     for (Event event in events) {
       if (event.canvasRect.contains(realPos)) {
@@ -53,8 +93,7 @@ class Manager {
   }
 
   PlannerTime getTimeAtPos(Offset pos) {
-    Offset realPos = Offset(pos.dx - controller.offset.dx,
-        (pos.dy - controller.offset.dy) / controller.zoom);
+    Offset realPos = _toGridPos(pos);
 
     int day = (realPos.dx / config.blockWidth).floor();
     int hour = config.minHour + (realPos.dy / config.blockHeight).floor();

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -196,13 +196,13 @@ class _PlannerState extends State<Planner> {
       onScaleUpdate: (details) =>
           _data.controller.updateZoom(details.verticalScale),
       onLongPressStart: (details) {
-        _data.controller.touchPos = details.localPosition;
+        _data.startDrag(details.localPosition);
       },
       onLongPressMoveUpdate: (details) {
-        _data.controller.touchPos = details.localPosition;
+        _data.updateDrag(details.localPosition);
       },
       onLongPressEnd: (details) {
-        _data.controller.touchPos = null;
+        _data.endDrag();
       },
       onTap: () {
         _data.controller.hideMenu();

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -51,4 +51,50 @@ void main() {
     expect(manager.controller.zoom, 1.5, reason: 'zoom is preserved');
     expect(manager.events.length, 2, reason: 'events reflect the new entries');
   });
+
+  // Regression for D5 (#11): drag detection, the Event drag mutations, and the
+  // onEntryMove callback used to live inside EventsPainter.paint(). They now live
+  // on the Manager and are driven by the widget's gesture handlers, so the
+  // lifecycle is exercisable directly and the painter stays pure.
+  group('drag lifecycle', () {
+    // Default config: blockWidth 200, blockHeight 40, minHour 0. An entry at
+    // day 0 / hour 9 occupies grid rect (0,360)-(200,400); its centre (100,380)
+    // is a body-drag (clear of the 8px top/bottom handle zones). With no scroll
+    // or zoom, planner-local coordinates equal grid coordinates.
+    Manager makeManager(void Function(PlannerEntry)? onMove) => Manager(
+          config: PlannerConfig(labels: const ['A', 'B'], onEntryMove: onMove),
+          entries: [makeEntry('1', 0)],
+        );
+
+    test('start/update/end moves the entry and fires onEntryMove once', () {
+      final moved = <PlannerEntry>[];
+      final manager = makeManager(moved.add);
+      final entry = manager.events.first.entry;
+      expect(entry.time.hour, 9);
+
+      manager.startDrag(const Offset(100, 380));
+      expect(manager.draggedEvent, isNotNull);
+
+      manager.updateDrag(const Offset(100, 420)); // drag down one block (1h)
+      expect(moved, isEmpty, reason: 'no callback fires mid-drag');
+
+      manager.endDrag();
+      expect(manager.draggedEvent, isNull);
+      expect(entry.time.hour, 10, reason: 'a one-block drag advances one hour');
+      expect(moved, hasLength(1), reason: 'onEntryMove fires exactly once, on end');
+      expect(identical(moved.single, entry), isTrue);
+    });
+
+    test('startDrag on empty space is a no-op and never fires onEntryMove', () {
+      var moves = 0;
+      final manager = makeManager((_) => moves++);
+
+      manager.startDrag(const Offset(100, 50)); // above the event (grid y<360)
+      expect(manager.draggedEvent, isNull);
+
+      manager.updateDrag(const Offset(100, 90)); // nothing is being dragged
+      manager.endDrag();
+      expect(moves, 0, reason: 'no event was picked up, so nothing moved');
+    });
+  });
 }

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -81,7 +81,8 @@ void main() {
       manager.endDrag();
       expect(manager.draggedEvent, isNull);
       expect(entry.time.hour, 10, reason: 'a one-block drag advances one hour');
-      expect(moved, hasLength(1), reason: 'onEntryMove fires exactly once, on end');
+      expect(moved, hasLength(1),
+          reason: 'onEntryMove fires exactly once, on end');
       expect(identical(moved.single, entry), isTrue);
     });
 

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -41,6 +41,19 @@ void main() {
     }
   }
 
+  // Press and hold past the long-press timeout (so the long-press recognizer
+  // wins the gesture arena over pan/scale, exactly as a real user dragging an
+  // event), then move and release.
+  Future<void> longPressDrag(
+      WidgetTester tester, Offset from, Offset delta) async {
+    final gesture = await tester.startGesture(from);
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    await gesture.moveBy(delta);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+  }
+
   testWidgets('two planners keep independent scroll state (D1)',
       (tester) async {
     const keyA = ValueKey('plannerA');
@@ -162,5 +175,61 @@ void main() {
     await createViaMenu(tester, key, point);
     expect(created!.hour, scrolledHour,
         reason: 'scroll position must survive a parent rebuild');
+  });
+
+  // Regression for D5 (#11): drag detection and the onEntryMove callback used to
+  // run *inside* EventsPainter.paint(). A host's onEntryMove almost always
+  // updates app state (setState), and calling setState during paint throws
+  // "setState() called during build". Driving a real long-press drag whose
+  // handler rebuilds therefore crashes on the old paint-side-effect code and
+  // succeeds now that drag lives in the gesture layer.
+  testWidgets('long-press drag moves an event without painting side effects',
+      (tester) async {
+    const key = ValueKey('planner');
+    final moved = <PlannerEntry>[];
+
+    // The event sits at day 0 / hour 9 -> grid rect (0,360)-(200,400) with the
+    // default 200x40 blocks. On screen it is offset by the hour column (50) and
+    // date row (50); its centre is therefore at planner-local (150, 430).
+    final entry = PlannerEntry(
+      id: 'evt',
+      time: PlannerTime(day: 0, hour: 9),
+      title: 'Drag me',
+      content: '',
+      color: const Color(0xFF2244AA),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: StatefulBuilder(
+          builder: (context, setState) {
+            return Planner(
+              key: key,
+              config: PlannerConfig(
+                labels: const ['c1', 'c2', 'c3'],
+                minHour: 0,
+                maxHour: 23,
+                // A real host handler: record the move and rebuild. Under the old
+                // code this setState ran during paint and threw.
+                onEntryMove: (e) => setState(() => moved.add(e)),
+              ),
+              entries: [entry],
+            );
+          },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final center =
+        tester.getRect(find.byKey(key)).topLeft + const Offset(150, 430);
+
+    // Drag down exactly one block (40px == 1 hour).
+    await longPressDrag(tester, center, const Offset(0, 40));
+
+    expect(tester.takeException(), isNull,
+        reason: 'onEntryMove must not fire during paint');
+    expect(moved, hasLength(1), reason: 'the drag committed exactly one move');
+    expect(entry.time.hour, 10, reason: 'a one-block drag advances one hour');
   });
 }


### PR DESCRIPTION
## Summary
`EventsPainter.paint()` used to detect drag start/stop, mutate `Event` drag state, and fire `onEntryMove` **during painting**. A painter must be pure, and firing a host callback mid-paint is fragile — a host `onEntryMove` that calls `setState` crashes with *"setState() called during build"*. This moves the whole drag lifecycle into the widget/gesture layer and leaves the painter rendering-only (PROJECT_OVERVIEW D5).

## Linked issue
Closes #11

## Changes
- **`manager.dart`**: new `startDrag`/`updateDrag`/`endDrag(localPos)` own the drag lifecycle — hit-test via `getEventAtPos`, drive the `Event` drag state, fire `onEntryMove` on release, and bump `triggerUpdate` to repaint. Extracted a shared `_toGridPos` helper (deduped from `getEventAtPos` and `getTimeAtPos`).
- **`events_painter.dart`**: `paint()` reduced to drawing the grid and each event; dropped the `draggedEvent` field and all side effects.
- **`planner_class.dart`**: the existing `onLongPressStart/Move/End` handlers now call the new `Manager` methods instead of setting `controller.touchPos`.
- **`controller.dart`**: removed the now-dead `touchPos` field (its only consumer was the painter).

## Test plan
- [x] `flutter analyze` clean (root + example)
- [x] unit/widget tests pass — `flutter test` (18 tests, 2 new):
  - `manager_test`: drag lifecycle moves the entry and fires `onEntryMove` exactly once on release; a drag starting on empty space is a no-op.
  - `planner_widget_test`: a real long-press drag whose `onEntryMove` rebuilds (`setState`) completes with **no** paint-phase exception.
- [x] integration/e2e tests pass — `flutter test integration_test -d windows` from `example/` (5 tests, 1 new): `drag_scenarios` drives the real composed app over real long-press recognition, asserting the event moves one hour and `onEntryMove` fires with no paint-phase side effects.
- [x] both new regressions **confirmed to fail on the unpatched `lib`** (each caught the paint-phase callback) and pass with the fix.

## Notes / screenshots
Branched off `develop` (the active integration branch), so the PR targets `develop`.