### PR TITLE
fix: clamp day/hour and bound zoom (min/max) (#12)

### DIFF
--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -135,8 +135,9 @@ class Controller {
   }
 
   void updateZoom(double scale) {
-    _zoom =
-        (_previousZoom * scale).clamp(config.minZoom, config.maxZoom).toDouble();
+    _zoom = (_previousZoom * scale)
+        .clamp(config.minZoom, config.maxZoom)
+        .toDouble();
     _calculateOffsets();
     triggerUpdate.value++;
   }

--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -135,7 +135,8 @@ class Controller {
   }
 
   void updateZoom(double scale) {
-    _zoom = _previousZoom * scale;
+    _zoom =
+        (_previousZoom * scale).clamp(config.minZoom, config.maxZoom).toDouble();
     _calculateOffsets();
     triggerUpdate.value++;
   }

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -95,8 +95,14 @@ class Manager {
   PlannerTime getTimeAtPos(Offset pos) {
     Offset realPos = _toGridPos(pos);
 
-    int day = (realPos.dx / config.blockWidth).floor();
-    int hour = config.minHour + (realPos.dy / config.blockHeight).floor();
+    // Clamp to valid ranges so taps above/left of the grid (negative) or past
+    // the last column/hour (grid smaller than the viewport) can't produce an
+    // out-of-range day/hour.
+    int day = (realPos.dx / config.blockWidth)
+        .floor()
+        .clamp(0, config.labels.length - 1);
+    int hour = (config.minHour + (realPos.dy / config.blockHeight).floor())
+        .clamp(config.minHour, config.maxHour);
     int minutes = 0;
     if (controller.zoom > 2.25) {
       minutes = ((realPos.dy.toInt() % config.blockHeight) / 10).floor() * 15;

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -12,6 +12,12 @@ class PlannerConfig {
   int blockWidth;
   int blockHeight;
 
+  /// Lower/upper bounds applied to the pinch/zoom factor in
+  /// [Controller.updateZoom]. Without these the zoom could shrink toward 0
+  /// (blocks collapse, hit-testing explodes) or grow without limit.
+  double minZoom;
+  double maxZoom;
+
   double dateRowHeight;
   double hourColumnWidth;
 
@@ -38,6 +44,8 @@ class PlannerConfig {
     this.maxHour = 24,
     this.blockWidth = 200,
     this.blockHeight = 40,
+    this.minZoom = 0.5,
+    this.maxZoom = 4.0,
     this.hourLabelStyle = const TextStyle(color: Colors.black),
     this.dateLabelStyle = const TextStyle(color: Colors.black),
     this.contextMenuTextStyle = const TextStyle(color: Colors.blue),

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -58,4 +58,47 @@ void main() {
     expect(controller.y, -30);
     expect(controller.zoom, 1.5);
   });
+
+  // Regression for D9 (#12): updateZoom multiplied without bounds, so pinch (or
+  // the zoom buttons) could drive zoom toward 0 (blocks collapse, hit-testing
+  // explodes) or grow it without limit. It now clamps to [minZoom, maxZoom].
+  group('updateZoom clamps to [minZoom, maxZoom] (D9, #12)', () {
+    test('zooming in past maxZoom clamps to maxZoom', () {
+      final controller = Controller(makeConfig()); // defaults 0.5 .. 4.0
+      controller.startZoom();
+      controller.updateZoom(10.0);
+      expect(controller.zoom, 4.0);
+    });
+
+    test('zooming out past minZoom clamps to minZoom', () {
+      final controller = Controller(makeConfig());
+      controller.startZoom();
+      controller.updateZoom(0.01);
+      expect(controller.zoom, 0.5);
+    });
+
+    test('honours custom minZoom/maxZoom from the config', () {
+      final controller = Controller(
+        PlannerConfig(labels: const ['A'], minZoom: 1.0, maxZoom: 2.0),
+      );
+      controller.startZoom();
+      controller.updateZoom(5.0);
+      expect(controller.zoom, 2.0);
+
+      controller.startZoom();
+      controller.updateZoom(0.1);
+      expect(controller.zoom, 1.0);
+    });
+
+    test('repeated zoom-out (as the button does) never drops below minZoom', () {
+      final controller = Controller(makeConfig());
+      // The zoom-out button runs startZoom();updateZoom(0.9) on each press.
+      for (var i = 0; i < 50; i++) {
+        controller.startZoom();
+        controller.updateZoom(0.9);
+        expect(controller.zoom, greaterThanOrEqualTo(0.5));
+      }
+      expect(controller.zoom, 0.5, reason: 'bottoms out exactly at minZoom');
+    });
+  });
 }

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -90,7 +90,8 @@ void main() {
       expect(controller.zoom, 1.0);
     });
 
-    test('repeated zoom-out (as the button does) never drops below minZoom', () {
+    test('repeated zoom-out (as the button does) never drops below minZoom',
+        () {
       final controller = Controller(makeConfig());
       // The zoom-out button runs startZoom();updateZoom(0.9) on each press.
       for (var i = 0; i < 50; i++) {

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -122,7 +122,8 @@ void main() {
       expect(time.hour, 8, reason: 'clamped up to minHour');
     });
 
-    test('a tap past the last column/hour clamps to the last day / maxHour', () {
+    test('a tap past the last column/hour clamps to the last day / maxHour',
+        () {
       // Raw: day floor(5000/200) = 25, hour 8 + floor(5000/40) = 133.
       final time = makeManager().getTimeAtPos(const Offset(5000, 5000));
       expect(time.day, 2, reason: 'clamped to labels.length - 1');

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -98,4 +98,42 @@ void main() {
       expect(moves, 0, reason: 'no event was picked up, so nothing moved');
     });
   });
+
+  // Regression for D9 (#12): getTimeAtPos used to return a negative day/hour for
+  // taps above/left of the grid, and an overshoot day/hour for taps past the
+  // last column/hour (reachable whenever the grid is smaller than the viewport).
+  // It now clamps both to valid ranges.
+  group('getTimeAtPos clamps to the grid (D9, #12)', () {
+    // 3 day columns (0..2) and hours 8..17. No scroll/zoom, so planner-local
+    // coordinates equal grid coordinates (blockWidth 200, blockHeight 40).
+    Manager makeManager() => Manager(
+          config: PlannerConfig(
+            labels: const ['A', 'B', 'C'],
+            minHour: 8,
+            maxHour: 17,
+          ),
+          entries: const [],
+        );
+
+    test('a tap above/left of the grid clamps to day 0 / minHour', () {
+      // Raw: day floor(-10/200) = -1, hour 8 + floor(-10/40) = 7.
+      final time = makeManager().getTimeAtPos(const Offset(-10, -10));
+      expect(time.day, 0, reason: 'clamped up to the first column');
+      expect(time.hour, 8, reason: 'clamped up to minHour');
+    });
+
+    test('a tap past the last column/hour clamps to the last day / maxHour', () {
+      // Raw: day floor(5000/200) = 25, hour 8 + floor(5000/40) = 133.
+      final time = makeManager().getTimeAtPos(const Offset(5000, 5000));
+      expect(time.day, 2, reason: 'clamped to labels.length - 1');
+      expect(time.hour, 17, reason: 'clamped down to maxHour');
+    });
+
+    test('a tap inside the grid is unaffected by the clamp', () {
+      // Raw: day floor(250/200) = 1, hour 8 + floor(120/40) = 11.
+      final time = makeManager().getTimeAtPos(const Offset(250, 120));
+      expect(time.day, 1);
+      expect(time.hour, 11);
+    });
+  });
 }

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -54,6 +54,42 @@ void main() {
     await tester.pump();
   }
 
+  // Pumps a single full-screen Planner (3 columns, hours 0..23) for the zoom
+  // tests and returns its on-screen rect. These read the *effective* zoom back
+  // out through getTimeAtPos: with no scroll, a fixed screen point at events-
+  // local y maps to hour floor(y / (zoom * blockHeight)). Tapping high enough
+  // that the mapped hour stays in [minHour, maxHour] keeps the hour clamp out of
+  // it, so the resulting hour is determined solely by the (clamped) zoom.
+  Future<Rect> pumpZoomPlanner(
+      WidgetTester tester, Key key, void Function(PlannerTime) onCreate) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          key: key,
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryCreate: onCreate,
+          ),
+          entries: const [],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    return tester.getRect(find.byKey(key));
+  }
+
+  Future<void> tapButton(WidgetTester tester, Key key, IconData icon,
+      int times) async {
+    final button =
+        find.descendant(of: find.byKey(key), matching: find.byIcon(icon));
+    for (var i = 0; i < times; i++) {
+      await tester.tap(button);
+      await tester.pump();
+    }
+  }
+
   testWidgets('two planners keep independent scroll state (D1)',
       (tester) async {
     const keyA = ValueKey('plannerA');
@@ -274,47 +310,43 @@ void main() {
     expect(created!.hour, 5, reason: 'clamped to maxHour');
   });
 
-  // Regression for D9 (#12): the zoom-out button multiplied zoom unbounded
-  // toward 0, which blows up getTimeAtPos's divide-by-zoom (raw hour into the
-  // hundreds). After clamping zoom to minZoom, mashing the real button still
-  // yields a created event at a valid in-range hour.
-  testWidgets('extreme zoom-out via the button keeps created times in range (D9)',
-      (tester) async {
+  // Regression for D9 (#12): updateZoom multiplied without bounds, so the real
+  // zoom-in button could grow zoom indefinitely. After zooming in well past
+  // maxZoom (4.0), a fixed screen point still maps through the *capped* zoom: at
+  // events-local y=350, floor(350 / (4.0 * 40)) = hour 2. Unbounded (~1.1^30 =
+  // 17x) the same point would collapse to hour 0 — so this fails without the cap
+  // and the hour clamp never masks it (2 and 0 are both in range).
+  testWidgets('zooming in past maxZoom stays bounded (D9)', (tester) async {
     const key = ValueKey('planner');
     PlannerTime? created;
+    final rect = await pumpZoomPlanner(tester, key, (t) => created = t);
 
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: Planner(
-          key: key,
-          config: PlannerConfig(
-            labels: const ['c1', 'c2', 'c3'],
-            minHour: 0,
-            maxHour: 5,
-            onEntryCreate: (t) => created = t,
-          ),
-          entries: const [],
-        ),
-      ),
-    ));
-    await tester.pumpAndSettle();
-
-    // Mash the real zoom-out control well past minZoom.
-    final zoomOut = find.descendant(
-      of: find.byKey(key),
-      matching: find.byIcon(Icons.zoom_out),
-    );
-    for (var i = 0; i < 40; i++) {
-      await tester.tap(zoomOut);
-      await tester.pump();
-    }
-
-    // A normal mid-grid tap. Unbounded, zoom would be ~0.9^40 and the raw hour
-    // would land in the hundreds; clamped, it stays within [minHour, maxHour].
-    await createViaMenu(tester, key, gridPointFor(tester.getRect(find.byKey(key))));
+    await tapButton(tester, key, Icons.zoom_in, 30);
+    await createViaMenu(
+        tester, key, rect.topLeft + const Offset(50 + 100, 50 + 350));
 
     expect(created, isNotNull);
-    expect(created!.hour, inInclusiveRange(0, 5),
-        reason: 'the zoom + hour clamps keep the created hour valid');
+    expect(created!.hour, 2,
+        reason: 'zoom is capped at maxZoom (4.0); unbounded it would be hour 0');
+  });
+
+  // Regression for D9 (#12): the real zoom-out button could shrink zoom toward 0,
+  // blowing up getTimeAtPos's divide-by-zoom. After zooming out well past minZoom
+  // (0.5), a fixed screen point maps through the *floored* zoom: at events-local
+  // y=50, floor(50 / (0.5 * 40)) = hour 2. Unbounded (~0.9^40 = 0.015) the divide
+  // would send the raw hour to ~84 (clamped away to maxHour 23) — so asserting an
+  // exact in-range hour 2 isolates the minZoom floor from the hour clamp.
+  testWidgets('zooming out past minZoom stays bounded (D9)', (tester) async {
+    const key = ValueKey('planner');
+    PlannerTime? created;
+    final rect = await pumpZoomPlanner(tester, key, (t) => created = t);
+
+    await tapButton(tester, key, Icons.zoom_out, 40);
+    await createViaMenu(
+        tester, key, rect.topLeft + const Offset(50 + 100, 50 + 50));
+
+    expect(created, isNotNull);
+    expect(created!.hour, 2,
+        reason: 'zoom is floored at minZoom (0.5); unbounded it would hit maxHour');
   });
 }

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -80,8 +80,8 @@ void main() {
     return tester.getRect(find.byKey(key));
   }
 
-  Future<void> tapButton(WidgetTester tester, Key key, IconData icon,
-      int times) async {
+  Future<void> tapButton(
+      WidgetTester tester, Key key, IconData icon, int times) async {
     final button =
         find.descendant(of: find.byKey(key), matching: find.byIcon(icon));
     for (var i = 0; i < times; i++) {
@@ -327,7 +327,8 @@ void main() {
 
     expect(created, isNotNull);
     expect(created!.hour, 2,
-        reason: 'zoom is capped at maxZoom (4.0); unbounded it would be hour 0');
+        reason:
+            'zoom is capped at maxZoom (4.0); unbounded it would be hour 0');
   });
 
   // Regression for D9 (#12): the real zoom-out button could shrink zoom toward 0,
@@ -347,6 +348,7 @@ void main() {
 
     expect(created, isNotNull);
     expect(created!.hour, 2,
-        reason: 'zoom is floored at minZoom (0.5); unbounded it would hit maxHour');
+        reason:
+            'zoom is floored at minZoom (0.5); unbounded it would hit maxHour');
   });
 }

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -232,4 +232,89 @@ void main() {
     expect(moved, hasLength(1), reason: 'the drag committed exactly one move');
     expect(entry.time.hour, 10, reason: 'a one-block drag advances one hour');
   });
+
+  // Regression for D9 (#12): getTimeAtPos returned an overshoot day/hour for a
+  // real tap past the last column/hour — reachable whenever the grid is smaller
+  // than the viewport (few days/hours), leaving empty space the tap lands in.
+  // Driven end-to-end through the real right-click "Create Event" flow.
+  testWidgets('tapping past the grid clamps the created day/hour (D9)',
+      (tester) async {
+    const key = ValueKey('planner');
+    PlannerTime? created;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          key: key,
+          // 2 columns (days 0..1) and hours 0..5: a 400x240px grid, far smaller
+          // than the 800x600 viewport, so a low/right tap lands in empty space
+          // past the grid rather than on a cell.
+          config: PlannerConfig(
+            labels: const ['c1', 'c2'],
+            minHour: 0,
+            maxHour: 5,
+            onEntryCreate: (t) => created = t,
+          ),
+          entries: const [],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Right of the last column AND below the last hour row: events-local
+    // (450, 300) -> raw day floor(450/200)=2, raw hour floor(300/40)=7. (Kept
+    // clear of the right edge so the context menu still fits on screen.)
+    final at = tester.getRect(find.byKey(key)).topLeft +
+        const Offset(50 + 450, 50 + 300);
+    await createViaMenu(tester, key, at);
+
+    expect(created, isNotNull);
+    expect(created!.day, 1,
+        reason: 'clamped to the last column (labels.length - 1)');
+    expect(created!.hour, 5, reason: 'clamped to maxHour');
+  });
+
+  // Regression for D9 (#12): the zoom-out button multiplied zoom unbounded
+  // toward 0, which blows up getTimeAtPos's divide-by-zoom (raw hour into the
+  // hundreds). After clamping zoom to minZoom, mashing the real button still
+  // yields a created event at a valid in-range hour.
+  testWidgets('extreme zoom-out via the button keeps created times in range (D9)',
+      (tester) async {
+    const key = ValueKey('planner');
+    PlannerTime? created;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          key: key,
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 5,
+            onEntryCreate: (t) => created = t,
+          ),
+          entries: const [],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Mash the real zoom-out control well past minZoom.
+    final zoomOut = find.descendant(
+      of: find.byKey(key),
+      matching: find.byIcon(Icons.zoom_out),
+    );
+    for (var i = 0; i < 40; i++) {
+      await tester.tap(zoomOut);
+      await tester.pump();
+    }
+
+    // A normal mid-grid tap. Unbounded, zoom would be ~0.9^40 and the raw hour
+    // would land in the hundreds; clamped, it stays within [minHour, maxHour].
+    await createViaMenu(tester, key, gridPointFor(tester.getRect(find.byKey(key))));
+
+    expect(created, isNotNull);
+    expect(created!.hour, inInclusiveRange(0, 5),
+        reason: 'the zoom + hour clamps keep the created hour valid');
+  });
 }


### PR DESCRIPTION
## Summary
`Manager.getTimeAtPos` could return a negative `day`/`hour` (taps above/left of the grid) or an overshoot `day`/`hour` (taps past the last column/hour, reachable whenever the grid is smaller than the viewport), and `Controller.updateZoom` multiplied the zoom factor without bounds — so pinch or the zoom buttons could drive zoom toward 0 (blocks collapse, hit-testing explodes) or grow it without limit. This clamps all three.

## Linked issue
Closes #12

## Changes
- `Manager.getTimeAtPos`: clamp `day` to `[0, labels.length-1]` and `hour` to `[minHour, maxHour]`.
- `PlannerConfig`: add configurable `minZoom`/`maxZoom` (defaults `0.5` / `4.0`).
- `Controller.updateZoom`: clamp the zoom factor to `[config.minZoom, config.maxZoom]`.
- Tests: unit tests for the day/hour clamp (`manager_test`) and the zoom clamp (`controller_test`), plus three end-to-end tests against the real composed `Planner` (`planner_widget_test`).

## Test plan
- [x] `flutter analyze` clean
- [x] unit/widget tests pass (`flutter test` — 28 passed)
- [x] integration/e2e tests pass — this package's e2e layer is `testWidgets` against the real composed `Planner` in `test/planner_widget_test.dart` (the same place D1/D2/D5/#11 added their integration coverage; there is no separate `integration_test/` in the library). Added:
  - `tapping past the grid clamps the created day/hour` — right-click "Create Event" past the last column/hour; asserts the created time clamps to the last day / `maxHour`.
  - `zooming in past maxZoom stays bounded` / `zooming out past minZoom stays bounded` — drive the real zoom buttons well past `max`/`minZoom`, then read the bounded zoom back through `getTimeAtPos` at a fixed screen point (chosen so the mapped hour stays in range, keeping the hour clamp out of it).
- [x] All new regression tests confirmed to **fail on the unpatched code** (day `-1`/`25`, zoom `10.0`/`0.01`/`0.478`, e2e day `2`, e2e hour `0`/`23`) and pass with the fix. The two zoom e2e tests were additionally verified to fail with **only** the zoom clamp reverted (hour clamp intact), proving they isolate the zoom clamp rather than relying on the hour clamp.

## Notes / screenshots
Defaults `minZoom 0.5` / `maxZoom 4.0` were previously unbounded; existing zoom interactions stay within these bounds. Refs PROJECT_OVERVIEW.md — D9 (P1).
