### PR TITLE
fix: default maxHour to 23 and add hour-label formatter (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Fixed an off-by-one in the hour column: `maxHour` now defaults to `23`
+  (inclusive last hour), so the default planner no longer paints a spurious 25th
+  row labelled "24", and a tap below the grid clamps to hour 23.
+- Added an optional `PlannerConfig.hourLabelFormatter` to control how each hour
+  renders in the left column (e.g. zero-padding, AM/PM, or `intl`).
+
 ## 0.0.4 - 2025-03-03
 
 - Updated dependencies and raised the minimum Dart SDK to 3.0.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A complete, runnable demo lives in [`example/`](example/lib/main.dart).
 | Type | Purpose |
 |------|---------|
 | `Planner` | The widget. Takes a `config` and a list of `entries`. |
-| `PlannerConfig` | Sizing (`blockWidth`, `blockHeight`, `minHour`, `maxHour`, …), colors, text styles, and the `onEntry*` callbacks. `labels` is required. |
+| `PlannerConfig` | Sizing (`blockWidth`, `blockHeight`, `minHour`, `maxHour` — the inclusive last hour, default `23`, …), colors, text styles, an optional `hourLabelFormatter`, and the `onEntry*` callbacks. `labels` is required. |
 | `PlannerEntry` | One event: `id`, `time`, `title`, `content`, `color`, and optional text styles. |
 | `PlannerTime` | `day` (index into `labels`), `hour`, `minutes`, and `duration` (in minutes). |
 

--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -10,6 +10,7 @@ surface) can miss rendering/geometry bugs.
 | [`app_smoke_scenarios.dart`](app_smoke_scenarios.dart) | Boots the real example app; asserts a `Planner` renders and the real secondary-tap menu opens. |
 | [`drag_scenarios.dart`](drag_scenarios.dart) | Long-press-dragging an event moves it and fires `onEntryMove` with no paint-phase side effects (device-level counterpart of the #11 / D5 regression). |
 | [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
+| [`hour_label_scenarios.dart`](hour_label_scenarios.dart) | The default `maxHour` (23) clamps a below-grid tap to hour 23, not the invalid 24 (#13 / D10). |
 | [`multi_planner_scenarios.dart`](multi_planner_scenarios.dart) | Two planners on one screen keep independent scroll state (device-level counterpart of the #9 / D1 regression). |
 | [`planner_harness.dart`](planner_harness.dart) | Reusable `PlannerHarness` for multi-planner / multi-config flows, plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`, `longPressDrag`). |
 

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -3,6 +3,7 @@ import 'package:integration_test/integration_test.dart';
 import 'app_smoke_scenarios.dart';
 import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
+import 'hour_label_scenarios.dart';
 import 'multi_planner_scenarios.dart';
 
 /// Single entry point for the integration suite.
@@ -18,5 +19,6 @@ void main() {
   appSmokeScenarios();
   dragScenarios();
   eventGeometryScenarios();
+  hourLabelScenarios();
   multiPlannerScenarios();
 }

--- a/example/integration_test/hour_label_scenarios.dart
+++ b/example/integration_test/hour_label_scenarios.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for the hour-row off-by-one (#13 / PROJECT_OVERVIEW D10):
+/// `maxHour` defaulted to 24, so the *default* planner painted a spurious 25th
+/// row ("24") and a below-grid tap could create an event at the invalid hour 24.
+/// The default is now 23.
+///
+/// This drives the *real* composed widget on a real device with `maxHour` LEFT
+/// AT ITS DEFAULT (the value under test); `minHour` 20 keeps the grid (4 rows)
+/// inside the window so a low tap lands past the last hour row and exercises the
+/// maxHour clamp through the real right-click "Create Event" flow.
+///
+/// The painted label text itself lives on a `CustomPaint` canvas (not in the
+/// widget/semantics tree), so the reachable hour is the observable, e2e-testable
+/// consequence of the row count; the formatting is covered by unit tests.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void hourLabelScenarios() {
+  testWidgets('default maxHour clamps a below-grid tap to hour 23, not 24',
+      (tester) async {
+    PlannerTime? created;
+
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        PlannerSpec(
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 20, // maxHour intentionally omitted -> default (23)
+            onEntryCreate: (t) => created = t,
+          ),
+        ),
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    final planner = find.byKey(PlannerHarness.keyFor(0));
+    // 300px below the grid top: column 0, raw hour 20 + floor(300/40) = 27,
+    // which clamps to maxHour.
+    final at = gridPointFor(tester.getRect(planner), downFromGridTop: 300);
+    await createViaMenu(tester, planner, at);
+
+    expect(created, isNotNull);
+    expect(created!.hour, 23,
+        reason: 'default maxHour is 23; the old default (24) produced hour 24');
+  });
+}

--- a/lib/internal/hour_column.dart
+++ b/lib/internal/hour_column.dart
@@ -1,7 +1,23 @@
 import 'package:flutter/cupertino.dart';
 
+import '../planner_config.dart';
 import 'hour_label.dart';
 import 'manager.dart';
+
+/// The hour-label strings shown down the left column, one per hour row from
+/// [PlannerConfig.minHour] to [PlannerConfig.maxHour] **inclusive**.
+///
+/// Each hour is rendered with [PlannerConfig.hourLabelFormatter] when provided,
+/// otherwise as the bare hour integer. Kept as a pure function (rather than
+/// inlined in [HourColumn]) so the row count and formatting are unit-testable
+/// without a canvas.
+List<String> buildHourLabels(PlannerConfig config) {
+  final format = config.hourLabelFormatter ?? (int hour) => hour.toString();
+  return [
+    for (int hour = config.minHour; hour <= config.maxHour; hour++)
+      format(hour),
+  ];
+}
 
 class HourColumn extends CustomPainter {
   final List<HourLabel> _labels = <HourLabel>[];
@@ -10,9 +26,9 @@ class HourColumn extends CustomPainter {
   HourColumn({required this.manager, required Listenable repaint})
       : super(repaint: repaint) {
     int _pos = 15;
-    for (int i = manager.config.minHour; i <= manager.config.maxHour; i++) {
+    for (final text in buildHourLabels(manager.config)) {
       _labels.add(HourLabel(
-        label: i.toString(),
+        label: text,
         position: _pos,
         manager: manager,
       ));

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -9,6 +9,14 @@ class PlannerConfig {
   int minHour;
   int maxHour;
 
+  /// Formats the integer hour shown in the left-hand hour column. Receives the
+  /// hour-of-day (`minHour`..`maxHour`) and returns the label text. When `null`
+  /// the hour is rendered as the bare integer (e.g. `9`, `17`).
+  ///
+  /// Use it for zero-padding, AM/PM, or `intl` formatting, e.g.
+  /// `hourLabelFormatter: (h) => h.toString().padLeft(2, '0')` → `09`, `17`.
+  String Function(int hour)? hourLabelFormatter;
+
   int blockWidth;
   int blockHeight;
 
@@ -41,7 +49,8 @@ class PlannerConfig {
   PlannerConfig({
     required this.labels,
     this.minHour = 0,
-    this.maxHour = 24,
+    this.maxHour = 23,
+    this.hourLabelFormatter,
     this.blockWidth = 200,
     this.blockHeight = 40,
     this.minZoom = 0.5,

--- a/test/hour_label_test.dart
+++ b/test/hour_label_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/hour_column.dart';
+import 'package:planner/planner.dart';
+
+void main() {
+  // Regression for D10 (#13): maxHour defaulted to 24 and the row loop runs
+  // `i <= maxHour`, so the default planner painted 25 rows including a spurious
+  // "24" (not a valid hour-of-day). The default is now 23, and an optional
+  // formatter controls how each hour renders.
+  group('buildHourLabels', () {
+    test('default config yields 24 rows, 0..23, with no spurious "24"', () {
+      final labels = buildHourLabels(PlannerConfig(labels: const ['A']));
+
+      expect(labels.length, 24, reason: 'a full day is 24 hour rows, not 25');
+      expect(labels.first, '0');
+      expect(labels.last, '23');
+      expect(labels, isNot(contains('24')),
+          reason: 'hour 24 is not a valid hour-of-day');
+    });
+
+    test('honours a minHour..maxHour subrange (inclusive)', () {
+      final labels = buildHourLabels(
+        PlannerConfig(labels: const ['A'], minHour: 8, maxHour: 17),
+      );
+
+      expect(
+          labels, ['8', '9', '10', '11', '12', '13', '14', '15', '16', '17']);
+    });
+
+    test('falls back to the bare integer when no formatter is set', () {
+      final labels = buildHourLabels(
+        PlannerConfig(labels: const ['A'], minHour: 0, maxHour: 2),
+      );
+
+      expect(labels, ['0', '1', '2']);
+    });
+
+    test('applies hourLabelFormatter to every row (e.g. zero-pad)', () {
+      final labels = buildHourLabels(
+        PlannerConfig(
+          labels: const ['A'],
+          minHour: 8,
+          maxHour: 10,
+          hourLabelFormatter: (h) => h.toString().padLeft(2, '0'),
+        ),
+      );
+
+      expect(labels, ['08', '09', '10']);
+    });
+  });
+}

--- a/test/planner_test.dart
+++ b/test/planner_test.dart
@@ -47,7 +47,7 @@ void main() {
       final config = PlannerConfig(labels: const ['Mon', 'Tue']);
       expect(config.labels, ['Mon', 'Tue']);
       expect(config.minHour, 0);
-      expect(config.maxHour, 24);
+      expect(config.maxHour, 23);
       expect(config.blockWidth, 200);
       expect(config.blockHeight, 40);
     });

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -310,6 +310,44 @@ void main() {
     expect(created!.hour, 5, reason: 'clamped to maxHour');
   });
 
+  // Regression for D10 (#13): maxHour defaulted to 24, so the *default* planner
+  // painted a spurious 25th hour row and a below-grid tap could create an event
+  // at the invalid hour 24. The default is now 23. Driven end-to-end through the
+  // real right-click "Create Event" flow with maxHour LEFT AT ITS DEFAULT (the
+  // value under test). minHour 20 keeps the grid (4 rows, 160px) well inside the
+  // viewport so a low tap lands in empty space past the last hour row.
+  testWidgets(
+      'default maxHour clamps a below-grid tap to hour 23, not 24 (D10)',
+      (tester) async {
+    const key = ValueKey('planner');
+    PlannerTime? created;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          key: key,
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 20, // maxHour intentionally omitted -> default (23)
+            onEntryCreate: (t) => created = t,
+          ),
+          entries: const [],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // events-local (100, 300): column 0, and y=300 is below the 160px grid, so
+    // the raw hour 20 + floor(300/40) = 27 clamps to maxHour.
+    final at = tester.getRect(find.byKey(key)).topLeft +
+        const Offset(50 + 100, 50 + 300);
+    await createViaMenu(tester, key, at);
+
+    expect(created, isNotNull);
+    expect(created!.hour, 23,
+        reason: 'default maxHour is 23; the old default (24) produced hour 24');
+  });
+
   // Regression for D9 (#12): updateZoom multiplied without bounds, so the real
   // zoom-in button could grow zoom indefinitely. After zooming in well past
   // maxZoom (4.0), a fixed screen point still maps through the *capped* zoom: at


### PR DESCRIPTION
## Summary
`maxHour` defaulted to `24` while the row loop runs `i <= maxHour`, so the default planner painted a spurious 25th row labelled 24 (not a valid hour-of-day) and a below-grid tap could create an event at the invalid hour 24. The default is now `23` (the inclusive last hour). Also adds an optional hour-label formatter.

## Linked issue
Closes #13

## Changes
- `PlannerConfig`: default `maxHour` `24` → `23`. Audited the `maxHour - minHour + 1` grid math — it is already correct under the inclusive-`maxHour` interpretation (e.g. business hours 8..17 → 10 rows); the only bug was the default value.
- `PlannerConfig`: added optional `hourLabelFormatter` (`String Function(int hour)?`) so consumers can zero-pad / AM-PM / `intl`-format the hour column; falls back to the bare integer.
- `hour_column.dart`: extracted hour-label generation into a pure, testable `buildHourLabels(config)` that applies the formatter.
- Docs: CHANGELOG (Unreleased), README config row, integration-test README.

## Test plan
- [x] `flutter analyze` clean (package **and** `example/`)
- [x] `dart format --set-exit-if-changed` clean
- [x] unit/widget tests pass — `flutter test` (33 tests). New: `test/hour_label_test.dart` (row count has no spurious 24 + formatting); `test/planner_widget_test.dart` default-`maxHour` clamps a below-grid tap to hour 23.
- [x] integration/e2e tests pass — `flutter test integration_test -d windows` (6 tests). New `hour_label_scenarios.dart`: default `maxHour` clamps a below-grid tap to hour 23 on a real Windows window.
- [x] Confirmed both new D10 regressions **fail on the unpatched default (24)** (widget hour → 24; unit count → 25) before relying on them.

## Notes / screenshots
The painted hour-label text lives on a `CustomPaint` canvas (not in the widget/semantics tree), so `find.text` cannot assert on the labels directly — the **formatter** is therefore covered by unit tests, while the **off-by-one** is covered end-to-end via its observable consequence (the reachable hour clamping to 23 instead of the invalid 24).