### PR TITLE
Unify event-time snapping into one configurable interval (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Unified event-time snapping: creating an event by tapping and dragging/resizing
+  one now snap to a single configurable interval, `PlannerConfig.snapMinutes`
+  (default `15`), instead of separate ad-hoc, zoom-dependent thresholds. Pass
+  `PlannerConfig.snapMinutesForZoom` to vary the interval with the zoom level, or
+  set `snapMinutes <= 1` for minute precision. Create and drag now land on the
+  same grid.
 - Fixed an off-by-one in the hour column: `maxHour` now defaults to `23`
   (inclusive last hour), so the default planner no longer paints a spurious 25th
   row labelled "24", and a tap below the grid clamps to hour 23.

--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -11,6 +11,7 @@ surface) can miss rendering/geometry bugs.
 | [`drag_scenarios.dart`](drag_scenarios.dart) | Long-press-dragging an event moves it and fires `onEntryMove` with no paint-phase side effects (device-level counterpart of the #11 / D5 regression). |
 | [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
 | [`hour_label_scenarios.dart`](hour_label_scenarios.dart) | The default `maxHour` (23) clamps a below-grid tap to hour 23, not the invalid 24 (#13 / D10). |
+| [`snapping_scenarios.dart`](snapping_scenarios.dart) | Create and drag snap event times to the single configurable `snapMinutes` interval, and agree (#14 / D8). |
 | [`multi_planner_scenarios.dart`](multi_planner_scenarios.dart) | Two planners on one screen keep independent scroll state (device-level counterpart of the #9 / D1 regression). |
 | [`planner_harness.dart`](planner_harness.dart) | Reusable `PlannerHarness` for multi-planner / multi-config flows, plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`, `longPressDrag`). |
 

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -5,6 +5,7 @@ import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
 import 'hour_label_scenarios.dart';
 import 'multi_planner_scenarios.dart';
+import 'snapping_scenarios.dart';
 
 /// Single entry point for the integration suite.
 ///
@@ -21,4 +22,5 @@ void main() {
   eventGeometryScenarios();
   hourLabelScenarios();
   multiPlannerScenarios();
+  snappingScenarios();
 }

--- a/example/integration_test/snapping_scenarios.dart
+++ b/example/integration_test/snapping_scenarios.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for D8 (#14): create-time and drag-time snapping used to
+/// apply different ad-hoc, zoom-dependent thresholds, so creating and dragging
+/// an event landed on different sub-hour grids. Both now share one configurable
+/// interval (`PlannerConfig.snapMinutes`).
+///
+/// These drive the *real* composed widget (real layout, real fonts, real
+/// secondary-tap and long-press gestures). `blockHeight` is set to 60 so one
+/// grid pixel equals one minute, making the snapped result read directly off the
+/// pixel offset. With `snapMinutes` at its default (15), a 23-minute offset must
+/// land on 15, not 23 — and create and drag must agree.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void snappingScenarios() {
+  testWidgets('creating via the menu snaps the minute offset to snapMinutes',
+      (tester) async {
+    PlannerTime? created;
+
+    await tester.pumpWidget(PlannerHarness(planners: [
+      PlannerSpec(
+        config: PlannerConfig(
+          labels: const ['c1', 'c2'],
+          minHour: 0,
+          maxHour: 23,
+          blockHeight: 60,
+          onEntryCreate: (t) => created = t,
+        ),
+      ),
+    ]));
+    await tester.pumpAndSettle();
+
+    // Grid y 143 == hour 2 (120) + 23 raw minutes; the +100px x lands in column 0.
+    final planner = find.byKey(PlannerHarness.keyFor(0));
+    final at =
+        tester.getRect(planner).topLeft + const Offset(50 + 100, 50 + 143);
+    await createViaMenu(tester, planner, at);
+
+    expect(created, isNotNull);
+    expect(created!.day, 0);
+    expect(created!.hour, 2);
+    expect(created!.minutes, 15,
+        reason: '23 raw minutes snap down to the 15-min grid');
+  });
+
+  testWidgets('long-press dragging snaps the moved start to the same grid',
+      (tester) async {
+    final moved = <PlannerEntry>[];
+
+    // An event at day 0 / hour 4 -> grid rect (0,240)-(200,300) with blockHeight
+    // 60; its centre is a body drag (clear of the 8px handle zones).
+    final entry = PlannerEntry(
+      id: 'evt',
+      time: PlannerTime(day: 0, hour: 4),
+      title: 'Snap me',
+      content: '',
+      color: const Color(0xFF2244AA),
+    );
+
+    await tester.pumpWidget(PlannerHarness(planners: [
+      PlannerSpec(
+        config: PlannerConfig(
+          labels: const ['c1', 'c2'],
+          minHour: 0,
+          maxHour: 23,
+          blockHeight: 60,
+          onEntryMove: moved.add,
+        ),
+        entries: [entry],
+      ),
+    ]));
+    await tester.pumpAndSettle();
+
+    // On screen the event centre is offset by the hour column (50) and date row
+    // (50): grid (100, 270) -> planner-local (150, 320).
+    final from = tester.getRect(find.byKey(PlannerHarness.keyFor(0))).topLeft +
+        const Offset(150, 320);
+
+    // Drag down 23px == 23 minutes: top 4:00 -> 4:23, snapped down to 4:15.
+    await longPressDrag(tester, from, const Offset(0, 23));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(moved, hasLength(1), reason: 'the drag committed exactly one move');
+    expect(moved.single.time.day, 0);
+    expect(moved.single.time.hour, 4);
+    expect(moved.single.time.minutes, 15,
+        reason: 'a 23-minute drag snaps to the same 15-min grid as create');
+  });
+}

--- a/lib/internal/event.dart
+++ b/lib/internal/event.dart
@@ -186,49 +186,50 @@ class Event {
   }
 
   void endDrag() {
-    if (_dragType == DragType.body) {
-      int newDay =
-          ((canvasRect.topLeft.dx + _dragOffset.dx) / manager.config.blockWidth)
-              .round();
-      double newHour = ((canvasRect.topLeft.dy + _dragOffset.dy) /
-              manager.config.blockHeight) +
-          manager.config.minHour;
-      entry.time.day = newDay;
-      entry.time.hour = newHour.floor();
-      entry.time.minutes = ((newHour - newHour.floor()) * 60).floor();
-    } else if (_dragType == DragType.topHandle) {
-      double newHour = (((canvasRect.topLeft.dy + _dragOffset.dy) /
-                      manager.config.blockHeight)
-                  .round() +
-              manager.config.minHour)
-          .toDouble();
-      int newMinutes =
-          _roundedMinutes(((newHour - newHour.floor()) * 60).floor());
-      entry.time.duration += ((entry.time.hour - newHour.floor()) * 60) -
-          (newMinutes - entry.time.minutes);
-      entry.time.hour = newHour.floor();
-      entry.time.minutes = newMinutes;
-    } else if (_dragType == DragType.bottomHandle) {
-      entry.time.duration +=
-          (_dragOffset.dy / (manager.config.blockHeight * 0.25)).round() * 15;
-      entry.time.duration = _roundedMinutes(entry.time.duration);
+    final config = manager.config;
+    final blockHeight = config.blockHeight;
+
+    // Absolute minutes from minHour for an event edge at grid-y [y], snapped to
+    // the configured interval — the same primitive create uses, so a dragged
+    // edge lands on the same grid as a freshly created event.
+    int minutesAt(double y) =>
+        manager.snapToInterval((y / blockHeight * 60).round());
+
+    switch (_dragType) {
+      case DragType.body:
+        // Move: the column snaps to the nearest day, the start time snaps to the
+        // configured interval, and the duration is unchanged.
+        entry.time.day =
+            ((canvasRect.left + _dragOffset.dx) / config.blockWidth).round();
+        final start = minutesAt(canvasRect.top + _dragOffset.dy);
+        entry.time.hour = config.minHour + start ~/ 60;
+        entry.time.minutes = start % 60;
+        break;
+      case DragType.topHandle:
+        // Resize from the top: the bottom edge stays put, so the snapped start
+        // time is absorbed by the duration.
+        final bottom = (entry.time.hour - config.minHour) * 60 +
+            entry.time.minutes +
+            entry.time.duration;
+        final start = minutesAt(canvasRect.top + _dragOffset.dy);
+        entry.time.hour = config.minHour + start ~/ 60;
+        entry.time.minutes = start % 60;
+        entry.time.duration = bottom - start;
+        break;
+      case DragType.bottomHandle:
+        // Resize from the bottom: the start stays put, the bottom edge snaps.
+        final start =
+            (entry.time.hour - config.minHour) * 60 + entry.time.minutes;
+        entry.time.duration =
+            minutesAt(canvasRect.bottom + _dragOffset.dy) - start;
+        break;
+      case DragType.none:
+        break;
     }
 
     _calculateCanvasRect();
 
     _dragOffset = Offset.zero;
     _dragType = DragType.none;
-  }
-
-  int _roundedMinutes(int minutes) {
-    if (manager.controller.zoom <= 1) {
-      return (minutes ~/ 30) * 30;
-    } else if (manager.controller.zoom <= 2) {
-      return (minutes ~/ 15) * 15;
-    } else if (manager.controller.zoom < 3) {
-      return (minutes ~/ 5) * 5;
-    } else {
-      return minutes;
-    }
   }
 }

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -101,14 +101,43 @@ class Manager {
     int day = (realPos.dx / config.blockWidth)
         .floor()
         .clamp(0, config.labels.length - 1);
-    int hour = (config.minHour + (realPos.dy / config.blockHeight).floor())
-        .clamp(config.minHour, config.maxHour);
-    int minutes = 0;
-    if (controller.zoom > 2.25) {
-      minutes = ((realPos.dy.toInt() % config.blockHeight) / 10).floor() * 15;
-    } else if (controller.zoom > 1.25) {
-      minutes = ((realPos.dy.toInt() % config.blockHeight) / 20).floor() * 30;
+
+    // Row index from the top of the grid, plus the proportional minute offset
+    // into that row (pixels -> minutes via blockHeight, not a hardcoded 40),
+    // snapped to the configured interval so a created event lands on the same
+    // grid a dragged one does.
+    final double rawRow = realPos.dy / config.blockHeight;
+    final int row = rawRow.floor();
+    int hour = config.minHour + row;
+    int minutes = snapToInterval(((rawRow - row) * 60).floor());
+
+    // A tap outside the grid clamps to a valid hour; its minute offset is
+    // meaningless, so pin it to the hour boundary.
+    if (hour < config.minHour) {
+      hour = config.minHour;
+      minutes = 0;
+    } else if (hour > config.maxHour) {
+      hour = config.maxHour;
+      minutes = 0;
     }
+
     return PlannerTime(day: day, hour: hour, minutes: minutes);
+  }
+
+  /// The snap interval (in minutes) in effect right now: the zoom-aware override
+  /// if the host supplied one, otherwise the flat [PlannerConfig.snapMinutes].
+  int get activeSnapMinutes =>
+      config.snapMinutesForZoom?.call(controller.zoom) ?? config.snapMinutes;
+
+  /// Snaps [minutes] to a multiple of [activeSnapMinutes]. The single snapping
+  /// primitive shared by create ([getTimeAtPos]) and drag/resize
+  /// ([Event.endDrag]), so the two stay in lockstep. An interval `<= 1` leaves
+  /// [minutes] untouched (minute precision); it truncates rather than rounds so
+  /// a within-hour offset can't spill into the next hour (e.g. 58 -> 45, never
+  /// 60, at a 15-minute snap).
+  int snapToInterval(int minutes) {
+    final step = activeSnapMinutes;
+    if (step <= 1) return minutes;
+    return (minutes ~/ step) * step;
   }
 }

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -20,6 +20,24 @@ class PlannerConfig {
   int blockWidth;
   int blockHeight;
 
+  /// Granularity, in minutes, that event times snap to — for **both** creating
+  /// an event by tapping an empty cell and dragging/resizing an existing one,
+  /// so the two behave identically (the old code used different ad-hoc,
+  /// zoom-dependent thresholds for each).
+  ///
+  /// Use a value that divides 60 evenly (e.g. `5`, `10`, `15`, `30`, `60`) so
+  /// snaps land on clean sub-hour boundaries. A value `<= 1` disables snapping
+  /// (minute precision). Snapping truncates rather than rounds, so a within-hour
+  /// offset never spills into the next hour.
+  int snapMinutes;
+
+  /// Optional zoom-aware override of [snapMinutes]. When non-null it is called
+  /// with the current zoom factor and its result is used as the snap interval
+  /// for that frame, letting events snap more finely as the user zooms in, e.g.
+  /// `snapMinutesForZoom: (z) => z >= 3 ? 5 : z >= 2 ? 15 : 30`. When null (the
+  /// default) the flat [snapMinutes] applies at every zoom level.
+  int Function(double zoom)? snapMinutesForZoom;
+
   /// Lower/upper bounds applied to the pinch/zoom factor in
   /// [Controller.updateZoom]. Without these the zoom could shrink toward 0
   /// (blocks collapse, hit-testing explodes) or grow without limit.
@@ -53,6 +71,8 @@ class PlannerConfig {
     this.hourLabelFormatter,
     this.blockWidth = 200,
     this.blockHeight = 40,
+    this.snapMinutes = 15,
+    this.snapMinutesForZoom,
     this.minZoom = 0.5,
     this.maxZoom = 4.0,
     this.hourLabelStyle = const TextStyle(color: Colors.black),

--- a/test/planner_test.dart
+++ b/test/planner_test.dart
@@ -50,6 +50,8 @@ void main() {
       expect(config.maxHour, 23);
       expect(config.blockWidth, 200);
       expect(config.blockHeight, 40);
+      expect(config.snapMinutes, 15);
+      expect(config.snapMinutesForZoom, isNull);
     });
   });
 }

--- a/test/snapping_test.dart
+++ b/test/snapping_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+import 'package:planner/planner_time.dart';
+
+void main() {
+  // Regression for D8 (#14): create-time (`getTimeAtPos`) and drag-time
+  // (`Event.endDrag`) snapping used to apply *different* ad-hoc, zoom-dependent
+  // thresholds (`zoom>2.25`/`/10*15` vs `~/30`/`~/15`/`~/5`), so creating and
+  // dragging an event landed on different grids. They now share one configurable
+  // interval — `PlannerConfig.snapMinutes` via `Manager.snapToInterval`.
+
+  // blockHeight 60 makes one grid-pixel == one minute, so the y-coordinates
+  // below read directly as minutes-from-minHour. blockWidth stays default (200).
+  Manager makeManager({
+    int snapMinutes = 15,
+    int Function(double zoom)? snapMinutesForZoom,
+    PlannerTime? time,
+  }) =>
+      Manager(
+        config: PlannerConfig(
+          labels: const ['A', 'B'],
+          minHour: 0,
+          maxHour: 23,
+          blockHeight: 60,
+          snapMinutes: snapMinutes,
+          snapMinutesForZoom: snapMinutesForZoom,
+        ),
+        entries: [
+          PlannerEntry(
+            id: 'e',
+            time: time ?? PlannerTime(day: 0, hour: 9),
+            title: 'e',
+            content: '',
+            color: const Color(0xFF112233),
+          ),
+        ],
+      );
+
+  group('create-time snapping (getTimeAtPos)', () {
+    test('snaps the minute offset down to the default 15-min interval', () {
+      // y = 263 == hour 4 (240) + 23 raw minutes -> snaps down to 15.
+      final time = makeManager().getTimeAtPos(const Offset(100, 263));
+      expect(time.hour, 4);
+      expect(time.minutes, 15);
+    });
+
+    test('honours a custom snapMinutes', () {
+      final time =
+          makeManager(snapMinutes: 30).getTimeAtPos(const Offset(100, 263));
+      expect(time.hour, 4);
+      expect(time.minutes, 0,
+          reason: '23 raw min snaps down to the 30-min grid');
+    });
+
+    test('snapMinutes <= 1 keeps minute precision', () {
+      final time =
+          makeManager(snapMinutes: 1).getTimeAtPos(const Offset(100, 263));
+      expect(time.hour, 4);
+      expect(time.minutes, 23, reason: 'snapping disabled -> exact minute');
+    });
+  });
+
+  group('drag-time snapping (Event.endDrag)', () {
+    // The single entry sits at day 0 / hour 9 -> grid rect (0,540)-(200,600)
+    // with blockHeight 60. Driving the Event directly keeps the top/bottom
+    // handle (8px) and body hit zones unambiguous.
+    test('a body drag snaps the start time and keeps the duration', () {
+      final e = makeManager().events.single;
+      e.startDrag(const Offset(100, 570)); // body, clear of the 8px handles
+      e.updateDrag(const Offset(100, 593)); // +23 min
+      e.endDrag();
+      expect(e.entry.time.hour, 9);
+      expect(e.entry.time.minutes, 15, reason: '+23 snaps down to +15');
+      expect(e.entry.time.duration, 60, reason: 'a move keeps the duration');
+    });
+
+    test('a top-handle drag snaps the start and pins the bottom edge', () {
+      final e = makeManager().events.single;
+      e.startDrag(const Offset(100, 540)); // top handle
+      e.updateDrag(const Offset(100, 563)); // +23 min
+      e.endDrag();
+      expect(e.entry.time.hour, 9);
+      expect(e.entry.time.minutes, 15);
+      // The bottom edge (10:00) stays put: 9:15 + 45 == 10:00.
+      expect(e.entry.time.duration, 45);
+    });
+
+    test('a bottom-handle drag snaps the bottom edge and pins the start', () {
+      final e = makeManager().events.single;
+      e.startDrag(const Offset(100, 599)); // bottom handle
+      e.updateDrag(const Offset(100, 623)); // +24 min
+      e.endDrag();
+      expect(e.entry.time.hour, 9, reason: 'the start stays put');
+      expect(e.entry.time.minutes, 0);
+      // Bottom 10:00 + 24 == 10:24 snaps down to 10:15 -> duration 75.
+      expect(e.entry.time.duration, 75);
+    });
+  });
+
+  test('create and drag land on the same grid for the same y (D8)', () {
+    // The whole point of the issue: the create tap and a body drag must agree.
+    final created = makeManager().getTimeAtPos(const Offset(100, 263));
+
+    // Drag an hour-0 event's body so its top lands at the same absolute y (263).
+    final e = makeManager(time: PlannerTime(day: 0, hour: 0)).events.single;
+    e.startDrag(const Offset(100, 30)); // body of the 0..60 rect
+    e.updateDrag(const Offset(100, 293)); // +263
+    e.endDrag();
+
+    expect(e.entry.time.hour, created.hour);
+    expect(e.entry.time.minutes, created.minutes);
+    expect(created.hour, 4);
+    expect(created.minutes, 15);
+  });
+
+  group('snap interval resolution', () {
+    test('activeSnapMinutes falls back to the flat snapMinutes', () {
+      final m = makeManager(snapMinutes: 10);
+      expect(m.activeSnapMinutes, 10);
+      expect(m.snapToInterval(23), 20);
+    });
+
+    test('snapMinutesForZoom overrides the flat value at the current zoom', () {
+      final m = makeManager(
+        snapMinutes: 15,
+        snapMinutesForZoom: (z) => z >= 2 ? 5 : 30,
+      );
+      expect(m.activeSnapMinutes, 30, reason: 'zoom 1 -> coarse 30-min snap');
+      expect(m.snapToInterval(23), 0);
+
+      m.controller.startZoom();
+      m.controller.updateZoom(2.5);
+      expect(m.activeSnapMinutes, 5, reason: 'zoomed in -> fine 5-min snap');
+      expect(m.snapToInterval(23), 20);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Create-time and drag-time snapping used different ad-hoc, zoom-dependent thresholds, so creating and dragging an event landed on different sub-hour grids. Both now share a single configurable interval, `PlannerConfig.snapMinutes` (default `15`), applied through `Manager.snapToInterval`. (D8 / P1)

## Linked issue
Closes #14

## Changes
- `PlannerConfig`: new `snapMinutes` (default `15`) — the single interval for both create and drag; optional `snapMinutesForZoom` callback to vary it with zoom; `snapMinutes <= 1` disables snapping.
- `Manager`: `getTimeAtPos` now derives the minute offset proportionally from `blockHeight` (not a hardcoded `40`) and snaps via a shared `snapToInterval`; added `activeSnapMinutes` (resolves the zoom override) and `snapToInterval` (truncates, so a within-hour offset can't spill into the next hour).
- `Event.endDrag`: body / top-handle / bottom-handle drags all snap through the same `snapToInterval`; removed the zoom-threshold `_roundedMinutes`. Body-drag minutes now snap too (previously they didn't).
- Tests: new `test/snapping_test.dart` (9) and two end-to-end scenarios in `snapping_scenarios.dart`; CHANGELOG + integration README updated.

## Test plan
- [x] `flutter analyze` clean (lib + example)
- [x] unit/widget tests pass — 42 (`flutter test`)
- [x] integration/e2e tests pass — 8 on Windows (`flutter test integration_test -d windows`), including the 2 new snapping scenarios (create-via-menu and long-press drag both snap to the same grid)
- [x] fail-without-fix verified: reverting the two lib files to HEAD made every new behavioral assertion fail (create min `0`→`15`, body-drag `22`→`15`, top-handle `0`→`15`, bottom-handle duration `90`→`75`, and create vs drag disagreed `0`≠`23`)

## Notes / screenshots
Behavior change: the default snap is now a flat 15 min for **both** create and drag (previously create snapped to the hour and drag to 30 min at default zoom). This is the intended unification — hosts wanting the old zoom-finer feel can supply `snapMinutesForZoom`.