### PR TITLE
chore: export planner_time.dart from the public API (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Then import it:
 
 ```dart
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 ```
 
 ## Usage
@@ -47,7 +46,6 @@ import 'package:planner/planner_time.dart';
 ```dart
 import 'package:flutter/material.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 class CalendarPage extends StatelessWidget {
   const CalendarPage({super.key});

--- a/example/integration_test/drag_scenarios.dart
+++ b/example/integration_test/drag_scenarios.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 import 'planner_harness.dart';
 

--- a/example/integration_test/event_geometry_scenarios.dart
+++ b/example/integration_test/event_geometry_scenarios.dart
@@ -2,7 +2,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 import 'planner_harness.dart';
 

--- a/example/integration_test/hour_label_scenarios.dart
+++ b/example/integration_test/hour_label_scenarios.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 import 'planner_harness.dart';
 

--- a/example/integration_test/multi_planner_scenarios.dart
+++ b/example/integration_test/multi_planner_scenarios.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 import 'planner_harness.dart';
 

--- a/example/integration_test/snapping_scenarios.dart
+++ b/example/integration_test/snapping_scenarios.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 import 'planner_harness.dart';
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:example/data.dart';
 import 'package:flutter/material.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 void main() {
   runApp(const MyApp());

--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:planner/planner.dart';
 
-import '../planner_config.dart';
-import '../planner_time.dart';
 import 'event.dart';
 
 enum MenuType {

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:planner/internal/event.dart';
 import 'package:planner/planner.dart';
 
-import '../planner_time.dart';
 import 'controller.dart';
 
 class Manager {

--- a/lib/planner.dart
+++ b/lib/planner.dart
@@ -3,3 +3,4 @@ library planner;
 export 'planner_class.dart';
 export 'planner_entry.dart';
 export 'planner_config.dart';
+export 'planner_time.dart';

--- a/test/event_geometry_test.dart
+++ b/test/event_geometry_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/internal/event.dart';
 import 'package:planner/internal/manager.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 void main() {
   // Regression for D3 + D4 (#10): an event's canvasRect must derive its top

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/internal/manager.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 void main() {
   PlannerConfig makeConfig() => PlannerConfig(labels: const ['A', 'B']);

--- a/test/planner_test.dart
+++ b/test/planner_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 void main() {
   group('PlannerTime', () {

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 void main() {
   // End-to-end against the *real* composed widget (real layout, real fonts, real

--- a/test/public_api_test.dart
+++ b/test/public_api_test.dart
@@ -1,0 +1,35 @@
+// Regression test for issue #15: the public umbrella import must expose the
+// whole public surface. This file deliberately imports ONLY
+// `package:planner/planner.dart` — if any of these types were not re-exported,
+// the file would fail to compile and this test would never run.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:planner/planner.dart';
+
+void main() {
+  group('public API surface (single umbrella import)', () {
+    test('PlannerTime is reachable via package:planner/planner.dart', () {
+      final time = PlannerTime(day: 1, hour: 9, minutes: 30, duration: 45);
+      expect(time.day, 1);
+      expect(time.hour, 9);
+      expect(time.minutes, 30);
+      expect(time.duration, 45);
+    });
+
+    test('PlannerEntry, PlannerConfig and Planner are reachable too', () {
+      final entry = PlannerEntry(
+        id: 'a1',
+        time: PlannerTime(day: 0, hour: 8),
+        title: 'Stand-up',
+        content: 'Daily sync',
+        color: const Color(0xFF00FF00),
+      );
+      final config = PlannerConfig(labels: const ['Mon']);
+
+      expect(entry, isA<PlannerEntry>());
+      expect(config, isA<PlannerConfig>());
+      expect(Planner.new, isA<Function>());
+    });
+  });
+}

--- a/test/snapping_test.dart
+++ b/test/snapping_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/internal/manager.dart';
 import 'package:planner/planner.dart';
-import 'package:planner/planner_time.dart';
 
 void main() {
   // Regression for D8 (#14): create-time (`getTimeAtPos`) and drag-time


### PR DESCRIPTION
## Summary
`PlannerTime` is part of the public surface but was not re-exported from `lib/planner.dart`, so consumers had to import `package:planner/planner_time.dart` directly. This exports it from the umbrella library so a single `import 'package:planner/planner.dart';` exposes the whole public API.

## Linked issue
Closes #15

## Changes
- `lib/planner.dart`: add `export 'planner_time.dart';` (the fix).
- `example/lib/main.dart` & `README.md`: drop the now-redundant direct `planner_time.dart` import (as the issue suggested).
- 5 example integration-test files, 5 unit/widget test files, and `lib/internal/controller.dart` / `lib/internal/manager.dart`: remove direct imports the analyzer flagged as `unnecessary_import` once the export landed, keeping `flutter analyze` clean (baseline `develop` was clean).
- `test/public_api_test.dart`: new regression test that imports **only** `package:planner/planner.dart` and exercises `PlannerTime` (and the other public types). Without the export it fails to compile; with it, it passes — verified both directions.

## Test plan
- [x] `dart format` clean
- [x] `flutter analyze` clean — No issues found
- [x] unit/widget tests pass (`flutter test`) — 44 tests
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — 8 tests. No *new* integration test was warranted (pure public-API export, no user-visible behavior change), but the full suite was re-run because this PR edits the example integration-test files.

## Notes / screenshots
PROJECT_OVERVIEW.md (concern C4) is intentionally left untouched — the overview is refreshed via the separate overview-update skill, consistent with how recent fixes #13/#14 were handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
