### PR TITLE
test: replace broken example test and cover entry-menu callbacks (#17)

### DIFF
--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -1,6 +1,7 @@
 import 'package:integration_test/integration_test.dart';
 
 import 'app_smoke_scenarios.dart';
+import 'context_menu_scenarios.dart';
 import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
 import 'hour_label_scenarios.dart';
@@ -18,6 +19,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   appSmokeScenarios();
+  contextMenuScenarios();
   dragScenarios();
   eventGeometryScenarios();
   hourLabelScenarios();

--- a/example/integration_test/context_menu_scenarios.dart
+++ b/example/integration_test/context_menu_scenarios.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+import 'package:example/main.dart' as app;
+
+/// Drives the *real* example app end-to-end to cover the **entry** context menu
+/// (right-clicking an existing event), which the create-event smoke
+/// ([app_smoke_scenarios.dart]) does not exercise. The "Edit Event" /
+/// "Delete Event" items are real Text widgets, so the menu itself is assertable
+/// even though event titles are painted on the canvas.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void contextMenuScenarios() {
+  testWidgets('right-clicking an event opens the edit/delete menu',
+      (tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    // The sample data's "Entry 1" sits at day 0 / 08:00 for 60 min
+    // (DataEntry.createSampleData). With the default 200x40 grid that is grid
+    // rect (0,320)-(200,360); skipping the hour column (50) and date row (50),
+    // the box centre lands at planner-local (50 + 100, 50 + 340).
+    final rect = tester.getRect(find.byType(Planner));
+    final at = rect.topLeft + const Offset(50 + 100, 50 + 340);
+
+    final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Right-clicking an event opens the *entry* menu (edit/delete), not the
+    // empty-grid *create* menu.
+    expect(find.text('Edit Event'), findsOneWidget);
+    expect(find.text('Delete Event'), findsOneWidget);
+    expect(find.text('Create Event'), findsNothing);
+
+    // Tapping an item closes the menu (the sample handler just logs).
+    await tester.tap(find.text('Delete Event'));
+    await tester.pumpAndSettle();
+    expect(find.text('Delete Event'), findsNothing);
+  });
+}

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,30 +1,26 @@
-// This is a basic Flutter widget test.
+// Widget smoke test for the example app.
 //
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// This used to be the default Flutter *counter* test (asserting a '0' -> '1'
+// FloatingActionButton flow) left over from `flutter create`. The example app
+// has no counter — it renders a Planner demo — so that test failed if ever run.
+// It now verifies the example actually boots into the planner.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
 
 import 'package:example/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('example app boots into the Planner demo', (tester) async {
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // The demo renders a single Planner inside a 'Planner Demo' scaffold.
+    expect(find.byType(Planner), findsOneWidget);
+    expect(find.text('Planner Demo'), findsOneWidget);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Guard against the old counter template creeping back in.
+    expect(find.byType(FloatingActionButton), findsNothing);
   });
 }

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -89,6 +89,54 @@ void main() {
     }
   }
 
+  // An event at day 0 / hour 9. With the default 200x40 grid it occupies grid
+  // rect (0,360)-(200,400); its centre is events-local (100,380) which, past the
+  // hour column (50) and date row (50), is planner-local (150, 430).
+  PlannerEntry eventAtHour9() => PlannerEntry(
+        id: 'evt',
+        time: PlannerTime(day: 0, hour: 9),
+        title: 'Meeting',
+        content: '',
+        color: const Color(0xFF2244AA),
+      );
+
+  // Pumps a single full-screen Planner holding [entry], wiring whichever entry
+  // callbacks the test cares about, and returns its on-screen rect.
+  Future<Rect> pumpEntryPlanner(
+    WidgetTester tester,
+    Key key,
+    PlannerEntry entry, {
+    void Function(PlannerEntry)? onEdit,
+    void Function(PlannerEntry)? onDelete,
+    void Function(PlannerTime)? onCreate,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          key: key,
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryEdit: onEdit,
+            onEntryDelete: onDelete,
+            onEntryCreate: onCreate,
+          ),
+          entries: [entry],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    return tester.getRect(find.byKey(key));
+  }
+
+  Future<void> rightClickAt(WidgetTester tester, Offset at) async {
+    final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+  }
+
   testWidgets('two planners keep independent scroll state (D1)',
       (tester) async {
     const keyA = ValueKey('plannerA');
@@ -387,5 +435,59 @@ void main() {
     expect(created!.hour, 2,
         reason:
             'zoom is floored at minZoom (0.5); unbounded it would hit maxHour');
+  });
+
+  // The entry context menu (right-click an existing event) and its onEntryEdit /
+  // onEntryDelete callbacks were untested — only the empty-grid "Create Event"
+  // menu (onEntryCreate) and the long-press drag (onEntryMove) had coverage.
+  // These drive the real composed Planner: a secondary tap on the event opens
+  // the *entry* menu, then tapping an item fires the matching callback.
+  group('entry context menu (right-click an event)', () {
+    testWidgets('opens the edit/delete menu and Edit fires onEntryEdit',
+        (tester) async {
+      const key = ValueKey('planner');
+      final edited = <PlannerEntry>[];
+      final entry = eventAtHour9();
+      final rect = await pumpEntryPlanner(tester, key, entry,
+          onEdit: edited.add, onDelete: (_) {}, onCreate: (_) {});
+
+      await rightClickAt(tester, rect.topLeft + const Offset(150, 430));
+
+      // The entry menu (edit/delete) opens — not the empty-grid create menu.
+      expect(
+          find.descendant(
+              of: find.byKey(key), matching: find.text('Edit Event')),
+          findsOneWidget);
+      expect(
+          find.descendant(
+              of: find.byKey(key), matching: find.text('Delete Event')),
+          findsOneWidget);
+      expect(find.text('Create Event'), findsNothing);
+
+      await tester.tap(find.descendant(
+          of: find.byKey(key), matching: find.text('Edit Event')));
+      await tester.pump();
+
+      expect(edited, hasLength(1));
+      expect(identical(edited.single, entry), isTrue,
+          reason: 'onEntryEdit receives the right-clicked entry');
+    });
+
+    testWidgets('Delete fires onEntryDelete with the event', (tester) async {
+      const key = ValueKey('planner');
+      final deleted = <PlannerEntry>[];
+      final entry = eventAtHour9();
+      final rect = await pumpEntryPlanner(tester, key, entry,
+          onEdit: (_) {}, onDelete: deleted.add, onCreate: (_) {});
+
+      await rightClickAt(tester, rect.topLeft + const Offset(150, 430));
+      await tester.tap(find.descendant(
+          of: find.byKey(key), matching: find.text('Delete Event')));
+      await tester.pump();
+
+      expect(deleted, hasLength(1));
+      expect(identical(deleted.single, entry), isTrue,
+          reason: 'onEntryDelete receives the right-clicked entry');
+    });
   });
 }


### PR DESCRIPTION
## Summary
Finishes the still-outstanding parts of #17. Since the issue was filed, a substantial suite was built up across #10–#16, so "expand test coverage" was largely done; this PR closes the two real remainders — the broken example smoke test and the uncovered entry-menu (`onEntryEdit`/`onEntryDelete`) callbacks — and adds an integration scenario for the entry menu. Test-only; no production code changes.

## Linked issue
Closes #17

## Changes
- **Replace the broken example test** (`example/test/widget_test.dart`): it was the unmodified `flutter create` *counter* test (imported `MyApp`, asserted a `0→1` counter) but the example renders a Planner demo, so it failed if run. Now it boots `MyApp` and asserts the Planner demo renders, with a guard against the counter template returning.
- **Cover the entry context menu** (`test/planner_widget_test.dart`): right-clicking an event opens the edit/delete menu and fires `onEntryEdit` / `onEntryDelete`, driven against the real composed `Planner`. (`onEntryCreate` via the create menu and `onEntryMove` via drag were already covered.)
- **Add an integration scenario** (`example/integration_test/context_menu_scenarios.dart`, registered in `app_test.dart`): drives the real example app's entry menu (right-click a sample event → edit/delete), which the create-event smoke didn't exercise.

## Out of scope (filed separately)
While covering callbacks I found the **double-tap** edit/create path is structurally dead: `PositionedTapDetector2` (which owns `onDoubleTap`) is the *parent* of the `paintEvents` `GestureDetector`, so the inner detector wins the tap arena and `onDoubleTap` never fires. Filed as #40. My initial double-tap tests reproduced it (callback stayed null); dropped here since it's an app bug, not a test gap — and the same callbacks are covered via the menus.

## Test plan
- [x] `flutter analyze` (package) and `flutter analyze example` — clean
- [x] `dart format --output=none --set-exit-if-changed .` — clean (39 files, 0 changed)
- [x] unit/widget tests pass (`flutter test`) — 46 passed
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`, full suite) — 9 passed, incl. the new entry-menu scenario (the real `onEntryDelete` fired end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)