### PR TITLE
chore: bump version to 0.2.0 and cut CHANGELOG release (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 - 2026-06-06
 
 - Unified event-time snapping: creating an event by tapping and dragging/resizing
   one now snap to a single configurable interval, `PlannerConfig.snapMinutes`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: planner
 description: >-
   A scrollable, zoomable day-grid widget for showing and editing events across
   labelled columns, with drag-to-move, drag-to-resize, and context-menu actions.
-version: 0.0.4
+version: 0.2.0
 homepage: https://github.com/pebble-world/planner
 repository: https://github.com/pebble-world/planner
 issue_tracker: https://github.com/pebble-world/planner/issues


### PR DESCRIPTION
## Summary
The package name `planner` already exists on pub.dev at `0.1.0` (confirmed ours), and pub.dev refuses any version ≤ the latest — so the current `0.0.4` cannot be published. This bumps the version to `0.2.0` (a minor bump covering the snapping/maxHour/hour-label work already sitting in the changelog) and cuts the `## Unreleased` block as a real release. This resolves the **A5** publish gate from PROJECT_OVERVIEW; every other publish blocker (A1–A4) was already cleared.

## Linked issue
Closes #18

## Changes
- `pubspec.yaml`: `version: 0.0.4` → `0.2.0`
- `CHANGELOG.md`: `## Unreleased` → `## 0.2.0 - 2026-06-06` (no entry edits)

## Test plan
- [x] `flutter analyze` clean — no issues
- [x] unit/widget tests pass (`flutter test`) — 46 tests
- [x] `flutter pub publish --dry-run` — name OK, **0.2.0 accepted**, archive builds (151 KB). Remaining dry-run warning is the A6 gitignored IDE files (`.idea/*`, `planner.iml`), which is pre-existing and tracked separately by #26 — out of scope here.
- [ ] No unit/integration test added: this is release-prep metadata (version + changelog) with **no runtime behavior** to exercise. The relevant gate for this change is the publish dry-run, which passed.

## Note
The actual `flutter pub publish` is **not** part of this PR — it is irreversible and requires an authorized-uploader's pub.dev credentials. That is a follow-up step performed manually after merge.