### PR TITLE
docs: record time-model decision — keep day-index (#19)

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -31,3 +31,5 @@ build/
 # --- package-specific exclusions ---
 # Internal quality-audit / orientation doc — kept in the repo, not shipped.
 PROJECT_OVERVIEW.md
+# Internal architecture decision records — kept in the repo, not shipped.
+docs/decisions/

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -8,7 +8,7 @@
 - **Version:** 0.0.4
 - **Repo:** https://github.com/pebble-world/planner
 - **Status:** internal-only (`publish_to: none`); goal is pub.dev + cross-project reuse.
-- **Last reviewed:** 2026-06-05
+- **Last reviewed:** 2026-06-06
 
 ---
 
@@ -31,8 +31,9 @@ rectangle positioned by time. The user can:
 There are **no real calendar dates anywhere**. [`PlannerTime`](lib/planner_time.dart)
 is `{ int day, int hour, int minutes, int duration }`, where `day` is an **index
 into `config.labels`** (a `List<String>`). The widget is really a *generic grid of
-time-slots in N labelled columns*, not a date-aware calendar. This is the single
-biggest design decision to revisit (see §4, Features).
+time-slots in N labelled columns*, not a date-aware calendar. This was the single
+biggest design fork — **now decided: keep the day-index model** (#19; see §4 and
+`docs/decisions/0001-time-model-day-index.md`).
 
 ---
 
@@ -170,29 +171,49 @@ Severity: 🔴 blocker/bug · 🟠 important · 🟡 polish.
 - **C4:** export `planner_time.dart`. **C1/C2/C3:** remove dead code / fix typo.
 - **C6:** add a real test suite (widget + golden), fix the example smoke test.
 
-### P2 — Make it a great *calendar* (pick a direction — see below)
-- Real date support, week navigation, "today" highlight, multi-day/all-day events.
+### P2 — Make it a great *calendar* (direction decided — see below)
+- ✅ **Time-model direction resolved (#19):** keep the day-index model; do **not**
+  migrate to `DateTime`. See `docs/decisions/0001-time-model-day-index.md`.
+- Add the genuine widget-level primitives as additive, non-breaking follow-ups:
+  highlight-column ("today" style, #46), event column-span (multi-day, #47),
+  all-day band (#48), optional `date ↔ index` consumer helpers (#49).
 - **D11** overlap/column layout. Accessibility (`Semantics`), localization of menu strings.
 
 ### P3 — Polish & tooling
 - **B2** bump `flutter_lints`; **E1/E2** CI + stricter analysis; **D6/D7** repaint &
   allocation optimizations; **B3** resolve the vendored dependency; **C7** example churn.
 
-### The key design fork — time model (no decision forced)
+### The key design fork — time model (✅ DECIDED: keep day-index, #19)
 
-**Option 1 — keep the abstract day-index model.**
+**Decision (2026-06-06):** keep the abstract **day-index** model — `day` stays an
+index into `config.labels`. We will **not** migrate to `DateTime`, and **not** take
+the optional-`DateTime`-per-column middle path. Full rationale in
+`docs/decisions/0001-time-model-day-index.md`.
+
+The reasoning, in short: the widget treats `day` purely as a column index and the
+label is already a free-form string, so `DateTime` turned out to be an **ergonomics**
+choice, not a **capability** unlock. Week navigation, `intl` formatting, and even
+"today" highlighting are all achievable in consumer code (or via tiny index-based
+primitives) without putting `DateTime` in the public API. Adding `DateTime` would
+only move responsibility into the library at the cost of a breaking change.
+
+The options as originally framed (retained for the record):
+
+**Option 1 — keep the abstract day-index model.** ← **chosen**
 - ➕ Minimal change; stays a flexible "N labelled columns of time-slots" widget;
   useful for non-calendar scheduling (rooms, machines, lanes).
-- ➖ Never a true calendar; the consumer must map dates ↔ indices themselves.
+- ➖ Never a true calendar out-of-the-box; the consumer maps dates ↔ indices
+  themselves (to be eased by optional, non-core helpers).
 
-**Option 2 — migrate to `DateTime`.**
-- ➕ Unlocks week navigation, today-highlight, multi-day/all-day events, time
-  zones/DST, and `intl` formatting — i.e. an actual calendar.
-- ➖ Larger API change (`PlannerTime` → `DateTime` + `Duration`), needs a migration
-  guide and a major version bump.
+**Option 2 — migrate to `DateTime`.** ← rejected
+- ➕ Batteries-included calendar ergonomics (week-stepping, today, multi-day) without
+  the consumer hand-rolling date↔index mapping.
+- ➖ Larger breaking API change (`PlannerTime` → `DateTime` + `Duration`), needs a
+  migration guide and a major version bump — for convenience, not new capability.
 
-A middle path exists: keep the column model but let each column *optionally* carry a
-`DateTime`, so date-aware features layer on without forcing the breaking change.
+**Middle path — optional `DateTime` per column.** ← rejected
+- Keeps the column model but lets each column optionally carry a `DateTime`; judged
+  not worth the added surface given the features are consumer-doable.
 
 ---
 

--- a/docs/decisions/0001-time-model-day-index.md
+++ b/docs/decisions/0001-time-model-day-index.md
@@ -1,0 +1,105 @@
+# ADR 0001 — Keep the day-index time model (no `DateTime` migration)
+
+- **Status:** Accepted
+- **Date:** 2026-06-06
+- **Issue:** [#19](https://github.com/pebble-world/planner/issues/19)
+- **Supersedes / relates to:** PROJECT_OVERVIEW.md §4 "the key design fork"
+
+## Context
+
+`PlannerTime` is `{ int day, int hour, int minutes, int duration }`, where `day` is
+an **index into `config.labels`** — there are no real calendar dates anywhere. Issue
+#19 framed three options:
+
+1. **Keep the day-index model** — minimal change; stays a generic "N labelled columns
+   of time-slots" widget (rooms, machines, lanes).
+2. **Migrate to `DateTime` + `Duration`** — real calendar features; a breaking API
+   change needing a migration guide and major version bump.
+3. **Middle path** — keep columns, let each column *optionally* carry a `DateTime`.
+
+The PROJECT_OVERVIEW listed week navigation, "today" highlighting, multi-day/all-day
+events, time zones/DST, and `intl` formatting as features "blocked" by the index
+model. We re-examined that claim against the actual code before deciding.
+
+### What the code actually does with `day`
+
+Across the widget, `day` is used **only** as an opaque column index:
+
+- `lib/internal/event.dart` — `entry.time.day * blockWidth` → horizontal pixel
+  position; drag-move snaps `day` to the nearest column.
+- `lib/internal/manager.dart` — a tap position maps to a `day` clamped into
+  `0..config.labels.length - 1`.
+- `lib/internal/date_row.dart` — the header simply renders each `config.labels`
+  string.
+- `lib/internal/grid.dart` — the column count is `config.labels.length`.
+
+The column header label is already a **free-form string**. The widget never reasons
+about dates.
+
+### Re-evaluating the "blocked" features
+
+`DateTime` turns out to be an **ergonomics** decision, not a **capability** unlock.
+Almost everything listed as blocked is already doable in consumer code on top of the
+index model:
+
+| Claimed "blocked" feature | Actually needs `DateTime` in the widget? |
+|---|---|
+| Week navigation | **No.** The consumer holds the current week, recomputes 7 labels + entries, and rebuilds. The widget never knows. |
+| `intl` / date formatting | **No.** Pure label string — the consumer formats `DateTime` → `"Mon 8 Jun"` and passes it as a label. |
+| "Today" highlight | **Almost no.** The widget only needs a *"highlight column index N"* flag, not a `DateTime`. |
+| Multi-day / all-day events | **Partly.** Needs an event to *span* columns (start-col → end-col) plus an all-day band — both expressible as indices. |
+| Time zones / DST | **The only genuine `DateTime` concern** — but it only bites if the *widget* computes durations across a DST boundary. For a wall-clock grid it does not; the consumer owns that math when building entries. |
+
+Putting `DateTime` into the public API would **move responsibility into the library**;
+it would not unlock anything the consumer cannot already do. The only things the
+widget itself genuinely lacks are small, index-based primitives.
+
+## Decision
+
+**Keep the day-index time model.** `planner` remains a generic
+"N labelled columns × hours" scheduling grid. Date semantics stay the consumer's
+responsibility.
+
+We will **not** migrate `PlannerTime` to `DateTime` and will **not** adopt the
+middle-path optional-`DateTime`-per-column approach. Instead, we will add the few
+primitives that are genuinely widget-level (and not consumer-doable) as separate,
+non-breaking follow-up issues:
+
+- **Highlight a column** ([#46](https://github.com/pebble-world/planner/issues/46))
+  — a configurable "emphasize column index N" (enables a "today" style without the
+  widget knowing dates).
+- **Event column-span** ([#47](https://github.com/pebble-world/planner/issues/47))
+  — let an entry render across a start→end column range (enables multi-day
+  rendering).
+- **All-day band** ([#48](https://github.com/pebble-world/planner/issues/48)) — a
+  row above the time grid for all-day / full-column entries.
+- **Optional consumer-side date helpers**
+  ([#49](https://github.com/pebble-world/planner/issues/49)) — a small
+  `date ↔ index` utility / week-builder (non-core) so the common calendar case is
+  easy without changing the core model.
+
+These are tracked as follow-up issues spun out of #19.
+
+## Consequences
+
+**Positive**
+
+- No breaking API change; no forced major version bump or migration guide.
+- The package stays honest about what it is — useful for non-calendar scheduling
+  (rooms, lanes, machines) as well as calendars.
+- Implementation effort moves from a large risky migration to small, focused,
+  additive features.
+
+**Negative / trade-offs**
+
+- Consumers building an ordinary week-calendar must own `date ↔ index` mapping, week
+  stepping, and "today" detection themselves (mitigated by the optional helpers
+  above).
+- DST / time-zone correctness for durations remains the consumer's responsibility.
+- We forgo the "batteries-included calendar" positioning on pub.dev; the package
+  competes as a flexible grid primitive instead.
+
+## Notes
+
+This ADR is an internal decision record and is excluded from the published pub.dev
+archive (see `.pubignore`), mirroring how `PROJECT_OVERVIEW.md` is handled.


### PR DESCRIPTION
## Summary
Resolves the long-standing time-model design fork (#19): **keep the abstract day-index model; do not migrate `PlannerTime` to `DateTime`.** This is a decision + planning PR — it records the decision and spins implementation out into focused follow-ups. No Dart source changes.

The decision rests on re-examining the actual code: `day` is used **purely as a column index** and the column label is already a free-form string, so `DateTime` turned out to be an *ergonomics* choice, not a *capability* unlock. Week navigation, `intl` formatting, and even "today" highlighting are all achievable in consumer code or via small index-based primitives — without putting `DateTime` in the public API.

## Linked issue
Closes #19

## Changes
- **New ADR** `docs/decisions/0001-time-model-day-index.md` — full rationale, the capability-vs-ergonomics table, alternatives considered (DateTime / middle path) and why they were rejected, and consequences.
- **`PROJECT_OVERVIEW.md`** — §1 "time model" and §4 "key design fork" updated to mark the fork **decided**; P2 roadmap now points at the follow-ups; "Last reviewed" bumped to 2026-06-06.
- **`.pubignore`** — exclude `docs/decisions/` from the published pub.dev archive (mirrors how `PROJECT_OVERVIEW.md` is handled — internal docs are not shipped).
- **Follow-up issues filed** (the "split into follow-up issues" half of #19):
  - #46 — highlight a configurable column ("today" style)
  - #47 — event column-span (multi-day rendering)
  - #48 — all-day band
  - #49 — optional `date <-> index` consumer helpers (non-core)

## Test plan
- [x] `flutter analyze` clean (`No issues found!`)
- [x] `dart format --output=none --set-exit-if-changed .` clean (0 changed)
- [x] No unit/widget test changes — **no Dart source changed** (docs + packaging metadata only), so the existing suite is unaffected.
- [x] No integration/e2e test — the change is **not user-visible** (documentation + `.pubignore` packaging metadata, zero behavior change), which is a sanctioned reason to skip it. The user-visible widget-level work is deferred to #46–#49, each of which will carry its own tests.

## Notes / screenshots
The four follow-ups are the genuinely widget-level primitives that are *not* consumer-doable; everything else date-related stays the consumer's responsibility under the day-index model. The optional helpers (#49) ease the common week-calendar case without changing the core model.