### PR TITLE
feat: lay out overlapping events in side-by-side columns (#20)

### DIFF
--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -6,6 +6,7 @@ import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
 import 'hour_label_scenarios.dart';
 import 'multi_planner_scenarios.dart';
+import 'overlap_scenarios.dart';
 import 'snapping_scenarios.dart';
 
 /// Single entry point for the integration suite.
@@ -24,5 +25,6 @@ void main() {
   eventGeometryScenarios();
   hourLabelScenarios();
   multiPlannerScenarios();
+  overlapScenarios();
   snappingScenarios();
 }

--- a/example/integration_test/overlap_scenarios.dart
+++ b/example/integration_test/overlap_scenarios.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for D11 (#20): concurrent events used to paint at full
+/// column width and stack on top of each other, so the rear event was both
+/// invisible and unclickable — every point in the column hit-tested to the
+/// first-drawn event. They now split the day-column into side-by-side
+/// sub-columns, so each event occupies (and hit-tests to) its own half.
+///
+/// This drives the *real* composed widget (real layout, real fonts, real
+/// secondary-tap gesture, real `getEventAtPos` hit-testing) with two events at
+/// the same time, then right-clicks each sub-column and confirms the entry menu
+/// resolves to the event that actually sits there. Under the old full-width
+/// geometry the right sub-column would have resolved to the left ('left') event.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void overlapScenarios() {
+  testWidgets('overlapping events lay out side by side and hit-test per column',
+      (tester) async {
+    final edited = <String>[];
+
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        PlannerSpec(
+          config: PlannerConfig(
+            labels: const ['col'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryEdit: (e) => edited.add(e.id),
+          ),
+          entries: [
+            PlannerEntry(
+              id: 'left',
+              time: PlannerTime(day: 0, hour: 2, duration: 60),
+              title: 'Left',
+              content: '',
+              color: const Color(0xFF2244AA),
+            ),
+            PlannerEntry(
+              id: 'right',
+              time: PlannerTime(day: 0, hour: 2, duration: 60),
+              title: 'Right',
+              content: '',
+              color: const Color(0xFFAA4422),
+            ),
+          ],
+        ),
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    final plannerFinder = find.byKey(PlannerHarness.keyFor(0));
+    final planner = tester.getRect(plannerFinder);
+
+    // Both events sit at day 0 / 02:00 for 60 min, so they split the 200px
+    // day-column into 0..100 (left) and 100..200 (right) at grid y 80..120. Past
+    // the hour column (50) and date row (50), the sub-column centres are
+    // planner-local (100, 150) and (200, 150).
+    final leftAt = planner.topLeft + const Offset(50 + 50, 50 + 100);
+    final rightAt = planner.topLeft + const Offset(50 + 150, 50 + 100);
+
+    // The RIGHT sub-column must open the right event's menu. Under the old
+    // full-width geometry both events covered the whole column, so any click
+    // resolved to the first-drawn ('left') event.
+    await _rightClickEdit(tester, plannerFinder, rightAt);
+    expect(edited.last, 'right',
+        reason: 'the right sub-column must hit-test to the right event');
+
+    // The LEFT sub-column must still open the left event's menu.
+    await _rightClickEdit(tester, plannerFinder, leftAt);
+    expect(edited.last, 'left',
+        reason: 'the left sub-column must hit-test to the left event');
+  });
+}
+
+/// Right-clicks [at] to open the entry context menu, then taps "Edit Event"
+/// (scoped to [planner]) so `onEntryEdit` fires with the event under the click.
+Future<void> _rightClickEdit(
+    WidgetTester tester, Finder planner, Offset at) async {
+  final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.descendant(
+    of: planner,
+    matching: find.text('Edit Event'),
+  ));
+  await tester.pumpAndSettle();
+}

--- a/lib/internal/event.dart
+++ b/lib/internal/event.dart
@@ -24,31 +24,27 @@ class Event {
   late Offset _dragOffset;
   late DragType _dragType = DragType.none;
 
+  /// Which sub-column this event occupies within its day-column, and how many
+  /// sub-columns the day-column is split into. They default to a single
+  /// full-width column; [Manager] overwrites them with the day's overlap layout
+  /// (#20 / PROJECT_OVERVIEW D11) and then calls [relayout].
+  int columnIndex = 0;
+  int columnCount = 1;
+
   Event({required this.entry, required this.manager}) {
-    _createPainters();
+    _createPaints();
+    relayout();
   }
 
-  void _createPainters() {
+  /// Recomputes the geometry and text wrapping after [columnIndex]/[columnCount]
+  /// change. [Manager] calls this once a day's overlap layout is known, so the
+  /// event occupies its narrowed sub-column instead of the full day-column.
+  void relayout() {
     _calculateCanvasRect();
+    _layoutText();
+  }
 
-    _titlePainter = TextPainter(
-      text: TextSpan(text: entry.title, style: entry.titleStyle),
-      textAlign: TextAlign.left,
-      textDirection: TextDirection.ltr,
-      maxLines: 1,
-      ellipsis: "...",
-    );
-    _titlePainter.layout(maxWidth: manager.config.blockWidth - 10);
-
-    _contentPainter = TextPainter(
-      text: TextSpan(text: entry.content, style: entry.textStyle),
-      textAlign: TextAlign.left,
-      textDirection: TextDirection.ltr,
-      maxLines: 4,
-      ellipsis: "...",
-    );
-    _contentPainter.layout(maxWidth: manager.config.blockWidth - 20);
-
+  void _createPaints() {
     _fillPaint = Paint()
       ..color = entry.color.withAlpha(100)
       ..style = PaintingStyle.fill;
@@ -65,26 +61,56 @@ class Event {
       ..strokeWidth = 1;
   }
 
+  void _layoutText() {
+    // Text wraps/ellipsizes within the event's actual (possibly narrowed) width,
+    // not the full day-column, so a split event still reads correctly.
+    final width = canvasRect.width;
+
+    _titlePainter = TextPainter(
+      text: TextSpan(text: entry.title, style: entry.titleStyle),
+      textAlign: TextAlign.left,
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+      ellipsis: "...",
+    );
+    _titlePainter.layout(maxWidth: (width - 10).clamp(0.0, double.infinity));
+
+    _contentPainter = TextPainter(
+      text: TextSpan(text: entry.content, style: entry.textStyle),
+      textAlign: TextAlign.left,
+      textDirection: TextDirection.ltr,
+      maxLines: 4,
+      ellipsis: "...",
+    );
+    _contentPainter.layout(maxWidth: (width - 20).clamp(0.0, double.infinity));
+  }
+
   void _calculateCanvasRect() {
     final blockHeight = manager.config.blockHeight;
+    // Concurrent events share a day-column by splitting it into [columnCount]
+    // equal sub-columns; this event sits in the [columnIndex]th one.
+    final fullWidth = manager.config.blockWidth.toDouble();
+    final columnWidth = fullWidth / columnCount;
     Offset a = Offset(
-        (entry.time.day * manager.config.blockWidth).toDouble(),
+        entry.time.day * fullWidth + columnIndex * columnWidth,
         (entry.time.hour - manager.config.minHour) * blockHeight +
             entry.time.minutes / 60 * blockHeight);
-    Offset b = a.translate(manager.config.blockWidth.toDouble(),
-        entry.time.duration / 60 * blockHeight);
+    Offset b = a.translate(columnWidth, entry.time.duration / 60 * blockHeight);
     canvasRect = Rect.fromPoints(a, b);
   }
 
-  void _paintHandle(Canvas canvas, Offset topLeft) {
+  void _paintHandle(Canvas canvas, Offset topLeft, double width) {
     Paint paint = Paint()
       ..color =
           _dragType == DragType.none ? entry.color.withAlpha(255) : Colors.white
       ..style = PaintingStyle.stroke
       ..strokeWidth = 3;
 
-    Offset left = topLeft.translate(manager.config.blockWidth * 0.5 - 20, 0.0);
-    Offset right = left.translate(40.0, 0.0);
+    // Centre the handle within the event's own width so a split event's handles
+    // stay inside its narrowed box (the 40px handle shrinks to fit if narrower).
+    final handleWidth = width < 40 ? width : 40.0;
+    Offset left = topLeft.translate((width - handleWidth) * 0.5, 0.0);
+    Offset right = left.translate(handleWidth, 0.0);
 
     canvas.drawLine(
       Offset(manager.controller.offset.dx + left.dx,
@@ -113,8 +139,8 @@ class Event {
     canvas.drawRect(screenRect,
         _dragType == DragType.none ? _strokePaint : _draggedStrokePaint);
 
-    _paintHandle(canvas, rect.topLeft.translate(0.0, 1));
-    _paintHandle(canvas, rect.bottomLeft.translate(0.0, -1));
+    _paintHandle(canvas, rect.topLeft.translate(0.0, 1), rect.width);
+    _paintHandle(canvas, rect.bottomLeft.translate(0.0, -1), rect.width);
 
     Rect clipRect = Rect.fromPoints(
         screenRect.topLeft.translate(2,
@@ -199,9 +225,11 @@ class Event {
     switch (_dragType) {
       case DragType.body:
         // Move: the column snaps to the nearest day, the start time snaps to the
-        // configured interval, and the duration is unchanged.
-        entry.time.day =
-            ((canvasRect.left + _dragOffset.dx) / config.blockWidth).round();
+        // configured interval, and the duration is unchanged. The day shifts by
+        // the horizontal drag in whole columns — measured from the current day,
+        // not canvasRect.left, which now carries a sub-column offset when the
+        // event is split across overlapping neighbours (#20).
+        entry.time.day += (_dragOffset.dx / config.blockWidth).round();
         final start = minutesAt(canvasRect.top + _dragOffset.dy);
         entry.time.hour = config.minHour + start ~/ 60;
         entry.time.minutes = start % 60;

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -36,6 +36,74 @@ class Manager {
     for (PlannerEntry entry in entries) {
       events.add(Event(entry: entry, manager: this));
     }
+    _layoutOverlaps();
+  }
+
+  /// Splits each day-column among events that overlap in time (#20 /
+  /// PROJECT_OVERVIEW D11). Without this, concurrent events all paint at full
+  /// column width and stack unreadably. Per day we greedily pack events into the
+  /// fewest sub-columns (a first-fit interval-graph colouring, so non-overlapping
+  /// events reuse a column), then every event in a connected overlap cluster is
+  /// narrowed to `1 / columns` of the day-column and offset to its own
+  /// sub-column — the standard side-by-side calendar layout.
+  void _layoutOverlaps() {
+    final byDay = <int, List<Event>>{};
+    for (final event in events) {
+      byDay.putIfAbsent(event.entry.time.day, () => []).add(event);
+    }
+    for (final dayEvents in byDay.values) {
+      _layoutDayColumn(dayEvents);
+    }
+  }
+
+  void _layoutDayColumn(List<Event> dayEvents) {
+    int startOf(Event e) => e.entry.time.hour * 60 + e.entry.time.minutes;
+    int endOf(Event e) => startOf(e) + e.entry.time.duration;
+
+    // Sort by start, then by end: first-fit packing assumes ascending starts.
+    dayEvents.sort((a, b) {
+      final byStart = startOf(a).compareTo(startOf(b));
+      return byStart != 0 ? byStart : endOf(a).compareTo(endOf(b));
+    });
+
+    // The events of the current connected overlap cluster, the end time of the
+    // last event placed in each of its sub-columns, and the cluster's latest end.
+    final cluster = <Event>[];
+    final columnEnds = <int>[];
+    int clusterEnd = -1;
+
+    void closeCluster() {
+      for (final event in cluster) {
+        event.columnCount = columnEnds.length;
+        event.relayout();
+      }
+      cluster.clear();
+      columnEnds.clear();
+      clusterEnd = -1;
+    }
+
+    for (final event in dayEvents) {
+      // A start at/after every event placed so far ends the cluster: its column
+      // count is now final, so close it before opening the next one.
+      if (cluster.isNotEmpty && startOf(event) >= clusterEnd) {
+        closeCluster();
+      }
+
+      // First-fit: reuse the earliest sub-column whose previous event has ended;
+      // otherwise open a new one.
+      var column = columnEnds.indexWhere((end) => end <= startOf(event));
+      if (column == -1) {
+        column = columnEnds.length;
+        columnEnds.add(endOf(event));
+      } else {
+        columnEnds[column] = endOf(event);
+      }
+      event.columnIndex =
+          column; // columnCount is filled in when the cluster closes
+      cluster.add(event);
+      if (endOf(event) > clusterEnd) clusterEnd = endOf(event);
+    }
+    closeCluster();
   }
 
   Event? _draggedEvent;

--- a/test/overlap_layout_test.dart
+++ b/test/overlap_layout_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/event.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+
+void main() {
+  // Regression for D11 (#20): concurrent events used to paint at full column
+  // width and stack on top of each other. The Manager now splits each day-column
+  // among overlapping events, so an event's canvasRect is narrowed to its
+  // sub-column (left offset + width) while leaving non-overlapping events full.
+
+  const blockWidth = 200; // PlannerConfig default
+
+  Manager managerWith(List<PlannerTime> times) => Manager(
+        config: PlannerConfig(labels: const ['A', 'B']),
+        entries: [
+          for (var i = 0; i < times.length; i++)
+            PlannerEntry(
+              id: '$i',
+              time: times[i],
+              title: 't$i',
+              content: '',
+              color: const Color(0xFF112233),
+            ),
+        ],
+      );
+
+  // Asserts an event sits in sub-column [index] of [count] within its day-column.
+  void expectColumn(Event e,
+      {required int day, required int index, required int count}) {
+    final columnWidth = blockWidth / count;
+    expect(e.canvasRect.left,
+        closeTo(day * blockWidth + index * columnWidth, 0.001),
+        reason: 'sub-column $index of $count on day $day');
+    expect(e.canvasRect.width, closeTo(columnWidth, 0.001),
+        reason: '1/$count of the day-column');
+  }
+
+  test('a lone event keeps the full day-column width', () {
+    final manager = managerWith([PlannerTime(day: 0, hour: 9, duration: 60)]);
+    expectColumn(manager.events.single, day: 0, index: 0, count: 1);
+  });
+
+  test('back-to-back events do not overlap and stay full width', () {
+    // 9:00-10:00 then 10:00-11:00: the second starts exactly when the first ends,
+    // so they are adjacent, not overlapping (overlap is strict).
+    final manager = managerWith([
+      PlannerTime(day: 0, hour: 9, duration: 60),
+      PlannerTime(day: 0, hour: 10, duration: 60),
+    ]);
+    expectColumn(manager.events[0], day: 0, index: 0, count: 1);
+    expectColumn(manager.events[1], day: 0, index: 0, count: 1);
+  });
+
+  test('two overlapping events split the day-column in half', () {
+    final manager = managerWith([
+      PlannerTime(day: 0, hour: 9, duration: 60),
+      PlannerTime(day: 0, hour: 9, minutes: 30, duration: 60),
+    ]);
+    // Sorted by start, the earlier event takes the left sub-column.
+    expectColumn(manager.events[0], day: 0, index: 0, count: 2);
+    expectColumn(manager.events[1], day: 0, index: 1, count: 2);
+  });
+
+  test('three mutually overlapping events split into thirds', () {
+    final manager = managerWith([
+      PlannerTime(day: 0, hour: 9, duration: 60),
+      PlannerTime(day: 0, hour: 9, duration: 60),
+      PlannerTime(day: 0, hour: 9, duration: 60),
+    ]);
+    expectColumn(manager.events[0], day: 0, index: 0, count: 3);
+    expectColumn(manager.events[1], day: 0, index: 1, count: 3);
+    expectColumn(manager.events[2], day: 0, index: 2, count: 3);
+  });
+
+  test('a transitively-connected cluster uses max concurrency, reusing columns',
+      () {
+    // A 9:00-10:00, B 9:30-10:30, C 10:15-11:00. A and C never overlap, but B
+    // chains them into one cluster. Max concurrency is 2, so the cluster splits
+    // into 2 columns and C reuses A's (now-free) left column.
+    final manager = managerWith([
+      PlannerTime(day: 0, hour: 9, duration: 60),
+      PlannerTime(day: 0, hour: 9, minutes: 30, duration: 60),
+      PlannerTime(day: 0, hour: 10, minutes: 15, duration: 45),
+    ]);
+    expectColumn(manager.events[0], day: 0, index: 0, count: 2); // A — left
+    expectColumn(manager.events[1], day: 0, index: 1, count: 2); // B — right
+    expectColumn(manager.events[2],
+        day: 0, index: 0, count: 2); // C — left again
+  });
+
+  test('overlaps are scoped per day-column', () {
+    // Two events at the same time but in different columns must NOT split each
+    // other — they live in independent day-columns.
+    final manager = managerWith([
+      PlannerTime(day: 0, hour: 9, duration: 60),
+      PlannerTime(day: 1, hour: 9, duration: 60),
+    ]);
+    expectColumn(manager.events[0], day: 0, index: 0, count: 1);
+    expectColumn(manager.events[1], day: 1, index: 0, count: 1);
+  });
+
+  test('a fresh overlap cluster after a gap restarts the column count', () {
+    // First pair overlaps (2 columns); after a gap, a second pair overlaps
+    // (its own 2 columns) — the gap must reset, not accumulate, the count.
+    final manager = managerWith([
+      PlannerTime(day: 0, hour: 9, duration: 60),
+      PlannerTime(day: 0, hour: 9, duration: 60),
+      PlannerTime(day: 0, hour: 15, duration: 60),
+      PlannerTime(day: 0, hour: 15, duration: 60),
+    ]);
+    expectColumn(manager.events[0], day: 0, index: 0, count: 2);
+    expectColumn(manager.events[1], day: 0, index: 1, count: 2);
+    expectColumn(manager.events[2], day: 0, index: 0, count: 2);
+    expectColumn(manager.events[3], day: 0, index: 1, count: 2);
+  });
+}


### PR DESCRIPTION
## Summary
Concurrent events on the same day-column all painted at full `blockWidth`, so they stacked on top of each other and the rear event was both invisible and unclickable (every point in the column hit-tested to the first-drawn event). This implements standard calendar column-splitting: overlapping events share a day-column by dividing its width into side-by-side sub-columns.

## Linked issue
Closes #20 (PROJECT_OVERVIEW D11, P2)

## Changes
- **`lib/internal/manager.dart`** — `_layoutOverlaps()` / `_layoutDayColumn()`, called from `_buildEvents()`. Per day-column it greedily packs events into the fewest sub-columns (a first-fit interval-graph colouring, so non-overlapping events reuse a column), groups them into connected overlap clusters, and gives every event in a cluster the cluster's column count.
- **`lib/internal/event.dart`**
  - `columnIndex` / `columnCount` fields + `relayout()`.
  - `_calculateCanvasRect()` narrows the rect to `1/columnCount` of the day-column, offset to its sub-column. This also fixes hit-testing — `getEventAtPos` resolves against the narrowed rects, so a click lands on the visible event rather than always the first-drawn one.
  - Text wraps/ellipsizes within the narrowed width.
  - `_paintHandle` centres the drag handle within the event's actual width (shrinking to fit a narrow column).
  - `endDrag` body-move derives the day from the horizontal drag delta instead of `canvasRect.left`, which now carries a sub-column offset (equivalent to the old formula for the full-width case).

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `flutter analyze` clean
- [x] unit/widget tests pass (`flutter test`) — **53 pass** (46 existing + 7 new in `test/overlap_layout_test.dart`: halves, thirds, transitive clusters, per-day scoping, cluster reset after a gap, adjacency-is-not-overlap)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — **10 pass**, including the new `overlap_scenarios.dart` which drives the real composed widget and asserts each sub-column hit-tests to its own event. Confirmed it is a genuine regression test: it **fails on the unpatched source** (the right sub-column resolved to the `left` event) and passes with the fix.