### PR TITLE
feat: make context-menu labels customizable / localizable (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ A complete, runnable demo lives in [`example/`](example/lib/main.dart).
 > Your callbacks own the data. Update your own list of entries (and call
 > `setState`) in response — the widget reports interactions but does not persist them.
 
+### Localizing the context menu
+
+The context-menu item labels default to English but are plain `String`s on
+`PlannerConfig`, so you can translate or rename them:
+
+```dart
+PlannerConfig(
+  labels: const ['Lun', 'Mar', 'Mer'],
+  contextMenuCreateLabel: 'Créer un événement',
+  contextMenuEditLabel: 'Modifier l’événement',
+  contextMenuDeleteLabel: 'Supprimer l’événement',
+);
+```
+
+| Field | Defaults to | Item |
+|-------|-------------|------|
+| `contextMenuCreateLabel` | `'Create Event'` | Shown on an empty grid cell. |
+| `contextMenuEditLabel` | `'Edit Event'` | Shown on an existing event. |
+| `contextMenuDeleteLabel` | `'Delete Event'` | Shown on an existing event. |
+
 ## Additional information
 
 - **Roadmap & known issues:** [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md).

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -2,6 +2,7 @@ import 'package:integration_test/integration_test.dart';
 
 import 'accessibility_scenarios.dart';
 import 'app_smoke_scenarios.dart';
+import 'context_menu_labels_scenarios.dart';
 import 'context_menu_scenarios.dart';
 import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
@@ -22,6 +23,7 @@ void main() {
 
   accessibilityScenarios();
   appSmokeScenarios();
+  contextMenuLabelsScenarios();
   contextMenuScenarios();
   dragScenarios();
   eventGeometryScenarios();

--- a/example/integration_test/context_menu_labels_scenarios.dart
+++ b/example/integration_test/context_menu_labels_scenarios.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end on a real device: the context-menu labels are configurable
+/// (#22). The example app uses the English defaults, so customised labels need
+/// their own driveable app — [PlannerHarness] renders a Planner whose
+/// `contextMenu*Label`s are overridden, and we assert the *translated* text is
+/// what the real composed menu paints (and the old English literals are gone).
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void contextMenuLabelsScenarios() {
+  testWidgets('the context menu renders the configured (translated) labels',
+      (tester) async {
+    final entry = PlannerEntry(
+      id: 'evt',
+      time: PlannerTime(day: 0, hour: 9),
+      title: 'Réunion',
+      content: '',
+      color: const Color(0xFF2244AA),
+    );
+
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        PlannerSpec(
+          config: PlannerConfig(
+            labels: const ['lun', 'mar', 'mer'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryCreate: (_) {},
+            onEntryEdit: (_) {},
+            onEntryDelete: (_) {},
+            contextMenuCreateLabel: 'Créer un événement',
+            contextMenuEditLabel: 'Modifier l’événement',
+            contextMenuDeleteLabel: 'Supprimer l’événement',
+          ),
+          entries: [entry],
+        ),
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    final key = PlannerHarness.keyFor(0);
+    final rect = tester.getRect(find.byKey(key));
+
+    // Right-click the event (day 0 / hour 9 -> centre at planner-local
+    // (150, 430) with the default 200x40 grid) to open the *entry* menu.
+    final gesture = await tester.startGesture(
+        rect.topLeft + const Offset(150, 430),
+        buttons: kSecondaryButton);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Modifier l’événement'), findsOneWidget);
+    expect(find.text('Supprimer l’événement'), findsOneWidget);
+    expect(find.text('Edit Event'), findsNothing);
+    expect(find.text('Delete Event'), findsNothing);
+  });
+}

--- a/lib/internal/context_menu.dart
+++ b/lib/internal/context_menu.dart
@@ -33,7 +33,7 @@ class _ContextMenuState extends State<ContextMenu> {
         Expanded(
           child: TextButton(
               child: Text(
-                'Create Event',
+                widget.manager.config.contextMenuCreateLabel,
                 style: widget.manager.config.contextMenuTextStyle,
               ),
               onPressed: () {
@@ -51,7 +51,7 @@ class _ContextMenuState extends State<ContextMenu> {
         Expanded(
           child: TextButton(
             child: Text(
-              'Edit Event',
+              widget.manager.config.contextMenuEditLabel,
               style: widget.manager.config.contextMenuTextStyle,
             ),
             onPressed: () {
@@ -69,7 +69,7 @@ class _ContextMenuState extends State<ContextMenu> {
       result.add(
         Expanded(
           child: TextButton(
-            child: Text('Delete Event',
+            child: Text(widget.manager.config.contextMenuDeleteLabel,
                 style: widget.manager.config.contextMenuDeleteTextStyle),
             onPressed: () {
               if (widget.manager.config.onEntryDelete != null) {

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -52,6 +52,21 @@ class PlannerConfig {
   TextStyle contextMenuTextStyle;
   TextStyle contextMenuDeleteTextStyle;
 
+  /// Label for the "create event" item shown when the context menu is opened on
+  /// an empty grid cell. Override to translate or customize it; defaults to the
+  /// English `'Create Event'`.
+  String contextMenuCreateLabel;
+
+  /// Label for the "edit event" item shown when the context menu is opened on an
+  /// existing event. Override to translate or customize it; defaults to the
+  /// English `'Edit Event'`.
+  String contextMenuEditLabel;
+
+  /// Label for the "delete event" item shown when the context menu is opened on
+  /// an existing event. Override to translate or customize it; defaults to the
+  /// English `'Delete Event'`.
+  String contextMenuDeleteLabel;
+
   Color hourBackground;
   Color dateBackground;
   Color plannerBackground = const Color.fromARGB(255, 50, 50, 50);
@@ -79,6 +94,9 @@ class PlannerConfig {
     this.dateLabelStyle = const TextStyle(color: Colors.black),
     this.contextMenuTextStyle = const TextStyle(color: Colors.blue),
     this.contextMenuDeleteTextStyle = const TextStyle(color: Colors.red),
+    this.contextMenuCreateLabel = 'Create Event',
+    this.contextMenuEditLabel = 'Edit Event',
+    this.contextMenuDeleteLabel = 'Delete Event',
     this.hourBackground = Colors.white,
     this.dateBackground = Colors.white,
     this.contextMenuBackground = Colors.white,

--- a/test/context_menu_labels_test.dart
+++ b/test/context_menu_labels_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+void main() {
+  // Issue #22: the context-menu item labels used to be hardcoded English
+  // ('Create Event' / 'Edit Event' / 'Delete Event'). They are now plain
+  // strings on PlannerConfig so apps can translate/customize them. These drive
+  // the *real* composed Planner: a secondary tap opens the menu and the rendered
+  // item text must come from the config, not the old literals.
+
+  // An event at day 0 / hour 9. With the default 200x40 grid it occupies grid
+  // rect (0,360)-(200,400); past the hour column (50) and date row (50) its
+  // centre is planner-local (150, 430) — same anchor the widget tests use.
+  PlannerEntry eventAtHour9() => PlannerEntry(
+        id: 'evt',
+        time: PlannerTime(day: 0, hour: 9),
+        title: 'Meeting',
+        content: '',
+        color: const Color(0xFF2244AA),
+      );
+
+  Future<Rect> pumpPlanner(
+    WidgetTester tester,
+    Key key, {
+    List<PlannerEntry> entries = const [],
+    String? createLabel,
+    String? editLabel,
+    String? deleteLabel,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          key: key,
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryCreate: (_) {},
+            onEntryEdit: (_) {},
+            onEntryDelete: (_) {},
+            // Leave each label unset to exercise its default.
+            contextMenuCreateLabel: createLabel ?? 'Create Event',
+            contextMenuEditLabel: editLabel ?? 'Edit Event',
+            contextMenuDeleteLabel: deleteLabel ?? 'Delete Event',
+          ),
+          entries: entries,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    return tester.getRect(find.byKey(key));
+  }
+
+  Future<void> rightClickAt(WidgetTester tester, Offset at) async {
+    final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+  }
+
+  testWidgets('defaults to "Create Event" on an empty cell', (tester) async {
+    const key = ValueKey('planner');
+    final rect = await pumpPlanner(tester, key);
+
+    await rightClickAt(tester, rect.topLeft + const Offset(50 + 100, 50 + 40));
+
+    expect(find.text('Create Event'), findsOneWidget);
+  });
+
+  testWidgets('defaults to "Edit Event"/"Delete Event" on an event',
+      (tester) async {
+    const key = ValueKey('planner');
+    final rect = await pumpPlanner(tester, key, entries: [eventAtHour9()]);
+
+    await rightClickAt(tester, rect.topLeft + const Offset(150, 430));
+
+    expect(find.text('Edit Event'), findsOneWidget);
+    expect(find.text('Delete Event'), findsOneWidget);
+  });
+
+  testWidgets('renders the custom create label on an empty cell',
+      (tester) async {
+    const key = ValueKey('planner');
+    final rect =
+        await pumpPlanner(tester, key, createLabel: 'Créer un événement');
+
+    await rightClickAt(tester, rect.topLeft + const Offset(50 + 100, 50 + 40));
+
+    expect(find.text('Créer un événement'), findsOneWidget);
+    expect(find.text('Create Event'), findsNothing,
+        reason: 'the hardcoded English literal must no longer be used');
+  });
+
+  testWidgets('renders the custom edit/delete labels on an event',
+      (tester) async {
+    const key = ValueKey('planner');
+    final rect = await pumpPlanner(
+      tester,
+      key,
+      entries: [eventAtHour9()],
+      editLabel: 'Modifier',
+      deleteLabel: 'Supprimer',
+    );
+
+    await rightClickAt(tester, rect.topLeft + const Offset(150, 430));
+
+    expect(find.text('Modifier'), findsOneWidget);
+    expect(find.text('Supprimer'), findsOneWidget);
+    expect(find.text('Edit Event'), findsNothing,
+        reason: 'the hardcoded English literal must no longer be used');
+    expect(find.text('Delete Event'), findsNothing,
+        reason: 'the hardcoded English literal must no longer be used');
+  });
+}


### PR DESCRIPTION
## Summary
Make the context-menu item labels customizable / localizable. They were hardcoded English strings; they are now defaulted `String` fields on `PlannerConfig`, so apps can translate or rename them without any breaking change.

## Linked issue
Closes #22

## Changes
- `lib/planner_config.dart`: add three defaulted fields — `contextMenuCreateLabel` (`'Create Event'`), `contextMenuEditLabel` (`'Edit Event'`), `contextMenuDeleteLabel` (`'Delete Event'`). Follows the existing flat `contextMenu*` field convention; defaults preserve current behaviour.
- `lib/internal/context_menu.dart`: read the three labels from config instead of the hardcoded literals.
- `test/context_menu_labels_test.dart`: new widget tests on the real composed `Planner` — the English defaults render, and custom create/edit/delete labels render (asserting the old literals are no longer used).
- `example/integration_test/context_menu_labels_scenarios.dart` + `app_test.dart`: new end-to-end scenario driving a real `PlannerHarness` with translated labels.
- `README.md`: add a "Localizing the context menu" subsection.

## Test plan
- [x] `flutter analyze` clean
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] unit/widget tests pass (`flutter test`) — 68 pass, 4 new
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`, full suite) — 12 pass, 1 new (`the context menu renders the configured (translated) labels`)

## Notes / screenshots
User-visible change (the rendered menu text), so an end-to-end scenario is included in addition to the widget tests.
