### PR TITLE
chore: bump flutter_lints to ^6.0.0 and fix new findings (#23)

### DIFF
--- a/lib/internal/context_menu.dart
+++ b/lib/internal/context_menu.dart
@@ -6,7 +6,7 @@ import 'manager.dart';
 class ContextMenu extends StatefulWidget {
   final Manager manager;
 
-  const ContextMenu({Key? key, required this.manager}) : super(key: key);
+  const ContextMenu({super.key, required this.manager});
 
   @override
   State<ContextMenu> createState() => _ContextMenuState();

--- a/lib/internal/date_row.dart
+++ b/lib/internal/date_row.dart
@@ -9,14 +9,14 @@ class DateRow extends CustomPainter {
 
   DateRow({required this.manager, required Listenable repaint})
       : super(repaint: repaint) {
-    int _pos = 60;
+    int pos = 60;
     for (String element in manager.config.labels) {
       _labels.add(DateLabel(
         label: element,
-        position: _pos,
+        position: pos,
         manager: manager,
       ));
-      _pos += manager.config.blockWidth;
+      pos += manager.config.blockWidth;
     }
   }
 

--- a/lib/internal/hour_column.dart
+++ b/lib/internal/hour_column.dart
@@ -25,14 +25,14 @@ class HourColumn extends CustomPainter {
 
   HourColumn({required this.manager, required Listenable repaint})
       : super(repaint: repaint) {
-    int _pos = 15;
+    int pos = 15;
     for (final text in buildHourLabels(manager.config)) {
       _labels.add(HourLabel(
         label: text,
-        position: _pos,
+        position: pos,
         manager: manager,
       ));
-      _pos += manager.config.blockHeight;
+      pos += manager.config.blockHeight;
     }
   }
 

--- a/lib/internal/scroll_detector.dart
+++ b/lib/internal/scroll_detector.dart
@@ -6,10 +6,10 @@ class ScrollDetector extends StatelessWidget {
   final Widget child;
 
   const ScrollDetector({
-    Key? key,
+    super.key,
     required this.onPointerScroll,
     required this.child,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/planner.dart
+++ b/lib/planner.dart
@@ -1,4 +1,4 @@
-library planner;
+library;
 
 export 'planner_class.dart';
 export 'planner_entry.dart';

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -16,13 +16,13 @@ class Planner extends StatefulWidget {
   final PlannerConfig config;
 
   const Planner({
-    Key? key,
+    super.key,
     required this.config,
     required this.entries,
-  }) : super(key: key);
+  });
 
   @override
-  _PlannerState createState() => _PlannerState();
+  State<Planner> createState() => _PlannerState();
 }
 
 class _PlannerState extends State<Planner> {
@@ -155,13 +155,13 @@ class _PlannerState extends State<Planner> {
             elevation: 2.0,
             constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
             fillColor: Theme.of(context).colorScheme.secondary,
+            padding: const EdgeInsets.all(4.0),
+            shape: const CircleBorder(),
             child: const Icon(
               Icons.zoom_out,
               size: 22.0,
               color: Colors.white,
             ),
-            padding: const EdgeInsets.all(4.0),
-            shape: const CircleBorder(),
           ),
         ),
         Padding(
@@ -174,13 +174,13 @@ class _PlannerState extends State<Planner> {
             elevation: 2.0,
             constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
             fillColor: Theme.of(context).colorScheme.secondary,
+            padding: const EdgeInsets.all(4.0),
+            shape: const CircleBorder(),
             child: const Icon(
               Icons.zoom_in,
               size: 22.0,
               color: Colors.white,
             ),
-            padding: const EdgeInsets.all(4.0),
-            shape: const CircleBorder(),
           ),
         ),
       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
Bumps `flutter_lints` from `^1.0.0` (resolved 1.0.4) to `^6.0.0` and clears all new findings it surfaces. Addresses PROJECT_OVERVIEW item **B2**.

Gate-tightening (`--fatal-infos`, doc lints) is intentionally **not** included here: the issue gates that work on the vendored file (**B3**) being resolved, and PROJECT_OVERVIEW tracks it separately as **E2** ("enable stricter lints once B2 lands").

## Linked issue
Closes #23

## Changes
- `pubspec.yaml`: `flutter_lints: ^1.0.0` -> `^6.0.0`
- Cleared the 9 new info-level findings (all behavior-preserving):
  - `use_super_parameters`: use `super.key` in `Planner`, `ContextMenu`, `ScrollDetector`
  - `no_leading_underscores_for_local_identifiers`: rename local `_pos` -> `pos` in `DateRow` / `HourColumn`
  - `unnecessary_library_name`: drop the name from `library planner;`
  - `sort_child_properties_last`: move `child:` last in the two zoom buttons
  - `library_private_types_in_public_api`: widen `Planner.createState` return type to `State<Planner>`

## Test plan
- [x] `flutter analyze` clean (No issues found)
- [x] unit/widget tests pass (`flutter test` — 68 passed)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows` in `example/` — 12 passed)

No new test added: this is a pure refactor + dependency bump with no user-visible behavior change, so an integration test is not warranted (per the workflow exception). The existing full suite — unit, widget, and Windows integration — passing proves no regression.
