### PR TITLE
chore: attribute vendored positioned_tap_detector_2 and lint it (#24)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -111,7 +111,7 @@ Severity: 🔴 blocker/bug · 🟠 important · 🟡 polish.
 |---|-----|-------|---------------|
 | B1 | 🟠 | `after_layout: ^1.2.0` is declared but **never imported** anywhere. Dead weight that lowers the pub score. | Remove from `pubspec.yaml`. ✅ (this pass) |
 | B2 | 🟡 | `flutter_lints: ^1.0.0` is several major versions behind (current ~5.x); modern lints are missed. | Bump to latest, fix any new findings. (deferred — may surface lints) |
-| B3 | 🟠 | [`positioned_tap_detector_2.dart`](lib/internal/positioned_tap_detector_2.dart) is a **verbatim vendored copy** of a pub package — no attribution, no upstream fixes, possible license violation. | Either depend on the pub package, or keep the copy *with* its original license header + NOTICE. |
+| B3 | 🟠 | [`positioned_tap_detector_2.dart`](lib/internal/positioned_tap_detector_2.dart) is a **verbatim vendored copy** of a pub package — no attribution, no upstream fixes, possible license violation. | Kept the copy with its MIT license header + [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md), removed the analysis exclude. ✅ (#24) |
 | B4 | 🟠 | `pubspec.lock` is **committed** despite being in `.gitignore` (libraries must not pin it). | `git rm --cached pubspec.lock example/pubspec.lock`. ✅ (this pass) |
 
 ### C. Project structure / hygiene

--- a/README.md
+++ b/README.md
@@ -144,3 +144,6 @@ PlannerConfig(
 ## License
 
 [MIT](LICENSE) © yvan vander sanden
+
+This package vendors third-party source code under its own license; see
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,40 @@
+# Third-party notices
+
+This project includes third-party source code. The components below are
+distributed under their own licenses, reproduced in full.
+
+---
+
+## positioned_tap_detector_2
+
+- **File:** [`lib/internal/positioned_tap_detector_2.dart`](lib/internal/positioned_tap_detector_2.dart)
+- **Source:** https://pub.dev/packages/positioned_tap_detector_2 (version 1.0.4)
+- **License:** MIT
+
+The file is a vendored copy of the upstream package with minor local
+modifications (deprecation fixes and lint cleanup); see the header comment in
+the file for the exact list of changes.
+
+```
+MIT License
+
+Copyright (c) 2021 Ali Raghebi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,4 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
-  exclude:
-    # Vendored third-party code (see PROJECT_OVERVIEW.md, issue B3).
-    - lib/internal/positioned_tap_detector_2.dart
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/internal/positioned_tap_detector_2.dart
+++ b/lib/internal/positioned_tap_detector_2.dart
@@ -1,13 +1,46 @@
+// Vendored from the `positioned_tap_detector_2` package, version 1.0.4.
+// Source: https://pub.dev/packages/positioned_tap_detector_2
+//
+// MIT License
+//
+// Copyright (c) 2021 Ali Raghebi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Local modifications relative to upstream 1.0.4:
+//   - Replaced the deprecated `hashValues` with `Object.hash`.
+//   - Modernized to satisfy this package's lints (generic function-type
+//     typedef, const/super-parameter constructor, public `createState` return
+//     type, `final` stream controller, `child` argument sorted last).
+//
+// See THIRD_PARTY_NOTICES.md for the full attribution.
+
 import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
 
-typedef TapPositionCallback(TapPosition position);
+typedef TapPositionCallback = void Function(TapPosition position);
 
 class PositionedTapDetector2 extends StatefulWidget {
-  PositionedTapDetector2({
-    Key? key,
+  const PositionedTapDetector2({
+    super.key,
     this.child,
     this.onTap,
     this.onDoubleTap,
@@ -15,7 +48,7 @@ class PositionedTapDetector2 extends StatefulWidget {
     this.doubleTapDelay = _defaultDelay,
     this.behavior,
     this.controller,
-  }) : super(key: key);
+  });
 
   static const _defaultDelay = Duration(milliseconds: 250);
   static const _doubleTapMaxOffset = 48.0;
@@ -29,11 +62,11 @@ class PositionedTapDetector2 extends StatefulWidget {
   final PositionedTapController? controller;
 
   @override
-  _TapPositionDetectorState createState() => _TapPositionDetectorState();
+  State<PositionedTapDetector2> createState() => _TapPositionDetectorState();
 }
 
 class _TapPositionDetectorState extends State<PositionedTapDetector2> {
-  StreamController<TapDownDetails> _controller = StreamController();
+  final StreamController<TapDownDetails> _controller = StreamController();
 
   Stream<TapDownDetails> get _stream => _controller.stream;
 
@@ -162,7 +195,6 @@ class _TapPositionDetectorState extends State<PositionedTapDetector2> {
       }
     }
     return GestureDetector(
-      child: widget.child,
       behavior: (widget.behavior ??
           (widget.child == null
               ? HitTestBehavior.translucent
@@ -170,6 +202,7 @@ class _TapPositionDetectorState extends State<PositionedTapDetector2> {
       onTap: _onTapEvent,
       onLongPress: _onLongPressEvent,
       onTapDown: _onTapDownEvent,
+      child: widget.child,
     );
   }
 }


### PR DESCRIPTION
## Summary
`lib/internal/positioned_tap_detector_2.dart` was a verbatim, unattributed copy of the `positioned_tap_detector_2` pub package, excluded from analysis as a stopgap. The upstream package is MIT but unmaintained (~4 years), and the vendored copy already carries a local modernization fix (`Object.hash`). Per the decision on #24, this keeps the vendored copy and makes it compliant rather than re-introducing the stale dependency.

## Linked issue
Closes #24

## Changes
- **`lib/internal/positioned_tap_detector_2.dart`** — added the upstream MIT license header (© 2021 Ali Raghebi) and a "local modifications" note; fixed the six lints the exclude was hiding: generic function-type typedef, `const`/`super.key` constructor, public `createState()` return type, `final` stream controller, and `child` argument sorted last. No behavior change.
- **`analysis_options.yaml`** — removed the `analyzer.exclude` stopgap (it was the only entry).
- **`THIRD_PARTY_NOTICES.md`** (new) — provenance + full MIT license text for the vendored file.
- **`README.md`** — License section now references the third-party notices.
- **`PROJECT_OVERVIEW.md`** — B3 marked resolved.

## Test plan
- [x] `flutter analyze` clean — No issues found
- [x] unit/widget tests pass (`flutter test`) — 67 tests
- [x] integration/e2e tests pass (`flutter test integration_test/app_test.dart -d windows`) — 12 scenarios
- No new tests added: this is a non-user-visible change (license attribution + behavior-preserving lint fixes). The tap-detection path it touches is already covered by existing tests (e.g. widget test "tapping past the grid clamps the created day/hour (D9)" and integration "right-click on empty grid opens the create-event menu"), which pass and serve as the regression net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)