### PR TITLE
perf: revision-gated repaints, cached grid paints, day-bucket hit-testing (#25)

### DIFF
--- a/lib/internal/date_row.dart
+++ b/lib/internal/date_row.dart
@@ -7,8 +7,14 @@ class DateRow extends CustomPainter {
   final List<DateLabel> _labels = <DateLabel>[];
   final Manager manager;
 
+  // The manager's data revision when this delegate was built; compared in
+  // shouldRepaint so the row repaints only when the data changed, not on every
+  // unrelated parent rebuild (#25 / D6).
+  final int _revision;
+
   DateRow({required this.manager, required Listenable repaint})
-      : super(repaint: repaint) {
+      : _revision = manager.revision,
+        super(repaint: repaint) {
     int pos = 60;
     for (String element in manager.config.labels) {
       _labels.add(DateLabel(
@@ -29,5 +35,6 @@ class DateRow extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+  bool shouldRepaint(covariant DateRow oldDelegate) =>
+      _revision != oldDelegate._revision;
 }

--- a/lib/internal/events_painter.dart
+++ b/lib/internal/events_painter.dart
@@ -9,8 +9,14 @@ class EventsPainter extends CustomPainter {
   final Grid _grid;
   final Manager manager;
 
+  // The manager's data revision when this delegate was built; compared in
+  // shouldRepaint so the canvas repaints (and its semantics rebuild) only when
+  // the event data changed, not on every unrelated parent rebuild (#25 / D6).
+  final int _revision;
+
   EventsPainter({required this.manager, required Listenable repaint})
       : _grid = Grid(manager: manager),
+        _revision = manager.revision,
         super(repaint: repaint);
 
   // Pure rendering only: draw the grid, then each event using its own drag
@@ -82,5 +88,6 @@ class EventsPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+  bool shouldRepaint(covariant EventsPainter oldDelegate) =>
+      _revision != oldDelegate._revision;
 }

--- a/lib/internal/grid.dart
+++ b/lib/internal/grid.dart
@@ -7,6 +7,19 @@ class Grid {
   final Manager manager;
 
   late Paint hPaint, vPaint;
+
+  // The half-hour and quarter-hour line paints fade in with zoom; their colour
+  // is a pure function of the current zoom, so they're cached and only
+  // recoloured when the zoom changes rather than reallocated every frame
+  // (#25 / D7).
+  final Paint div2Paint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1;
+  final Paint div3Paint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1;
+  double _cachedZoom = double.nan;
+
   final List<Line> hLines = [];
   final List<Line> vLines = [];
 
@@ -60,26 +73,21 @@ class Grid {
       line.draw(canvas, vPaint);
     }
 
-    // now we need to determine the visibility for 30 minite lines, depending on zoom factor
-    double color2 = manager.controller.zoom - 1;
-    if (color2 < 0) color2 = 0;
-    if (color2 > 1) color2 = 1;
+    // The 30-minute lines fade in past zoom 1, the 15/45-minute lines past
+    // zoom 2. These thresholds are cheap to recompute each frame and also gate
+    // line visibility below.
+    final double zoom = manager.controller.zoom;
+    final double color2 = (zoom - 1).clamp(0.0, 1.0).toDouble();
+    final double color3 = (zoom - 2).clamp(0.0, 1.0).toDouble();
 
-    // .. and set the color for this line
-    Paint div2paint = Paint()
-      ..color = Color.fromARGB((color2 * 60).toInt(), 255, 255, 255)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1;
-
-    // same for the next zoomlevel, which shows 15 and 45 minute lines
-    double color3 = manager.controller.zoom - 2;
-    if (color3 < 0) color3 = 0;
-    if (color3 > 1) color3 = 1;
-
-    Paint div3paint = Paint()
-      ..color = Color.fromARGB((color3 * 30).toInt(), 255, 255, 255)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1;
+    // Recolour the cached paints only when the zoom actually changed, reusing
+    // the same Paint objects across frames instead of allocating two per frame
+    // (#25 / D7).
+    if (zoom != _cachedZoom) {
+      div2Paint.color = Color.fromARGB((color2 * 60).toInt(), 255, 255, 255);
+      div3Paint.color = Color.fromARGB((color3 * 30).toInt(), 255, 255, 255);
+      _cachedZoom = zoom;
+    }
 
     // draw lines
     for (int i = 0; i < hLines.length; i++) {
@@ -88,10 +96,10 @@ class Grid {
         hLines[i].draw(canvas, vPaint);
       } else if ((i + 1) % 2 == 0 && color2 != 0) {
         // half an hour
-        hLines[i].draw(canvas, div2paint);
+        hLines[i].draw(canvas, div2Paint);
       } else if (color3 != 0) {
         // 15 and 45 minutes
-        hLines[i].draw(canvas, div3paint);
+        hLines[i].draw(canvas, div3Paint);
       }
     }
   }

--- a/lib/internal/hour_column.dart
+++ b/lib/internal/hour_column.dart
@@ -23,8 +23,14 @@ class HourColumn extends CustomPainter {
   final List<HourLabel> _labels = <HourLabel>[];
   final Manager manager;
 
+  // The manager's data revision when this delegate was built; compared in
+  // shouldRepaint so the column repaints only when the data changed, not on
+  // every unrelated parent rebuild (#25 / D6).
+  final int _revision;
+
   HourColumn({required this.manager, required Listenable repaint})
-      : super(repaint: repaint) {
+      : _revision = manager.revision,
+        super(repaint: repaint) {
     int pos = 15;
     for (final text in buildHourLabels(manager.config)) {
       _labels.add(HourLabel(
@@ -44,5 +50,6 @@ class HourColumn extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+  bool shouldRepaint(covariant HourColumn oldDelegate) =>
+      _revision != oldDelegate._revision;
 }

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -10,6 +10,21 @@ class Manager {
   final Controller controller;
   final List<Event> events = [];
 
+  // Bumped every time the event set is rebuilt (construct / update). Painters
+  // snapshot it and compare it in shouldRepaint, so the canvas repaints — and
+  // its accessibility semantics rebuild — exactly when the data changed, not on
+  // every unrelated parent rebuild (#25 / D6). Scroll and zoom repaints stay on
+  // the controller's repaint listenable, independent of this.
+  int _revision = 0;
+  int get revision => _revision;
+
+  // Events bucketed by their day-column (entry.time.day). getEventAtPos
+  // hit-tests only the tapped column's bucket instead of scanning every event
+  // (#25): an event's rect lies entirely within its own day-column, so no other
+  // bucket can contain the point. Rebuilt only when the event set or an event's
+  // day can have changed — never per frame or per tap.
+  final Map<int, List<Event>> _eventsByDay = {};
+
   Manager({
     required this.config,
     required this.entries,
@@ -37,6 +52,18 @@ class Manager {
       events.add(Event(entry: entry, manager: this));
     }
     _layoutOverlaps();
+    _rebuildDayIndex();
+    _revision++;
+  }
+
+  /// Rebuilds the [_eventsByDay] hit-test buckets from the current [events].
+  /// One linear pass, called only when the event set or an event's day can have
+  /// changed (build/update and after a drag commits a possible day move).
+  void _rebuildDayIndex() {
+    _eventsByDay.clear();
+    for (final Event event in events) {
+      _eventsByDay.putIfAbsent(event.entry.time.day, () => []).add(event);
+    }
   }
 
   /// Splits each day-column among events that overlap in time (#20 /
@@ -143,6 +170,9 @@ class Manager {
     final dragged = _draggedEvent!;
     _draggedEvent = null;
     dragged.endDrag();
+    // A move can change the event's day-column, so refresh the hit-test buckets
+    // even if the host doesn't rebuild in response to onEntryMove (#25).
+    _rebuildDayIndex();
     config.onEntryMove?.call(dragged.entry);
     controller.triggerUpdate.value++;
   }
@@ -179,9 +209,16 @@ class Manager {
   }
 
   Event? getEventAtPos(Offset pos) {
-    Offset realPos = _toGridPos(pos);
+    final Offset realPos = _toGridPos(pos);
 
-    for (Event event in events) {
+    // Only events in the tapped day-column can contain the point, so scan that
+    // one bucket instead of every event (#25). A tap outside the grid maps to
+    // an absent bucket and simply finds nothing.
+    final int day = (realPos.dx / config.blockWidth).floor();
+    final List<Event>? candidates = _eventsByDay[day];
+    if (candidates == null) return null;
+
+    for (final Event event in candidates) {
       if (event.canvasRect.contains(realPos)) {
         return event;
       }

--- a/test/painter_performance_test.dart
+++ b/test/painter_performance_test.dart
@@ -1,0 +1,169 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/date_row.dart';
+import 'package:planner/internal/events_painter.dart';
+import 'package:planner/internal/grid.dart';
+import 'package:planner/internal/hour_column.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+
+// Covers the three painter-performance fixes in #25:
+//   D6 — shouldRepaint compares a data revision instead of always returning true
+//   D7 — Grid caches the zoom-dependent line paints instead of allocating them
+//        every frame
+//   hit-testing — getEventAtPos scans only the tapped day-column's bucket
+void main() {
+  PlannerConfig makeConfig() => PlannerConfig(labels: const ['A', 'B']);
+
+  PlannerEntry makeEntry(String id, int day) => PlannerEntry(
+        id: id,
+        time: PlannerTime(day: day, hour: 9),
+        title: 'event $id',
+        content: '',
+        color: const Color(0xFF112233),
+      );
+
+  // Sets the controller to an absolute [zoom]: updateZoom multiplies the zoom
+  // captured at startZoom by its scale argument.
+  void setZoom(Manager manager, double zoom) {
+    final current = manager.controller.zoom;
+    manager.controller.startZoom();
+    manager.controller.updateZoom(zoom / current);
+  }
+
+  group('D6 — painters repaint only when the data revision changes', () {
+    test('Manager.revision bumps each time the events are (re)built', () {
+      final manager =
+          Manager(config: makeConfig(), entries: [makeEntry('1', 0)]);
+      final before = manager.revision;
+
+      manager.update(config: makeConfig(), entries: [makeEntry('1', 0)]);
+
+      expect(manager.revision, greaterThan(before));
+    });
+
+    test('shouldRepaint is false for unchanged data, true after an update', () {
+      final manager =
+          Manager(config: makeConfig(), entries: [makeEntry('1', 0)]);
+      final repaint = manager.controller.triggerUpdate;
+
+      final events0 = EventsPainter(manager: manager, repaint: repaint);
+      final hours0 = HourColumn(manager: manager, repaint: repaint);
+      final dates0 = DateRow(manager: manager, repaint: repaint);
+
+      // A fresh delegate built from the same, unchanged data must not force a
+      // repaint — the old code returned true unconditionally, defeating the
+      // optimization, so this fails without the revision comparison.
+      expect(
+          EventsPainter(manager: manager, repaint: repaint)
+              .shouldRepaint(events0),
+          isFalse);
+      expect(
+          HourColumn(manager: manager, repaint: repaint).shouldRepaint(hours0),
+          isFalse);
+      expect(DateRow(manager: manager, repaint: repaint).shouldRepaint(dates0),
+          isFalse);
+
+      manager.update(
+          config: makeConfig(),
+          entries: [makeEntry('1', 0), makeEntry('2', 1)]);
+
+      // After the data changed the new delegate's revision differs -> repaint
+      // (and, via the default shouldRebuildSemantics, semantics rebuild too).
+      expect(
+          EventsPainter(manager: manager, repaint: repaint)
+              .shouldRepaint(events0),
+          isTrue);
+      expect(
+          HourColumn(manager: manager, repaint: repaint).shouldRepaint(hours0),
+          isTrue);
+      expect(DateRow(manager: manager, repaint: repaint).shouldRepaint(dates0),
+          isTrue);
+    });
+  });
+
+  group('D7 — Grid caches the zoom-dependent line paints', () {
+    test('reuses the same Paint objects across frames and recolours on zoom',
+        () {
+      final manager = Manager(config: makeConfig(), entries: const []);
+      final grid = Grid(manager: manager);
+      final canvas = ui.Canvas(ui.PictureRecorder());
+
+      // At zoom 1.5 the 30-min lines are half-faded (alpha 0.5*60=30) and the
+      // 15/45-min lines are still invisible (alpha 0).
+      // Colours are compared as quantized 32-bit ARGB ints: modern Flutter
+      // stores Color channels as floats, so Paint.color == Color.fromARGB can
+      // fail on float ULPs even when the values are equal.
+      setZoom(manager, 1.5);
+      grid.draw(canvas);
+      final div2 = grid.div2Paint;
+      final div3 = grid.div3Paint;
+      expect(div2.color.toARGB32(),
+          const Color.fromARGB(30, 255, 255, 255).toARGB32());
+      expect(div3.color.toARGB32(),
+          const Color.fromARGB(0, 255, 255, 255).toARGB32());
+
+      // Same zoom, next frame: identical Paint instances, unchanged colour —
+      // i.e. no per-frame allocation.
+      grid.draw(canvas);
+      expect(identical(grid.div2Paint, div2), isTrue);
+      expect(identical(grid.div3Paint, div3), isTrue);
+      expect(grid.div2Paint.color.toARGB32(),
+          const Color.fromARGB(30, 255, 255, 255).toARGB32());
+
+      // Zoom in to 2.5: the same instances are recoloured (30-min fully on at
+      // alpha 60, 15/45-min fading in at alpha 0.5*30=15).
+      setZoom(manager, 2.5);
+      grid.draw(canvas);
+      expect(identical(grid.div2Paint, div2), isTrue);
+      expect(identical(grid.div3Paint, div3), isTrue);
+      expect(grid.div2Paint.color.toARGB32(),
+          const Color.fromARGB(60, 255, 255, 255).toARGB32());
+      expect(grid.div3Paint.color.toARGB32(),
+          const Color.fromARGB(15, 255, 255, 255).toARGB32());
+    });
+  });
+
+  group('#25 — getEventAtPos hit-tests only the tapped day-column', () {
+    // Default config: blockWidth 200, blockHeight 40, minHour 0. An entry at
+    // day d / hour 9 (duration 60) occupies grid rect
+    // (d*200, 360) - (d*200+200, 400).
+    test('finds the event in the tapped column', () {
+      final manager = Manager(
+        config: makeConfig(),
+        entries: [makeEntry('a', 0), makeEntry('b', 1)],
+      );
+
+      expect(manager.getEventAtPos(const Offset(100, 380))?.entry.id, 'a');
+      expect(manager.getEventAtPos(const Offset(300, 380))?.entry.id, 'b');
+    });
+
+    test('returns null when the tap misses every event', () {
+      final manager =
+          Manager(config: makeConfig(), entries: [makeEntry('a', 0)]);
+
+      expect(
+          manager.getEventAtPos(const Offset(100, 50)), isNull); // wrong time
+      expect(
+          manager.getEventAtPos(const Offset(300, 380)), isNull); // empty day
+      expect(manager.getEventAtPos(const Offset(-50, 380)), isNull); // off-grid
+    });
+
+    test('a drag that changes the day re-buckets the event', () {
+      final manager =
+          Manager(config: makeConfig(), entries: [makeEntry('a', 0)]);
+
+      // Long-press the event in day 0, drag one column right, release.
+      manager.startDrag(const Offset(100, 380));
+      manager.updateDrag(const Offset(300, 380));
+      manager.endDrag();
+
+      // It is now hit-testable in day 1 and no longer in day 0 — which only
+      // holds because endDrag rebuilds the day index.
+      expect(manager.getEventAtPos(const Offset(300, 380))?.entry.id, 'a');
+      expect(manager.getEventAtPos(const Offset(100, 380)), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Painter performance pass (#25 / PROJECT_OVERVIEW D6 + D7 + hit-testing). Three targeted optimizations, all behaviour-preserving:

- **D6 — real `shouldRepaint`.** All painters returned `true` unconditionally, so every parent rebuild (e.g. opening/closing the context menu) forced a full repaint. `Manager` now carries a `revision` counter, bumped whenever the event set is (re)built. Each painter snapshots it at construction and `shouldRepaint` compares snapshots, so the canvas repaints only when the data actually changed. Scroll/zoom repaints continue to flow through the controller's `repaint` listenable, untouched. Because `shouldRebuildSemantics` defaults to `shouldRepaint`, this also keeps accessibility semantics (#21) rebuilding correctly on data change while dropping the spurious churn.
- **D7 — cached grid paints.** `Grid.draw` allocated two `Paint` objects (`div2`/`div3`) every frame. Their colour is a pure function of zoom, so they're now cached fields and recoloured only when the zoom changes.
- **Hit-testing — day-bucketed `getEventAtPos`.** Tap hit-testing was an O(n) linear scan of every event. Events are now bucketed by their day-column (`entry.time.day`); a tap maps to one column, so only that bucket is scanned. Lightweight (no spatial-tree machinery), since this is a per-tap operation, not per-frame. The index is rebuilt on (re)build and after a drag that may move an event to another day.

## Linked issue
Closes #25

## Changes
- `lib/internal/manager.dart` — `revision` counter (D6); `_eventsByDay` index + bucketed `getEventAtPos`; `endDrag` re-buckets after a possible day move.
- `lib/internal/grid.dart` — cache `div2Paint`/`div3Paint`, recolour only on zoom change (D7).
- `lib/internal/events_painter.dart`, `lib/internal/hour_column.dart`, `lib/internal/date_row.dart` — `shouldRepaint` compares the captured revision (D6).
- `test/painter_performance_test.dart` — new unit tests for all three.

## Test plan
- [x] `flutter analyze` clean
- [x] unit/widget tests pass (`flutter test`) — 74 pass (6 new)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — 12 pass

No *new* integration test was added: D6/D7 are pure performance refactors with **no visible behaviour change** (identical pixels, identical semantics), and the hit-testing change returns identical results — so this is not user-visible per the workflow's exception. The existing 12-scenario integration suite (incl. drag, per-column overlap hit-test, and accessibility) was run as a regression and passes.

## Note
While investigating D6 I confirmed a **pre-existing, out-of-scope** accessibility bug: event semantics are culled to the viewport but are not rebuilt on scroll (the `repaint` listenable only marks needs-paint, never needs-semantics), so a scrolled-in event gains no semantics node until the next relayout/data change. Filed as #56 rather than expanding this PR. This PR does not change that scroll-time behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
