### PR TITLE
fix: double-tap edit/create callbacks now fire (#40)

### DIFF
--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -4,6 +4,7 @@ import 'accessibility_scenarios.dart';
 import 'app_smoke_scenarios.dart';
 import 'context_menu_labels_scenarios.dart';
 import 'context_menu_scenarios.dart';
+import 'double_tap_scenarios.dart';
 import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
 import 'hour_label_scenarios.dart';
@@ -26,6 +27,7 @@ void main() {
   appSmokeScenarios();
   contextMenuLabelsScenarios();
   contextMenuScenarios();
+  doubleTapScenarios();
   dragScenarios();
   eventGeometryScenarios();
   hourLabelScenarios();

--- a/example/integration_test/double_tap_scenarios.dart
+++ b/example/integration_test/double_tap_scenarios.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+/// End-to-end guard for #40: the double-tap edit/create paths were dead.
+///
+/// The `PositionedTapDetector2` that owns `onDoubleTap` wrapped the events
+/// `GestureDetector`, whose own `onTap` won the gesture arena — so the parent's
+/// tap stream was never fed and `onDoubleTap` never resolved. The detector is
+/// now driven from the single events detector through its controller, so a real
+/// double-tap reaches `onEntryEdit` / `onEntryCreate`.
+///
+/// This drives the *real* composed widget (real layout, real fonts, real tap
+/// recognition over the competing drag/scale/long-press recognizers) with two
+/// genuine taps inside the detector's double-tap window.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void doubleTapScenarios() {
+  // Two quick taps at the same point, within the detector's 250ms double-tap
+  // window. The first tap is buffered on a stream and only resolves a
+  // double-tap once the second arrives in time, so the gap stays well under the
+  // window; the trailing pump past it flushes the (now no-op) timeout timer.
+  Future<void> doubleTapAt(WidgetTester tester, Offset at) async {
+    await tester.tapAt(at);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(at);
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  testWidgets('double-tapping an event fires onEntryEdit', (tester) async {
+    final edited = <PlannerEntry>[];
+    final created = <PlannerTime>[];
+
+    await tester.pumpWidget(
+        _DoubleTapHostApp(onEdit: edited.add, onCreate: created.add));
+    await tester.pumpAndSettle();
+
+    // The single event sits at day 0 / hour 9 -> grid rect (0,360)-(200,400)
+    // with the default 200x40 blocks. On screen it is offset by the hour column
+    // (50) and date row (50); its centre is therefore at planner-local (150, 430).
+    final center =
+        tester.getRect(find.byType(Planner)).topLeft + const Offset(150, 430);
+    await doubleTapAt(tester, center);
+
+    expect(edited, hasLength(1),
+        reason: 'double-tapping an event must fire onEntryEdit');
+    expect(edited.single.id, 'evt',
+        reason: 'onEntryEdit receives the double-tapped entry');
+    expect(created, isEmpty,
+        reason: 'a hit on an event edits it, it does not create');
+  });
+
+  testWidgets('double-tapping empty grid fires onEntryCreate', (tester) async {
+    final created = <PlannerTime>[];
+    final edited = <PlannerEntry>[];
+
+    await tester.pumpWidget(
+        _DoubleTapHostApp(onEdit: edited.add, onCreate: created.add));
+    await tester.pumpAndSettle();
+
+    // events-local (100, 200) past the hour column (50) and date row (50):
+    // column 0, and y=200 in an unscrolled 40px grid maps to hour 5 — free,
+    // since the only event sits at hour 9.
+    final at = tester.getRect(find.byType(Planner)).topLeft +
+        const Offset(50 + 100, 50 + 200);
+    await doubleTapAt(tester, at);
+
+    expect(created, hasLength(1),
+        reason: 'double-tapping empty grid must fire onEntryCreate');
+    expect(created.single.day, 0);
+    expect(created.single.hour, 5,
+        reason: 'the tapped point maps to day 0 / hour 5');
+    expect(edited, isEmpty,
+        reason: 'an empty-grid hit creates, it does not edit');
+  });
+}
+
+/// A minimal real app hosting one [Planner] with a single event at day 0 /
+/// hour 9, recording double-tap edit/create callbacks.
+class _DoubleTapHostApp extends StatelessWidget {
+  const _DoubleTapHostApp({required this.onEdit, required this.onCreate});
+
+  final void Function(PlannerEntry) onEdit;
+  final void Function(PlannerTime) onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryEdit: onEdit,
+            onEntryCreate: onCreate,
+          ),
+          entries: [
+            PlannerEntry(
+              id: 'evt',
+              time: PlannerTime(day: 0, hour: 9),
+              title: 'Meeting',
+              content: '',
+              color: const Color(0xFF2244AA),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -32,6 +32,13 @@ class _PlannerState extends State<Planner> {
   // static to survive that churn.
   late Manager _data;
 
+  // Drives the position-aware double-tap detector from the single events
+  // GestureDetector below. Nesting a second tap detector (the old layout) let
+  // the inner detector win the gesture arena, so the double-tap stream was
+  // never fed and onEntryEdit/onEntryCreate never fired (#40). Feeding the
+  // detector through its controller keeps one detector in the arena.
+  final PositionedTapController _tapController = PositionedTapController();
+
   @override
   void initState() {
     super.initState();
@@ -62,6 +69,7 @@ class _PlannerState extends State<Planner> {
                   child: Stack(
                     children: [
                       PositionedTapDetector2(
+                        controller: _tapController,
                         onDoubleTap: (position) {
                           if (position.relative == null) {
                             return;
@@ -220,8 +228,16 @@ class _PlannerState extends State<Planner> {
       onLongPressEnd: (details) {
         _data.endDrag();
       },
+      // Feed taps to the double-tap detector via its controller (see
+      // _tapController): onTapDown records the pending tap, onTap confirms it.
+      // hideMenu stays on the immediate tap so dismissing the menu isn't held
+      // back by the double-tap window.
+      onTapDown: (details) {
+        _tapController.onTapDown(details);
+      },
       onTap: () {
         _data.controller.hideMenu();
+        _tapController.onTap();
       },
       onSecondaryTapDown: (details) {
         showMenu(details);

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -138,6 +138,18 @@ void main() {
     await tester.pump();
   }
 
+  // Two quick taps at the same point, within the detector's 250ms double-tap
+  // window. PositionedTapDetector2 buffers the first tap on a stream and only
+  // resolves a double-tap once the second arrives in time, so the gap stays
+  // well under the window; the trailing pump past it flushes the (now no-op)
+  // timeout timer so none is left pending.
+  Future<void> doubleTapAt(WidgetTester tester, Offset at) async {
+    await tester.tapAt(at);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(at);
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
   testWidgets('two planners keep independent scroll state (D1)',
       (tester) async {
     const keyA = ValueKey('plannerA');
@@ -493,6 +505,72 @@ void main() {
       expect(deleted, hasLength(1));
       expect(identical(deleted.single, entry), isTrue,
           reason: 'onEntryDelete receives the right-clicked entry');
+    });
+  });
+
+  // Regression for #40: the double-tap edit/create paths were dead. The
+  // PositionedTapDetector2 that owns onDoubleTap wrapped the paintEvents
+  // GestureDetector, whose own onTap won the gesture arena, so the parent's tap
+  // stream was never fed and onDoubleTap never resolved. The detector is now
+  // driven from the single events detector via its controller, so a real
+  // double-tap reaches onEntryEdit / onEntryCreate. These drive the real
+  // composed Planner with two genuine taps inside the double-tap window.
+  group('double-tap edit/create (#40)', () {
+    testWidgets('double-tapping an event fires onEntryEdit', (tester) async {
+      const key = ValueKey('planner');
+      final edited = <PlannerEntry>[];
+      final created = <PlannerTime>[];
+      final entry = eventAtHour9();
+      final rect = await pumpEntryPlanner(tester, key, entry,
+          onEdit: edited.add, onCreate: created.add);
+
+      // The event's centre is planner-local (150, 430) (see eventAtHour9).
+      await doubleTapAt(tester, rect.topLeft + const Offset(150, 430));
+
+      expect(edited, hasLength(1),
+          reason: 'double-tapping an event must fire onEntryEdit');
+      expect(identical(edited.single, entry), isTrue,
+          reason: 'onEntryEdit receives the double-tapped entry');
+      expect(created, isEmpty,
+          reason: 'a hit on an event edits it, it does not create');
+    });
+
+    testWidgets('double-tapping empty grid fires onEntryCreate',
+        (tester) async {
+      const key = ValueKey('planner');
+      final created = <PlannerTime>[];
+      final edited = <PlannerEntry>[];
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Planner(
+            key: key,
+            config: PlannerConfig(
+              labels: const ['c1', 'c2', 'c3'],
+              minHour: 0,
+              maxHour: 23,
+              onEntryEdit: edited.add,
+              onEntryCreate: created.add,
+            ),
+            entries: const [],
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // events-local (100, 200) past the hour column (50) and date row (50):
+      // column 0, and y=200 in an unscrolled 40px grid maps to hour 5.
+      final rect = tester.getRect(find.byKey(key));
+      await doubleTapAt(
+          tester, rect.topLeft + const Offset(50 + 100, 50 + 200));
+
+      expect(created, hasLength(1),
+          reason: 'double-tapping empty grid must fire onEntryCreate');
+      expect(created.single.day, 0);
+      expect(created.single.hour, 5,
+          reason: 'the tapped point maps to day 0 / hour 5');
+      expect(edited, isEmpty,
+          reason: 'an empty-grid hit creates, it does not edit');
     });
   });
 


### PR DESCRIPTION
## Summary
Double-tap edit/create callbacks (`onEntryEdit` / `onEntryCreate`) never fired. The `PositionedTapDetector2` that owns `onDoubleTap` wrapped the events `GestureDetector`, whose own `onTap` won the gesture arena — so the parent's tap stream was never fed and `onDoubleTap` never resolved. This collapses the two nested tap detectors into one.

## Linked issue
Closes #40

## Changes
- `lib/planner_class.dart`: run `PositionedTapDetector2` in controller mode (renders only its child, no second `GestureDetector`) and drive it from the single events detector via `PositionedTapController` — `onTapDown` records the pending tap, `onTap` confirms it. `hideMenu` stays on the immediate tap so menu dismissal isn't held back by the double-tap window.
- `test/planner_widget_test.dart`: new `double-tap edit/create (#40)` group — double-tap an event fires `onEntryEdit`; double-tap empty grid fires `onEntryCreate`.
- `example/integration_test/double_tap_scenarios.dart` (new) + `app_test.dart`: the same two paths end-to-end against the real composed widget.

## Test plan
- [x] `flutter analyze` clean
- [x] `dart format --output=none --set-exit-if-changed .` passes
- [x] unit/widget tests pass (`flutter test`) — 94 tests incl. 2 new; confirmed both **fail** on the unpatched code
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — 16 tests incl. 2 new; confirmed both **fail** on the unpatched code

## Notes / screenshots
Scope kept to the gesture-arena fix; pre-existing context-menu overlay quirks and other PROJECT_OVERVIEW items are intentionally left untouched.