### PR TITLE
feat: configurable column highlight ("today" style) (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Added an optional column highlight (a "today"-style emphasis). Set
+  `PlannerConfig.highlightedColumn` to a column index (into `labels`) and the
+  grid fills that column behind the lines and events; `highlightColumnColor`
+  (default a subtle translucent white wash) sets the fill. The widget stays
+  date-agnostic — a calendar consumer maps `DateTime.now()` to an index itself
+  (ADR 0001). `null` (the default) or an out-of-range index highlights nothing.
+
 ## 0.2.0 - 2026-06-06
 
 - Made the on-canvas zoom +/- buttons configurable: hide them with

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -175,8 +175,9 @@ Severity: 🔴 blocker/bug · 🟠 important · 🟡 polish.
 - ✅ **Time-model direction resolved (#19):** keep the day-index model; do **not**
   migrate to `DateTime`. See `docs/decisions/0001-time-model-day-index.md`.
 - Add the genuine widget-level primitives as additive, non-breaking follow-ups:
-  highlight-column ("today" style, #46), event column-span (multi-day, #47),
-  all-day band (#48), optional `date ↔ index` consumer helpers (#49).
+  ✅ highlight-column ("today" style, #46 — `PlannerConfig.highlightedColumn`),
+  event column-span (multi-day, #47), all-day band (#48), optional
+  `date ↔ index` consumer helpers (#49).
 - **D11** overlap/column layout. Accessibility (`Semantics`), localization of menu strings.
 
 ### P3 — Polish & tooling

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A complete, runnable demo lives in [`example/`](example/lib/main.dart).
 | Type | Purpose |
 |------|---------|
 | `Planner` | The widget. Takes a `config` and a list of `entries`. |
-| `PlannerConfig` | Sizing (`blockWidth`, `blockHeight`, `minHour`, `maxHour` — the inclusive last hour, default `23`, …), colors, text styles, an optional `hourLabelFormatter`, the zoom controls (`showZoomControls`, `zoomButtonColor`, `zoomButtonIconColor`), the wheel `scrollStep`, and the `onEntry*` callbacks. `labels` is required. |
+| `PlannerConfig` | Sizing (`blockWidth`, `blockHeight`, `minHour`, `maxHour` — the inclusive last hour, default `23`, …), colors, text styles, an optional `hourLabelFormatter`, the optional column highlight (`highlightedColumn`, `highlightColumnColor`), the zoom controls (`showZoomControls`, `zoomButtonColor`, `zoomButtonIconColor`), the wheel `scrollStep`, and the `onEntry*` callbacks. `labels` is required. |
 | `PlannerEntry` | One event: `id`, `time`, `title`, `content`, `color`, and optional text styles. |
 | `PlannerTime` | `day` (index into `labels`), `hour`, `minutes`, and `duration` (in minutes). |
 
@@ -135,6 +135,34 @@ PlannerConfig(
 | `contextMenuCreateLabel` | `'Create Event'` | Shown on an empty grid cell. |
 | `contextMenuEditLabel` | `'Edit Event'` | Shown on an existing event. |
 | `contextMenuDeleteLabel` | `'Delete Event'` | Shown on an existing event. |
+
+### Highlighting a column ("today" style)
+
+`planner` is column-based, not date-based (see the note above), so it has no idea
+which column is "today". To emphasize one — a calendar's current day, the active
+room, the selected lane — set `highlightedColumn` to its **index** into `labels`;
+the grid fills that column behind the lines and events:
+
+```dart
+final labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+PlannerConfig(
+  labels: labels,
+  // A calendar consumer owns the date↔index mapping and passes the index:
+  highlightedColumn: 2, // e.g. DateTime.now().weekday - 1
+  highlightColumnColor: Colors.amber.withOpacity(0.15), // optional
+);
+```
+
+`highlightedColumn` defaults to `null` (no highlight); an out-of-range index
+highlights nothing. `highlightColumnColor` defaults to a subtle translucent white
+wash that reads on the default dark background — override it for a different tint
+(or a darker wash on a light background).
+
+| Field | Defaults to | Purpose |
+|-------|-------------|---------|
+| `highlightedColumn` | `null` | Index into `labels` of the column to emphasize. |
+| `highlightColumnColor` | translucent white | Fill painted across that column. |
 
 ## Additional information
 

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -7,6 +7,7 @@ import 'context_menu_scenarios.dart';
 import 'double_tap_scenarios.dart';
 import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
+import 'highlight_column_scenarios.dart';
 import 'hour_label_scenarios.dart';
 import 'multi_planner_scenarios.dart';
 import 'overlap_scenarios.dart';
@@ -30,6 +31,7 @@ void main() {
   doubleTapScenarios();
   dragScenarios();
   eventGeometryScenarios();
+  highlightColumnScenarios();
   hourLabelScenarios();
   multiPlannerScenarios();
   overlapScenarios();

--- a/example/integration_test/highlight_column_scenarios.dart
+++ b/example/integration_test/highlight_column_scenarios.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/events_painter.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for the configurable column highlight (#46): the host sets
+/// `PlannerConfig.highlightedColumn` (an index into `labels`, ADR 0001 — no
+/// `DateTime` in the API) and the grid painter fills that column behind the
+/// lines and events.
+///
+/// The highlight is painted on the `CustomPaint` canvas, not in the
+/// widget/semantics tree, so its render *is* the observable: this drives the
+/// real composed widget on a real device and asserts what the events canvas
+/// actually paints — that the right column is filled, and that the fill sits
+/// *behind* an event in that column (a layer-ordering bug an isolated widget
+/// test of the painter can't surface).
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void highlightColumnScenarios() {
+  // The events grid is painted by EventsPainter on its own CustomPaint; scope
+  // `paints` assertions to that render object so surrounding chrome can't match.
+  Finder eventsCanvas() => find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is EventsPainter,
+      );
+
+  testWidgets('highlights the configured column behind its events',
+      (tester) async {
+    final entry = PlannerEntry(
+      id: 'evt',
+      time: PlannerTime(day: 1, hour: 9),
+      title: 'Meeting',
+      content: '',
+      color: const Color(0xFF2244AA),
+    );
+
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        PlannerSpec(
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            highlightedColumn: 1,
+            highlightColumnColor: const Color(0xFF00FF00),
+          ),
+          entries: [entry],
+        ),
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    // Default 200x40 grid, hours 0..23 (24 rows), no scroll, zoom 1: column 1
+    // occupies grid rect (200, 0) 200 wide and 24*40 = 960 tall. This geometry
+    // is grid-content space (independent of the real window size, which only
+    // clips it). The green highlight rect is painted first, then the event's
+    // fill rect (entry.color at alpha 100) — the order proves the highlight
+    // backs the event rather than covering it.
+    expect(
+      eventsCanvas(),
+      paints
+        ..rect(
+          rect: const Rect.fromLTWH(200, 0, 200, 960),
+          color: const Color(0xFF00FF00),
+        )
+        ..rect(color: const Color(0x642244AA)),
+    );
+  });
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -86,6 +86,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 "day 9",
                 "day 10"
               ],
+              // Emphasize a column ("today" style). The widget is date-agnostic,
+              // so a real calendar would map DateTime.now() to this index itself.
+              highlightedColumn: 0,
               //dateBackground: Colors.red,
               //hourBackground: Colors.deepOrange,
               onEntryMove: (entry) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -168,7 +168,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.2.0"
   platform:
     dependency: transitive
     description:

--- a/lib/internal/grid.dart
+++ b/lib/internal/grid.dart
@@ -23,7 +23,26 @@ class Grid {
   final List<Line> hLines = [];
   final List<Line> vLines = [];
 
+  // Optional "today"-style column emphasis (#46). When the host sets a valid
+  // [PlannerConfig.highlightedColumn] we fill that column behind the grid lines
+  // and events. Resolved once here (index + Paint) rather than per frame; both
+  // stay null when nothing is highlighted or the index is out of range, so
+  // [draw] skips the highlight entirely.
+  int? highlightColumn;
+  Paint? highlightPaint;
+
   Grid({required this.manager}) {
+    final config = manager.config;
+    final highlighted = config.highlightedColumn;
+    if (highlighted != null &&
+        highlighted >= 0 &&
+        highlighted < config.labels.length) {
+      highlightColumn = highlighted;
+      highlightPaint = Paint()
+        ..color = config.highlightColumnColor
+        ..style = PaintingStyle.fill;
+    }
+
     // vertical lines: drawn after each day
     Offset vstart = Offset(manager.config.blockWidth.toDouble(), 0);
     Offset vend = Offset(
@@ -68,6 +87,10 @@ class Grid {
   }
 
   void draw(Canvas canvas) {
+    // The highlighted column is filled first so the grid lines and events draw
+    // on top of it (it emphasizes the column without obscuring its content).
+    _drawHighlight(canvas);
+
     // vertical lines can be drawn instantly
     for (var line in vLines) {
       line.draw(canvas, vPaint);
@@ -102,5 +125,32 @@ class Grid {
         hLines[i].draw(canvas, div3Paint);
       }
     }
+  }
+
+  // Fills the highlighted column (if any) across the full hour range. The rect
+  // is mapped through the controller's scroll [offset] and time-axis [zoom] the
+  // same way the grid lines are (see [Line.draw]), so the highlight tracks the
+  // column as the user pans/zooms. A no-op when no column is highlighted.
+  void _drawHighlight(Canvas canvas) {
+    final column = highlightColumn;
+    final paint = highlightPaint;
+    if (column == null || paint == null) return;
+
+    final config = manager.config;
+    final offset = manager.controller.offset;
+    final zoom = manager.controller.zoom;
+    final blockWidth = config.blockWidth.toDouble();
+    final gridHeight =
+        config.blockHeight.toDouble() * (config.maxHour - config.minHour + 1);
+
+    canvas.drawRect(
+      Rect.fromLTWH(
+        offset.dx + column * blockWidth,
+        offset.dy,
+        blockWidth,
+        gridHeight * zoom,
+      ),
+      paint,
+    );
   }
 }

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -67,6 +67,20 @@ class PlannerConfig {
   /// English `'Delete Event'`.
   String contextMenuDeleteLabel;
 
+  /// Index into [labels] of a column to emphasize — e.g. a "today" highlight —
+  /// or `null` (the default) to highlight nothing. The widget stays
+  /// date-agnostic: a consumer building a calendar maps `DateTime.now()` to a
+  /// column index itself and passes it here (see ADR 0001 / #46), so no
+  /// `DateTime` enters the public API. An out-of-range index highlights nothing.
+  int? highlightedColumn;
+
+  /// Fill colour painted across the [highlightedColumn], behind the grid lines
+  /// and events. Defaults to a subtle translucent white wash so setting
+  /// [highlightedColumn] alone is visible on the default dark [plannerBackground];
+  /// override it for a different emphasis (e.g. a brand "today" tint, or a darker
+  /// wash on a light background). Ignored when [highlightedColumn] is `null`.
+  Color highlightColumnColor;
+
   Color hourBackground;
   Color dateBackground;
   Color plannerBackground = const Color.fromARGB(255, 50, 50, 50);
@@ -117,6 +131,8 @@ class PlannerConfig {
     this.contextMenuCreateLabel = 'Create Event',
     this.contextMenuEditLabel = 'Edit Event',
     this.contextMenuDeleteLabel = 'Delete Event',
+    this.highlightedColumn,
+    this.highlightColumnColor = const Color.fromARGB(40, 255, 255, 255),
     this.hourBackground = Colors.white,
     this.dateBackground = Colors.white,
     this.contextMenuBackground = Colors.white,

--- a/test/highlight_column_test.dart
+++ b/test/highlight_column_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/events_painter.dart';
+import 'package:planner/planner.dart';
+
+// Issue #46: a configurable "today"-style column highlight. The widget stays
+// date-agnostic (ADR 0001) — the host passes a column *index* into `labels`
+// plus a colour, and the grid painter fills that column behind the lines and
+// events. These tests drive the real composed Planner and inspect what the
+// events CustomPaint actually paints.
+void main() {
+  // The events grid is painted by EventsPainter on its own CustomPaint; scope
+  // `paints` assertions to that render object so the surrounding chrome (date
+  // row, hour column, Material internals) can't match by accident.
+  Finder eventsCanvas() => find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is EventsPainter,
+      );
+
+  // A full-screen Planner with the given highlight settings and no entries, so
+  // the only rect the grid can paint is the highlight itself.
+  Future<void> pumpHighlight(
+    WidgetTester tester, {
+    int? highlightedColumn,
+    Color? highlightColumnColor,
+    List<PlannerEntry> entries = const [],
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            highlightedColumn: highlightedColumn,
+            highlightColumnColor:
+                highlightColumnColor ?? const Color(0xFF00FF00),
+          ),
+          entries: entries,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  group('PlannerConfig highlight defaults', () {
+    test('highlightedColumn is null and the colour is a translucent wash', () {
+      final c = PlannerConfig(labels: const ['A']);
+      expect(c.highlightedColumn, isNull);
+      expect(c.highlightColumnColor, const Color.fromARGB(40, 255, 255, 255));
+    });
+  });
+
+  group('column highlight rendering', () {
+    // With the default 200x40 grid, hours 0..23 (24 rows), no scroll and zoom 1,
+    // column 1 occupies grid rect (200, 0) 200 wide and 24*40 = 960 tall.
+    testWidgets('fills the configured column at the right geometry/colour',
+        (tester) async {
+      await pumpHighlight(tester, highlightedColumn: 1);
+
+      expect(
+        eventsCanvas(),
+        paints
+          ..rect(
+            rect: const Rect.fromLTWH(200, 0, 200, 960),
+            color: const Color(0xFF00FF00),
+          ),
+      );
+    });
+
+    testWidgets('column 0 is filled flush with the grid origin',
+        (tester) async {
+      await pumpHighlight(tester, highlightedColumn: 0);
+
+      expect(
+        eventsCanvas(),
+        paints
+          ..rect(
+            rect: const Rect.fromLTWH(0, 0, 200, 960),
+            color: const Color(0xFF00FF00),
+          ),
+      );
+    });
+
+    testWidgets('paints nothing when highlightedColumn is null (the default)',
+        (tester) async {
+      await pumpHighlight(tester); // highlightedColumn omitted -> null
+
+      // No entries either, so an unhighlighted grid paints only lines (drawLine),
+      // never a rect.
+      expect(eventsCanvas(), isNot(paints..rect()));
+    });
+
+    testWidgets('an out-of-range index highlights nothing', (tester) async {
+      // 3 labels -> valid indices 0..2; index 5 must be ignored, not clamped.
+      await pumpHighlight(tester, highlightedColumn: 5);
+
+      expect(eventsCanvas(), isNot(paints..rect()));
+    });
+
+    testWidgets('a negative index highlights nothing', (tester) async {
+      await pumpHighlight(tester, highlightedColumn: -1);
+
+      expect(eventsCanvas(), isNot(paints..rect()));
+    });
+
+    // The highlight is a backdrop: it must be painted *before* the events so it
+    // emphasizes the column without occluding the events sitting in it.
+    testWidgets('is painted behind the events in its column', (tester) async {
+      final entry = PlannerEntry(
+        id: 'evt',
+        time: PlannerTime(day: 1, hour: 9),
+        title: 'Meeting',
+        content: '',
+        color: const Color(0xFF2244AA),
+      );
+      await pumpHighlight(tester, highlightedColumn: 1, entries: [entry]);
+
+      // The green highlight rect, then the event's fill rect (entry.color at
+      // alpha 100) — the order proves the highlight sits underneath.
+      expect(
+        eventsCanvas(),
+        paints
+          ..rect(color: const Color(0xFF00FF00))
+          ..rect(color: const Color(0x642244AA)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an optional, **date-agnostic** column highlight (a "today"-style emphasis). The host sets `PlannerConfig.highlightedColumn` to a column *index* into `labels`, and the grid painter fills that column behind the lines and events. `highlightColumnColor` (default a subtle translucent white wash) sets the fill.

Per ADR 0001 (follow-up from #19), the widget stays date-agnostic: a calendar consumer maps `DateTime.now()` to a column index itself, so **no `DateTime` enters the public API** (explicitly out of scope on the issue).

## Linked issue

Closes #46

## Changes

- **`lib/planner_config.dart`** — new `int? highlightedColumn` (default `null`) and `Color highlightColumnColor` (default `Color.fromARGB(40, 255, 255, 255)`).
- **`lib/internal/grid.dart`** — resolves a valid highlighted column + `Paint` once in the constructor (null / out-of-range → no highlight); `_drawHighlight` fills the column *first* in `draw()` so grid lines and events render on top. The rect is mapped through the same scroll-offset/zoom transform as the grid lines, so it tracks the column as the user pans/zooms.
- **`test/highlight_column_test.dart`** (new) — config defaults; correct geometry/colour for columns 0 and 1; nothing painted for null / out-of-range / negative index; highlight painted *behind* an event in its column.
- **`example/integration_test/highlight_column_scenarios.dart`** (new, registered in `app_test.dart`) — drives the real composed app and asserts the column is filled at the right geometry and *behind* the event (layer ordering).
- **Docs/demo** — README (config table + "Highlighting a column" section), CHANGELOG (Unreleased), PROJECT_OVERVIEW (#46 marked done), `example/lib/main.dart` demos `highlightedColumn: 0`.
- `example/pubspec.lock` — incidental, correct sync of the path-dependency version (`0.0.4`→`0.2.0`) regenerated by `flutter pub get`.

## Test plan

- [x] `flutter analyze` clean (No issues found)
- [x] unit/widget tests pass — `flutter test` (101 tests, incl. 7 new highlight tests)
- [x] integration/e2e tests pass — `flutter test integration_test/app_test.dart -d windows` (17 tests, incl. the new "highlights the configured column behind its events" scenario). User-visible change, so an end-to-end test is included; it runs against the real composed app on a real device. Verified the new tests fail on unpatched code (disabling the draw fails the 3 positive rendering tests while the absence/defaults tests correctly stay green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)