### PR TITLE
feat: column-spanning (multi-day) events (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Added column-spanning (multi-day) events. Set `PlannerTime.endDay` to a
+  column index after `day` and the event renders across the whole `day..endDay`
+  range; `null` (the default) or any value `<= day` is a single-column event, so
+  existing entries are unaffected. The span stays index-based — no `DateTime`
+  enters the model (ADR 0001). Spanning events are read-only in this first cut
+  (they can't be dragged or resized) but stay tappable for edit/delete. A new
+  `PlannerConfig.spanOverlap` chooses how a span coexists with the per-column
+  overlap split: `SpanOverlap.fullWidth` (the default) draws it as one box across
+  its columns; `SpanOverlap.split` folds it into each column's sub-column layout.
 - Added an optional column highlight (a "today"-style emphasis). Set
   `PlannerConfig.highlightedColumn` to a column index (into `labels`) and the
   grid fills that column behind the lines and events; `highlightColumnColor`

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -176,7 +176,8 @@ Severity: 🔴 blocker/bug · 🟠 important · 🟡 polish.
   migrate to `DateTime`. See `docs/decisions/0001-time-model-day-index.md`.
 - Add the genuine widget-level primitives as additive, non-breaking follow-ups:
   ✅ highlight-column ("today" style, #46 — `PlannerConfig.highlightedColumn`),
-  event column-span (multi-day, #47), all-day band (#48), optional
+  ✅ event column-span (multi-day, #47 — `PlannerTime.endDay` +
+  `PlannerConfig.spanOverlap`), all-day band (#48), optional
   `date ↔ index` consumer helpers (#49).
 - **D11** overlap/column layout. Accessibility (`Semantics`), localization of menu strings.
 

--- a/docs/decisions/0001-time-model-day-index.md
+++ b/docs/decisions/0001-time-model-day-index.md
@@ -69,8 +69,9 @@ non-breaking follow-up issues:
   — a configurable "emphasize column index N" (enables a "today" style without the
   widget knowing dates).
 - **Event column-span** ([#47](https://github.com/pebble-world/planner/issues/47))
-  — let an entry render across a start→end column range (enables multi-day
-  rendering).
+  — ✅ done: `PlannerTime.endDay` lets an entry render across a start→end column
+  range (enables multi-day rendering), with `PlannerConfig.spanOverlap` choosing
+  how it coexists with the per-column overlap split.
 - **All-day band** ([#48](https://github.com/pebble-world/planner/issues/48)) — a
   row above the time grid for all-day / full-column entries.
 - **Optional consumer-side date helpers**

--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -12,6 +12,7 @@ surface) can miss rendering/geometry bugs.
 | [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
 | [`hour_label_scenarios.dart`](hour_label_scenarios.dart) | The default `maxHour` (23) clamps a below-grid tap to hour 23, not the invalid 24 (#13 / D10). |
 | [`snapping_scenarios.dart`](snapping_scenarios.dart) | Create and drag snap event times to the single configurable `snapMinutes` interval, and agree (#14 / D8). |
+| [`span_scenarios.dart`](span_scenarios.dart) | A column-spanning event (`PlannerTime.endDay`) paints one box across its columns, hit-tests from any column it covers, and is read-only — a long-press drag doesn't move it (#47). |
 | [`multi_planner_scenarios.dart`](multi_planner_scenarios.dart) | Two planners on one screen keep independent scroll state (device-level counterpart of the #9 / D1 regression). |
 | [`planner_harness.dart`](planner_harness.dart) | Reusable `PlannerHarness` for multi-planner / multi-config flows, plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`, `longPressDrag`). |
 

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -12,6 +12,7 @@ import 'hour_label_scenarios.dart';
 import 'multi_planner_scenarios.dart';
 import 'overlap_scenarios.dart';
 import 'snapping_scenarios.dart';
+import 'span_scenarios.dart';
 import 'zoom_scenarios.dart';
 
 /// Single entry point for the integration suite.
@@ -36,5 +37,6 @@ void main() {
   multiPlannerScenarios();
   overlapScenarios();
   snappingScenarios();
+  spanScenarios();
   zoomScenarios();
 }

--- a/example/integration_test/span_scenarios.dart
+++ b/example/integration_test/span_scenarios.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/events_painter.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for column-spanning events (#47): a [PlannerEntry] whose
+/// [PlannerTime.endDay] is set after [PlannerTime.day] renders across the whole
+/// `day..endDay` column range, is reachable by a pointer from *any* column it
+/// covers (not just the start column), and is read-only in this first cut —
+/// a long-press drag must not move it.
+///
+/// The span is drawn on the `CustomPaint` canvas and hit-tested by
+/// `getEventAtPos`, neither of which an isolated widget test exercises with real
+/// layout/fonts/gestures. So this drives the real composed widget and asserts
+/// what the canvas actually paints plus how real secondary-tap / long-press
+/// gestures resolve.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void spanScenarios() {
+  // Scope `paints` assertions to the events canvas so surrounding chrome can't
+  // match (mirrors the highlight-column scenario).
+  Finder eventsCanvas() => find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is EventsPainter,
+      );
+
+  PlannerSpec spanningPlanner({
+    void Function(PlannerEntry)? onEntryEdit,
+    void Function(PlannerEntry)? onEntryMove,
+  }) =>
+      PlannerSpec(
+        config: PlannerConfig(
+          labels: const ['c1', 'c2', 'c3'],
+          minHour: 0,
+          maxHour: 23,
+          onEntryEdit: onEntryEdit,
+          onEntryMove: onEntryMove,
+        ),
+        entries: [
+          PlannerEntry(
+            id: 'span',
+            time: PlannerTime(day: 0, endDay: 1, hour: 2, duration: 60),
+            title: 'Conference',
+            content: '',
+            color: const Color(0xFF2244AA),
+          ),
+        ],
+      );
+
+  testWidgets(
+      'a span paints one box across its columns and hit-tests from each',
+      (tester) async {
+    final edited = <String>[];
+
+    await tester.pumpWidget(PlannerHarness(
+      planners: [spanningPlanner(onEntryEdit: (e) => edited.add(e.id))],
+    ));
+    await tester.pumpAndSettle();
+
+    // Default 200x40 grid, no scroll/zoom: the span over columns 0..1 at 02:00
+    // for 60 min draws ONE continuous fill box from x 0..400 at y 80..120 (its
+    // colour is entry.color at alpha 100). A single-column event would only
+    // reach x 200 — the 400-wide box is the spanning behaviour itself.
+    expect(
+      eventsCanvas(),
+      paints
+        ..rect(
+          rect: const Rect.fromLTWH(0, 80, 400, 40),
+          color: const Color(0x642244AA),
+        ),
+    );
+
+    final plannerFinder = find.byKey(PlannerHarness.keyFor(0));
+    final planner = tester.getRect(plannerFinder);
+
+    // Right-click column 1 — the span's NON-start column. Past the hour column
+    // (50) and date row (50), its centre is planner-local (50 + 300, 50 + 100).
+    // The menu must resolve to the span, proving it hit-tests from a column it
+    // covers but does not start in.
+    final inColumn1 = planner.topLeft + const Offset(50 + 300, 50 + 100);
+    await _rightClickEdit(tester, plannerFinder, inColumn1);
+    expect(edited.last, 'span',
+        reason:
+            'the span must hit-test from a column it covers, not just its start');
+  });
+
+  testWidgets('a span is read-only: a long-press drag does not move it',
+      (tester) async {
+    final moved = <String>[];
+
+    await tester.pumpWidget(PlannerHarness(
+      planners: [spanningPlanner(onEntryMove: (e) => moved.add(e.id))],
+    ));
+    await tester.pumpAndSettle();
+
+    final planner = tester.getRect(find.byKey(PlannerHarness.keyFor(0)));
+    // Press on the span (column 0 centre) and try to drag it a full column
+    // right. A draggable event would fire onEntryMove on release; the span must
+    // not (#47 — read-only first cut).
+    final onSpan = planner.topLeft + const Offset(50 + 100, 50 + 100);
+    await longPressDrag(tester, onSpan, const Offset(200, 0));
+
+    expect(moved, isEmpty,
+        reason: 'spanning events cannot be dragged/resized (#47)');
+  });
+}
+
+/// Right-clicks [at] to open the entry context menu, then taps "Edit Event"
+/// (scoped to [planner]) so `onEntryEdit` fires with the event under the click.
+Future<void> _rightClickEdit(
+    WidgetTester tester, Finder planner, Offset at) async {
+  final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.descendant(
+    of: planner,
+    matching: find.text('Edit Event'),
+  ));
+  await tester.pumpAndSettle();
+}

--- a/lib/internal/event.dart
+++ b/lib/internal/event.dart
@@ -17,7 +17,26 @@ class Event {
   PlannerEntry entry;
   final Manager manager;
 
+  /// The event's bounding rectangle in grid space — for a single-column event
+  /// this is its drawn rect; for a spanning event it is the bounding box of all
+  /// its [segmentRects]. Used for the accessibility node's rect and as the drag
+  /// anchor (single-column events only).
   late Rect canvasRect;
+
+  /// The rectangles actually drawn and hit-tested, in grid space. A
+  /// single-column event has exactly one (`== canvasRect`); a spanning event
+  /// (#47) has one per covered column — a single continuous box in
+  /// [SpanOverlap.fullWidth], or one narrowed sub-column box per column in
+  /// [SpanOverlap.split].
+  late List<Rect> segmentRects;
+
+  /// Per-column sub-column placement for a spanning event in
+  /// [SpanOverlap.split], keyed by column index: which sub-column the event got
+  /// in that column's overlap cluster and how many that column was split into.
+  /// Empty for single-column events and for [SpanOverlap.fullWidth] spans (which
+  /// draw across the full column width); [Manager] fills it during layout.
+  final Map<int, ({int index, int count})> _spanColumns = {};
+
   late TextPainter _titlePainter;
   late TextPainter _contentPainter;
   late Paint _fillPaint, _draggedFillPaint;
@@ -40,12 +59,24 @@ class Event {
   }
 
   /// Recomputes the geometry and text wrapping after [columnIndex]/[columnCount]
-  /// change. [Manager] calls this once a day's overlap layout is known, so the
-  /// event occupies its narrowed sub-column instead of the full day-column.
+  /// (or, for a spanning event, its [_spanColumns] placement) change. [Manager]
+  /// calls this once a day's overlap layout is known, so the event occupies its
+  /// narrowed sub-column instead of the full day-column.
   void relayout() {
     _calculateCanvasRect();
     _layoutText();
   }
+
+  /// Records the sub-column ([index] of [count]) this spanning event was given
+  /// in [column]'s overlap cluster ([SpanOverlap.split]). [Manager] calls this
+  /// per covered column while packing; [relayout] then rebuilds the geometry.
+  void setSpanColumn(int column, int index, int count) =>
+      _spanColumns[column] = (index: index, count: count);
+
+  /// Clears any recorded span placement, so the next [relayout] draws the span
+  /// at full column width ([SpanOverlap.fullWidth]). [Manager] calls this before
+  /// re-laying out overlaps.
+  void clearSpanColumns() => _spanColumns.clear();
 
   void _createPaints() {
     _fillPaint = Paint()
@@ -66,8 +97,10 @@ class Event {
 
   void _layoutText() {
     // Text wraps/ellipsizes within the event's actual (possibly narrowed) width,
-    // not the full day-column, so a split event still reads correctly.
-    final width = canvasRect.width;
+    // not the full day-column, so a split event still reads correctly. For a
+    // spanning event that is the start-column segment it renders in, not the
+    // full multi-column bounding box.
+    final width = segmentRects.first.width;
 
     _titlePainter = TextPainter(
       text: TextSpan(text: entry.title, style: entry.titleStyle),
@@ -89,18 +122,64 @@ class Event {
   }
 
   void _calculateCanvasRect() {
-    final blockHeight = manager.config.blockHeight;
-    // Concurrent events share a day-column by splitting it into [columnCount]
-    // equal sub-columns; this event sits in the [columnIndex]th one.
-    final fullWidth = manager.config.blockWidth.toDouble();
-    final columnWidth = fullWidth / columnCount;
-    Offset a = Offset(
-        entry.time.day * fullWidth + columnIndex * columnWidth,
-        (entry.time.hour - manager.config.minHour) * blockHeight +
-            entry.time.minutes / 60 * blockHeight);
-    Offset b = a.translate(columnWidth, entry.time.duration / 60 * blockHeight);
-    canvasRect = Rect.fromPoints(a, b);
+    final config = manager.config;
+    final blockHeight = config.blockHeight;
+    final fullWidth = config.blockWidth.toDouble();
+    final time = entry.time;
+
+    // The vertical extent is the same whatever the column layout: the start
+    // offset derives from blockHeight (not a hardcoded 40, D3) and the minute
+    // offset is proportional (D4).
+    final top = (time.hour - config.minHour) * blockHeight +
+        time.minutes / 60 * blockHeight;
+    final bottom = top + time.duration / 60 * blockHeight;
+
+    if (!time.spansColumns) {
+      // Single column: concurrent events share it by splitting into
+      // [columnCount] equal sub-columns; this event sits in the [columnIndex]th.
+      final columnWidth = fullWidth / columnCount;
+      final left = time.day * fullWidth + columnIndex * columnWidth;
+      canvasRect = Rect.fromLTRB(left, top, left + columnWidth, bottom);
+      segmentRects = [canvasRect];
+      return;
+    }
+
+    // Spanning event (#47). With no recorded placement ([SpanOverlap.fullWidth])
+    // it draws as one continuous box across columns day..lastDay; otherwise
+    // ([SpanOverlap.split]) it draws one rect per column, each narrowed to the
+    // sub-column the day's overlap cluster assigned it.
+    if (_spanColumns.isEmpty) {
+      final left = time.day * fullWidth;
+      final right = (time.lastDay + 1) * fullWidth;
+      segmentRects = [Rect.fromLTRB(left, top, right, bottom)];
+    } else {
+      segmentRects = [
+        for (int day = time.day; day <= time.lastDay; day++)
+          _columnSegment(day, fullWidth, top, bottom),
+      ];
+    }
+    canvasRect = segmentRects.reduce((a, b) => a.expandToInclude(b));
   }
+
+  /// The sub-column rectangle for [day] in a split spanning event: narrowed to
+  /// the placement the day's overlap cluster gave it, defaulting to the full
+  /// column when the day carries no concurrent neighbours.
+  Rect _columnSegment(int day, double fullWidth, double top, double bottom) {
+    final placement = _spanColumns[day];
+    final count = placement?.count ?? 1;
+    final index = placement?.index ?? 0;
+    final columnWidth = fullWidth / count;
+    final left = day * fullWidth + index * columnWidth;
+    return Rect.fromLTRB(left, top, left + columnWidth, bottom);
+  }
+
+  /// Whether [point] (grid space) falls inside any of this event's drawn
+  /// rectangles — the hit-test primitive [Manager.getEventAtPos] uses. For a
+  /// single-column event this is just [canvasRect]; for a spanning event it is
+  /// any covered column's segment, so the event is reachable from any column it
+  /// crosses.
+  bool containsGridPoint(Offset point) =>
+      segmentRects.any((rect) => rect.contains(point));
 
   /// Maps a rect from the grid's coordinate space to on-screen (canvas-local)
   /// coordinates, applying the current scroll offset and time-axis zoom. The
@@ -178,17 +257,31 @@ class Event {
   }
 
   void paint(Canvas canvas) {
-    Rect rect = _getCurrentRect();
-    Rect screenRect = _toScreen(rect);
+    final fillPaint =
+        _dragType == DragType.none ? _fillPaint : _draggedFillPaint;
+    final strokePaint =
+        _dragType == DragType.none ? _strokePaint : _draggedStrokePaint;
 
-    canvas.drawRect(screenRect,
-        _dragType == DragType.none ? _fillPaint : _draggedFillPaint);
-    canvas.drawRect(screenRect,
-        _dragType == DragType.none ? _strokePaint : _draggedStrokePaint);
+    // Fill + stroke every segment. A single-column event has exactly one (its
+    // live rect, carrying any drag offset); a spanning event has one per covered
+    // column (#47) and never drags.
+    final segments = _currentSegments();
+    for (final segment in segments) {
+      final screenSegment = _toScreen(segment);
+      canvas.drawRect(screenSegment, fillPaint);
+      canvas.drawRect(screenSegment, strokePaint);
+    }
 
-    _paintHandle(canvas, rect.topLeft.translate(0.0, 1), rect.width);
-    _paintHandle(canvas, rect.bottomLeft.translate(0.0, -1), rect.width);
+    // Resize handles are a drag/resize affordance; spanning events are read-only
+    // in this first cut (#47), so only single-column events draw them.
+    if (!entry.time.spansColumns) {
+      final rect = segments.first;
+      _paintHandle(canvas, rect.topLeft.translate(0.0, 1), rect.width);
+      _paintHandle(canvas, rect.bottomLeft.translate(0.0, -1), rect.width);
+    }
 
+    // Title/content render in the start-column segment.
+    final Rect screenRect = _toScreen(segments.first);
     Rect clipRect = Rect.fromPoints(
         screenRect.topLeft.translate(2,
             entry.titleStyle.fontSize != null ? entry.titleStyle.fontSize! : 8),
@@ -207,6 +300,13 @@ class Event {
     _contentPainter.paint(canvas, cpos);
     canvas.restore();
   }
+
+  /// The rectangles to draw this frame, in grid space. While a single-column
+  /// event is being dragged its live rect carries the drag offset; otherwise
+  /// every event uses its static [segmentRects] (a spanning event never drags,
+  /// so it always does).
+  List<Rect> _currentSegments() =>
+      _dragType == DragType.none ? segmentRects : [_getCurrentRect()];
 
   Rect _getCurrentRect() {
     Rect result;

--- a/lib/internal/events_painter.dart
+++ b/lib/internal/events_painter.dart
@@ -64,7 +64,11 @@ class EventsPainter extends CustomPainter {
       if (!rect.overlaps(viewport)) continue;
 
       final canEdit = config.onEntryEdit != null;
-      final canMove = config.onEntryMove != null;
+      // Spanning events are read-only in this first cut (#47): they can't be
+      // dragged, so the accessibility move nudges (the keyboard equivalent of a
+      // drag-move) aren't offered for them either. Edit/delete stay available.
+      final canMove =
+          config.onEntryMove != null && !event.entry.time.spansColumns;
 
       nodes.add(CustomPainterSemantics(
         key: ValueKey(event.entry.id),

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -58,11 +58,16 @@ class Manager {
 
   /// Rebuilds the [_eventsByDay] hit-test buckets from the current [events].
   /// One linear pass, called only when the event set or an event's day can have
-  /// changed (build/update and after a drag commits a possible day move).
+  /// changed (build/update and after a drag commits a possible day move). A
+  /// spanning event (#47) is bucketed into every column it covers, so it
+  /// hit-tests from any of them, not just its start column.
   void _rebuildDayIndex() {
     _eventsByDay.clear();
     for (final Event event in events) {
-      _eventsByDay.putIfAbsent(event.entry.time.day, () => []).add(event);
+      final time = event.entry.time;
+      for (int day = time.day; day <= time.lastDay; day++) {
+        _eventsByDay.putIfAbsent(day, () => []).add(event);
+      }
     }
   }
 
@@ -73,17 +78,41 @@ class Manager {
   /// events reuse a column), then every event in a connected overlap cluster is
   /// narrowed to `1 / columns` of the day-column and offset to its own
   /// sub-column — the standard side-by-side calendar layout.
+  ///
+  /// A column-spanning event (#47) is folded into the packing of **every column
+  /// it covers** only under [SpanOverlap.split]; under [SpanOverlap.fullWidth]
+  /// (the default) it is excluded so it draws across the full column width.
+  /// Because a spanning event's placement is gathered across several columns, it
+  /// is relaid out once at the end (single-column events relayout as each cluster
+  /// closes).
   void _layoutOverlaps() {
+    final split = config.spanOverlap == SpanOverlap.split;
     final byDay = <int, List<Event>>{};
     for (final event in events) {
-      byDay.putIfAbsent(event.entry.time.day, () => []).add(event);
+      final time = event.entry.time;
+      if (time.spansColumns) {
+        // Reset any prior placement; an excluded (full-width) span keeps it
+        // empty and draws across all its columns.
+        event.clearSpanColumns();
+        if (!split) continue;
+        for (int day = time.day; day <= time.lastDay; day++) {
+          byDay.putIfAbsent(day, () => []).add(event);
+        }
+      } else {
+        byDay.putIfAbsent(time.day, () => []).add(event);
+      }
     }
-    for (final dayEvents in byDay.values) {
-      _layoutDayColumn(dayEvents);
+    for (final entry in byDay.entries) {
+      _layoutDayColumn(entry.key, entry.value);
+    }
+    // Spanning events depend on placements gathered across all their columns, so
+    // build their geometry only once every column has been packed.
+    for (final event in events) {
+      if (event.entry.time.spansColumns) event.relayout();
     }
   }
 
-  void _layoutDayColumn(List<Event> dayEvents) {
+  void _layoutDayColumn(int day, List<Event> dayEvents) {
     int startOf(Event e) => e.entry.time.hour * 60 + e.entry.time.minutes;
     int endOf(Event e) => startOf(e) + e.entry.time.duration;
 
@@ -94,18 +123,23 @@ class Manager {
     });
 
     // The events of the current connected overlap cluster, the end time of the
-    // last event placed in each of its sub-columns, and the cluster's latest end.
+    // last event placed in each of its sub-columns, the sub-column each event
+    // landed in, and the cluster's latest end. The sub-column is kept in a local
+    // map rather than on the Event, since a spanning event is packed once per
+    // column it crosses and must not clobber its other columns' placements.
     final cluster = <Event>[];
     final columnEnds = <int>[];
+    final columnOf = <Event, int>{};
     int clusterEnd = -1;
 
     void closeCluster() {
+      final count = columnEnds.length;
       for (final event in cluster) {
-        event.columnCount = columnEnds.length;
-        event.relayout();
+        _assignColumn(event, day, columnOf[event]!, count);
       }
       cluster.clear();
       columnEnds.clear();
+      columnOf.clear();
       clusterEnd = -1;
     }
 
@@ -125,12 +159,25 @@ class Manager {
       } else {
         columnEnds[column] = endOf(event);
       }
-      event.columnIndex =
-          column; // columnCount is filled in when the cluster closes
+      columnOf[event] = column; // count is filled in when the cluster closes
       cluster.add(event);
       if (endOf(event) > clusterEnd) clusterEnd = endOf(event);
     }
     closeCluster();
+  }
+
+  /// Applies the packed sub-column ([index] of [count]) to [event] for [day]. A
+  /// single-column event stores it directly and relays out now; a spanning event
+  /// records it per column (relayout is deferred to [_layoutOverlaps] once all
+  /// its columns are packed).
+  void _assignColumn(Event event, int day, int index, int count) {
+    if (event.entry.time.spansColumns) {
+      event.setSpanColumn(day, index, count);
+    } else {
+      event.columnIndex = index;
+      event.columnCount = count;
+      event.relayout();
+    }
   }
 
   Event? _draggedEvent;
@@ -150,6 +197,10 @@ class Manager {
     if (_draggedEvent != null) return;
     final event = getEventAtPos(localPos);
     if (event == null) return;
+    // Spanning events are read-only in this first cut (#47): a long-press on one
+    // starts no drag, so it can't be moved or resized (it stays tappable for
+    // edit/delete via double-tap and the context menu).
+    if (event.entry.time.spansColumns) return;
     _draggedEvent = event;
     event.startDrag(_toGridPos(localPos));
     controller.triggerUpdate.value++;
@@ -221,7 +272,7 @@ class Manager {
     if (candidates == null) return null;
 
     for (final Event event in candidates) {
-      if (event.canvasRect.contains(realPos)) {
+      if (event.containsGridPoint(realPos)) {
         return event;
       }
     }

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -3,6 +3,24 @@ import 'package:flutter/material.dart';
 import 'planner_entry.dart';
 import 'planner_time.dart';
 
+/// How a column-spanning event (one whose [PlannerTime.endDay] covers several
+/// columns, #47) coexists with the per-column overlap layout that splits
+/// concurrent single-column events into side-by-side sub-columns (#20 / D11).
+enum SpanOverlap {
+  /// The spanning event draws as one continuous rectangle across the full width
+  /// of every column it covers, and is **excluded** from the sub-column packing.
+  /// Concurrent single-column events keep their own side-by-side split and may
+  /// visually overlap the span. The default — simplest and the usual look for a
+  /// multi-day banner-style event.
+  fullWidth,
+
+  /// The spanning event takes part in each covered column's overlap cluster,
+  /// reserving a sub-column beside the concurrent single-column events there.
+  /// Because the sub-column it gets can differ per column, the span is drawn as
+  /// one rectangle per column rather than a single continuous box.
+  split,
+}
+
 class PlannerConfig {
   List<String> labels;
 
@@ -74,6 +92,13 @@ class PlannerConfig {
   /// `DateTime` enters the public API. An out-of-range index highlights nothing.
   int? highlightedColumn;
 
+  /// How column-spanning events (those whose [PlannerTime.endDay] covers several
+  /// columns, #47) coexist with the per-column overlap split (#20). Defaults to
+  /// [SpanOverlap.fullWidth] — the span draws as one continuous box across its
+  /// columns; switch to [SpanOverlap.split] to fold it into each column's
+  /// sub-column layout instead. Has no effect on single-column events.
+  SpanOverlap spanOverlap;
+
   /// Fill colour painted across the [highlightedColumn], behind the grid lines
   /// and events. Defaults to a subtle translucent white wash so setting
   /// [highlightedColumn] alone is visible on the default dark [plannerBackground];
@@ -131,6 +156,7 @@ class PlannerConfig {
     this.contextMenuCreateLabel = 'Create Event',
     this.contextMenuEditLabel = 'Edit Event',
     this.contextMenuDeleteLabel = 'Delete Event',
+    this.spanOverlap = SpanOverlap.fullWidth,
     this.highlightedColumn,
     this.highlightColumnColor = const Color.fromARGB(40, 255, 255, 255),
     this.hourBackground = Colors.white,

--- a/lib/planner_time.dart
+++ b/lib/planner_time.dart
@@ -2,23 +2,53 @@
 /// `PlannerConfig.labels` — there are no calendar dates here), a start [hour]
 /// and [minutes], and a [duration] in minutes.
 ///
+/// An event may also **span columns** (#47): when [endDay] is set to a column
+/// index after [day], the event renders across the whole `day..endDay` range
+/// (a multi-day / multi-column event). This stays index-based — no `DateTime`
+/// enters the model (ADR 0001). [endDay] of `null` (or any value `<= day`) is a
+/// single-column event, the default.
+///
 /// Immutable (#27): every field is `final`, so a drag/resize or accessibility
 /// nudge produces a *new* instance via [copyWith] rather than mutating in place,
 /// which keeps diffing predictable and lets value [==] decide when anything
 /// actually changed.
 class PlannerTime {
   final int day;
+
+  /// Last column the event covers, inclusive. `null` (or `<= day`) means the
+  /// event occupies the single column [day]. When greater than [day] the event
+  /// spans the columns `day..endDay` — see [lastDay] / [columnSpan] for the
+  /// normalized values the geometry uses.
+  final int? endDay;
+
   final int hour;
   final int minutes;
   final int duration;
 
   PlannerTime(
-      {this.day = 0, this.hour = 0, this.minutes = 0, this.duration = 60});
+      {this.day = 0,
+      this.endDay,
+      this.hour = 0,
+      this.minutes = 0,
+      this.duration = 60});
+
+  /// The last column the event covers, inclusive and never before [day]: the
+  /// raw [endDay] when it lies after [day], otherwise [day] itself. Geometry and
+  /// hit-testing iterate `day..lastDay`.
+  int get lastDay => (endDay != null && endDay! > day) ? endDay! : day;
+
+  /// How many columns the event covers (`1` for a single-column event).
+  int get columnSpan => lastDay - day + 1;
+
+  /// Whether the event covers more than one column (a spanning event).
+  bool get spansColumns => columnSpan > 1;
 
   /// Returns a copy with the given fields replaced; omitted fields are kept.
-  PlannerTime copyWith({int? day, int? hour, int? minutes, int? duration}) =>
+  PlannerTime copyWith(
+          {int? day, int? endDay, int? hour, int? minutes, int? duration}) =>
       PlannerTime(
         day: day ?? this.day,
+        endDay: endDay ?? this.endDay,
         hour: hour ?? this.hour,
         minutes: minutes ?? this.minutes,
         duration: duration ?? this.duration,
@@ -29,14 +59,15 @@ class PlannerTime {
       identical(this, other) ||
       other is PlannerTime &&
           other.day == day &&
+          other.endDay == endDay &&
           other.hour == hour &&
           other.minutes == minutes &&
           other.duration == duration;
 
   @override
-  int get hashCode => Object.hash(day, hour, minutes, duration);
+  int get hashCode => Object.hash(day, endDay, hour, minutes, duration);
 
   @override
   String toString() =>
-      'PlannerTime(day: $day, hour: $hour, minutes: $minutes, duration: $duration)';
+      'PlannerTime(day: $day, endDay: $endDay, hour: $hour, minutes: $minutes, duration: $duration)';
 }

--- a/test/event_span_test.dart
+++ b/test/event_span_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+
+void main() {
+  // Column-spanning events (#47): a PlannerTime may set endDay after day, and
+  // the event then renders across the whole day..endDay column range. The span
+  // stays index-based (no DateTime; ADR 0001) and is read-only in this first
+  // cut. SpanOverlap controls how it coexists with the per-column overlap split.
+
+  const blockWidth = 200; // PlannerConfig default
+  const blockHeight = 40; // PlannerConfig default
+
+  Manager managerWith(
+    List<PlannerEntry> entries, {
+    SpanOverlap spanOverlap = SpanOverlap.fullWidth,
+    List<String> labels = const ['A', 'B', 'C'],
+  }) =>
+      Manager(
+        config: PlannerConfig(
+          labels: labels,
+          minHour: 0,
+          spanOverlap: spanOverlap,
+        ),
+        entries: entries,
+      );
+
+  PlannerEntry entryAt(String id, PlannerTime time) => PlannerEntry(
+        id: id,
+        time: time,
+        title: id,
+        content: '',
+        color: const Color(0xFF112233),
+      );
+
+  Rect rectFor(
+          {required int day,
+          required int endColExclusive,
+          required int hour}) =>
+      Rect.fromLTRB(
+        day * blockWidth.toDouble(),
+        hour * blockHeight.toDouble(),
+        endColExclusive * blockWidth.toDouble(),
+        (hour + 1) * blockHeight.toDouble(),
+      );
+
+  group('PlannerTime span helpers', () {
+    test('endDay null is a single column (the default)', () {
+      final t = PlannerTime(day: 1, hour: 9);
+      expect(t.lastDay, 1);
+      expect(t.columnSpan, 1);
+      expect(t.spansColumns, isFalse);
+    });
+
+    test('endDay after day spans the inclusive range', () {
+      final t = PlannerTime(day: 1, endDay: 3, hour: 9);
+      expect(t.lastDay, 3);
+      expect(t.columnSpan, 3);
+      expect(t.spansColumns, isTrue);
+    });
+
+    test('endDay equal to or before day stays a single column', () {
+      expect(PlannerTime(day: 2, endDay: 2).spansColumns, isFalse);
+      final before = PlannerTime(day: 2, endDay: 1);
+      expect(before.lastDay, 2); // never before day
+      expect(before.spansColumns, isFalse);
+    });
+
+    test('copyWith carries endDay, and value equality includes it', () {
+      final base = PlannerTime(day: 0, endDay: 2, hour: 9);
+      expect(base.copyWith(hour: 10).endDay, 2);
+      expect(PlannerTime(day: 0, endDay: 2),
+          equals(PlannerTime(day: 0, endDay: 2)));
+      expect(PlannerTime(day: 0, endDay: 2),
+          isNot(equals(PlannerTime(day: 0, endDay: 3))));
+      expect(PlannerTime(day: 0, endDay: 2).hashCode,
+          PlannerTime(day: 0, endDay: 2).hashCode);
+    });
+  });
+
+  group('fullWidth geometry (the default)', () {
+    test('a spanning event is one continuous box across its columns', () {
+      final event = managerWith([
+        entryAt('s', PlannerTime(day: 0, endDay: 2, hour: 9, duration: 60)),
+      ]).events.single;
+
+      expect(event.segmentRects.length, 1, reason: 'one continuous box');
+      expect(event.segmentRects.single,
+          rectFor(day: 0, endColExclusive: 3, hour: 9));
+      // canvasRect (the a11y/anchor bounding box) matches the single segment.
+      expect(event.canvasRect, rectFor(day: 0, endColExclusive: 3, hour: 9));
+    });
+
+    test('a single-column event is unchanged (one full-column segment)', () {
+      final event = managerWith([
+        entryAt('x', PlannerTime(day: 1, hour: 9, duration: 60)),
+      ]).events.single;
+
+      expect(event.segmentRects, [event.canvasRect]);
+      expect(event.canvasRect, rectFor(day: 1, endColExclusive: 2, hour: 9));
+    });
+
+    test('a concurrent single-column event keeps full width under a span', () {
+      // In fullWidth the span is excluded from packing, so the single-column
+      // event is NOT narrowed — it stays a full column (and may overlap the span).
+      final manager = managerWith([
+        entryAt('s', PlannerTime(day: 0, endDay: 2, hour: 9, duration: 60)),
+        entryAt('x', PlannerTime(day: 1, hour: 9, duration: 60)),
+      ]);
+      final x = manager.events.firstWhere((e) => e.entry.id == 'x');
+      expect(x.columnCount, 1);
+      expect(x.canvasRect, rectFor(day: 1, endColExclusive: 2, hour: 9));
+    });
+  });
+
+  group('split geometry', () {
+    test('a span folds into each crossed column\'s overlap cluster', () {
+      // Span over columns 0..2 at 09:00, plus a concurrent single-column event
+      // in column 1. Column 1 splits in two; columns 0 and 2 (no neighbour) stay
+      // full width — so the span draws one rect per column, narrowed only where
+      // it shares the column.
+      final manager = managerWith(
+        [
+          entryAt('s', PlannerTime(day: 0, endDay: 2, hour: 9, duration: 60)),
+          entryAt('x', PlannerTime(day: 1, hour: 9, duration: 60)),
+        ],
+        spanOverlap: SpanOverlap.split,
+      );
+      final s = manager.events.firstWhere((e) => e.entry.id == 's');
+      final x = manager.events.firstWhere((e) => e.entry.id == 'x');
+
+      expect(s.segmentRects.length, 3, reason: 'one rect per covered column');
+      // Column 0: full width.
+      expect(s.segmentRects[0], rectFor(day: 0, endColExclusive: 1, hour: 9));
+      // Column 1: left sub-column of two (the span sorts first, so takes left).
+      expect(s.segmentRects[1], const Rect.fromLTRB(200, 360, 300, 400));
+      // Column 2: full width.
+      expect(s.segmentRects[2], rectFor(day: 2, endColExclusive: 3, hour: 9));
+
+      // The single-column neighbour is narrowed to the right sub-column.
+      expect(x.columnIndex, 1);
+      expect(x.columnCount, 2);
+      expect(x.canvasRect, const Rect.fromLTRB(300, 360, 400, 400));
+
+      // The span's bounding box still covers the whole range.
+      expect(s.canvasRect, rectFor(day: 0, endColExclusive: 3, hour: 9));
+    });
+  });
+
+  group('hit-testing reaches a span from any column it covers', () {
+    Offset at(double gridX, int hour) =>
+        Offset(gridX, hour * blockHeight + blockHeight / 2);
+
+    test('fullWidth: a tap in a non-start column resolves to the span', () {
+      final manager = managerWith([
+        entryAt('s', PlannerTime(day: 0, endDay: 2, hour: 9, duration: 60)),
+      ]);
+      // Column 2 (start column is 0): the span must still be found there.
+      expect(manager.getEventAtPos(at(500, 9))?.entry.id, 's');
+      expect(manager.getEventAtPos(at(100, 9))?.entry.id, 's');
+    });
+
+    test('split: each sub-column resolves to the event sitting there', () {
+      final manager = managerWith(
+        [
+          entryAt('s', PlannerTime(day: 0, endDay: 2, hour: 9, duration: 60)),
+          entryAt('x', PlannerTime(day: 1, hour: 9, duration: 60)),
+        ],
+        spanOverlap: SpanOverlap.split,
+      );
+      // Column 1 left half -> span; right half -> single-column neighbour.
+      expect(manager.getEventAtPos(at(250, 9))?.entry.id, 's');
+      expect(manager.getEventAtPos(at(350, 9))?.entry.id, 'x');
+      // Column 2 (full-width span segment) -> span.
+      expect(manager.getEventAtPos(at(500, 9))?.entry.id, 's');
+    });
+  });
+
+  group('spanning events are read-only (#47)', () {
+    Offset at(double gridX, int hour) =>
+        Offset(gridX, hour * blockHeight + blockHeight / 2);
+
+    test('a long-press on a span starts no drag', () {
+      final manager = managerWith([
+        entryAt('s', PlannerTime(day: 0, endDay: 2, hour: 9, duration: 60)),
+      ]);
+      manager.startDrag(at(100, 9));
+      expect(manager.draggedEvent, isNull,
+          reason: 'spanning events cannot be dragged/resized');
+    });
+
+    test('a single-column event still starts a drag (control)', () {
+      final manager = managerWith([
+        entryAt('x', PlannerTime(day: 0, hour: 9, duration: 60)),
+      ]);
+      manager.startDrag(at(100, 9));
+      expect(manager.draggedEvent?.entry.id, 'x');
+    });
+  });
+}

--- a/test/public_api_test.dart
+++ b/test/public_api_test.dart
@@ -10,11 +10,20 @@ import 'package:planner/planner.dart';
 void main() {
   group('public API surface (single umbrella import)', () {
     test('PlannerTime is reachable via package:planner/planner.dart', () {
-      final time = PlannerTime(day: 1, hour: 9, minutes: 30, duration: 45);
+      final time =
+          PlannerTime(day: 1, endDay: 3, hour: 9, minutes: 30, duration: 45);
       expect(time.day, 1);
+      expect(time.endDay, 3); // column span (#47)
       expect(time.hour, 9);
       expect(time.minutes, 30);
       expect(time.duration, 45);
+    });
+
+    test('SpanOverlap and the config field are reachable', () {
+      final config =
+          PlannerConfig(labels: const ['Mon'], spanOverlap: SpanOverlap.split);
+      expect(config.spanOverlap, SpanOverlap.split);
+      expect(SpanOverlap.values, hasLength(2));
     });
 
     test('PlannerEntry, PlannerConfig and Planner are reachable too', () {


### PR DESCRIPTION
## Summary

Lets a `PlannerEntry` render across a **range of columns** (multi-day / multi-column rendering), the widget-level primitive spun out of the #19 time-model decision (ADR 0001: keep the day-index model — no `DateTime`). Set `PlannerTime.endDay` to a column index after `day` and the event draws across the whole `day..endDay` range. `null` (the default) or any value `<= day` is a single-column event, so **existing entries are unaffected**.

Per the scoping decisions on the issue:
- **Read-only first cut** — spanning events can't be dragged or resized (single-column events keep full drag/resize). They stay tappable for edit/delete. Span drag/resize is deferred.
- **Overlap behavior is a config option** — `PlannerConfig.spanOverlap`:
  - `SpanOverlap.fullWidth` (default): the span draws as one continuous box across its columns, excluded from the per-column sub-column packing.
  - `SpanOverlap.split`: the span folds into each crossed column's overlap cluster, reserving a sub-column beside concurrent single-column events (drawn as one rect per column).

## Linked issue

Closes #47

## Changes

- **Model** — `PlannerTime` gains optional `endDay` + `lastDay`/`columnSpan`/`spansColumns` helpers; `copyWith`/`==`/`hashCode`/`toString` updated.
- **Config** — new `SpanOverlap { fullWidth, split }` enum + `PlannerConfig.spanOverlap` (default `fullWidth`).
- **Geometry** — `Event` now carries `segmentRects` (one box for `fullWidth`, one per column for `split`); `containsGridPoint` hit-tests every segment; resize handles are skipped on spans.
- **Layout / hit-test** — `Manager._layoutOverlaps` folds spans into each crossed column under `split` (excludes them under `fullWidth`); hit-test buckets index a span into every column it covers; `startDrag` is a no-op on a span (read-only guard).
- **A11y** — spans keep edit/delete actions but drop the move-nudge (mirrors no-drag).
- **Scroll edges** — handled by the existing viewport `ClipRect`, same as single-column events (no special-casing).
- **Docs** — CHANGELOG, PROJECT_OVERVIEW (#47 ticked), ADR 0001, and the integration-test README updated.

## Test plan

- [x] `flutter analyze` clean
- [x] `dart format --set-exit-if-changed` clean
- [x] unit/widget tests pass (`flutter test`) — **116 pass**; 14 new in `test/event_span_test.dart` (span helpers, fullWidth + split geometry, cross-column & sub-column hit-test, read-only guard) + 2 in `public_api_test.dart`
- [x] integration/e2e tests pass (`flutter test integration_test -d windows` from `example/`) — **19 scenarios pass**; 2 new in `span_scenarios.dart` drive the real composed app: a span paints one box across its columns, hit-tests from a non-start column via real right-click, and ignores a real long-press drag (read-only)
- [x] regression confirmed: removing the read-only guard makes the span draggable and **both** the unit and e2e read-only tests fail; restored and re-verified green