### PR TITLE
fix: horizontal pan snaps columns right when grid is narrower than viewport (#64)

### DIFF
--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -81,6 +81,9 @@ class Controller {
     _maxYOffset = 0 -
         (((config.blockHeight * zoom) * (config.maxHour - config.minHour + 1) -
             (_canvasHeight - config.dateRowHeight)));
+    if (_maxXOffset > 0) {
+      _maxXOffset = 0;
+    }
     if (_maxYOffset > 0) {
       _maxYOffset = 0;
     }

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/internal/controller.dart';
 import 'package:planner/planner.dart';
@@ -106,6 +107,35 @@ void main() {
   // Regression for D12 (#28): verticalScroll used a fixed 20px step, so one wheel
   // notch moved progressively less *time* the further you zoomed in (each hour
   // row is `blockHeight * zoom` px tall). The step now scales with zoom.
+  // Regression for #64: when the grid is narrower than the canvas,
+  // _maxXOffset was positive, so any horizontal drag snapped x to that positive
+  // value — pushing columns to the far right.  The guard now clamps it to 0.
+  group('horizontal pan is a no-op when grid is narrower than viewport (#64)',
+      () {
+    Controller wideViewport() {
+      // 3 labels × blockWidth 200 = 600 px of grid; canvas is 1600 px wide.
+      final c = Controller(
+        PlannerConfig(labels: const ['A', 'B', 'C'], blockWidth: 200),
+      );
+      c.setSize(const Size(1600, 900));
+      return c;
+    }
+
+    test('x stays 0 after a left drag', () {
+      final c = wideViewport();
+      c.startHorizontalDrag(100);
+      c.updateHorizontalDrag(80); // drag left 20 px
+      expect(c.x, 0, reason: 'grid is fully visible — no horizontal pan');
+    });
+
+    test('x stays 0 after a right drag', () {
+      final c = wideViewport();
+      c.startHorizontalDrag(100);
+      c.updateHorizontalDrag(200); // drag right 100 px
+      expect(c.x, 0, reason: 'cannot pan right past x=0');
+    });
+  });
+
   group('verticalScroll step scales with zoom (D12, #28)', () {
     test('at zoom 1 one notch moves by the base scrollStep (default 20)', () {
       final controller = Controller(makeConfig());


### PR DESCRIPTION
## Summary

- `_calculateOffsets()` could produce a positive `_maxXOffset` when the total grid width was less than the canvas width, causing any horizontal drag to snap day-columns to the right edge.
- Added the missing X-axis guard (mirrors the existing Y-axis guard): `if (_maxXOffset > 0) { _maxXOffset = 0; }`.

## Linked issue

Closes #64

## Changes

- `lib/internal/controller.dart` — one-line guard in `_calculateOffsets()`
- `test/controller_test.dart` — two regression tests (left drag and right drag stay at x=0 when grid < viewport)

## Test plan

- [x] `flutter analyze` clean
- [x] 116 unit/widget tests pass (`flutter test`)
- [x] No integration tests added — this is a pure controller-layer fix with no user-visible rendering path; the regression is fully exercised by the unit tests which drive `startHorizontalDrag`/`updateHorizontalDrag` directly against a wide viewport.