### PR TITLE
Outlook-style direct manipulation: immediate drag-move/resize, 2D pan, wheel modifiers (#65)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -19,10 +19,15 @@ and a `List<`[`PlannerEntry`](lib/planner_entry.dart)`>`, and it paints a grid o
 columns (one per label) with horizontal hour lines, then draws each event as a
 rectangle positioned by time. The user can:
 
-- **Pan horizontally** to move across day-columns.
-- **Pan / mouse-wheel scroll vertically** to move across hours.
-- **Zoom** the time axis via pinch or the on-canvas +/- buttons.
-- **Long-press + drag** an event to move it, or drag its top/bottom handle to resize.
+- **Pan** the canvas by dragging empty space — both axes at once (#65) — or pan
+  a single axis via the date row / hour gutter.
+- **Mouse wheel:** plain wheel scrolls the time axis, `Shift`+wheel scrolls the
+  day axis, `Ctrl`+wheel zooms (#65).
+- **Zoom** the time axis via pinch, `Ctrl`+wheel, or the on-canvas +/- buttons.
+- **Desktop drag-to-edit (#65):** press an event body and drag to move it, or
+  drag its top/bottom edge to resize — immediately, no long-press. Hovering shows
+  a `move` / `resizeUpDown` cursor as the cue. On **touch**, a one-finger drag
+  pans; event move/resize is reserved for the `onEntryLongPress` callback (#66).
 - **Double-tap / right-click** to open a context menu that fires
   `onEntryCreate` / `onEntryEdit` / `onEntryDelete` / `onEntryMove` callbacks.
 

--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -8,13 +8,14 @@ surface) can miss rendering/geometry bugs.
 |------|----------------|
 | [`app_test.dart`](app_test.dart) | The single entry point. Registers every scenario so the whole suite runs in **one** app launch (desktop can only launch one app per `flutter test` invocation). |
 | [`app_smoke_scenarios.dart`](app_smoke_scenarios.dart) | Boots the real example app; asserts a `Planner` renders and the real secondary-tap menu opens. |
-| [`drag_scenarios.dart`](drag_scenarios.dart) | Long-press-dragging an event moves it and fires `onEntryMove` with no paint-phase side effects (device-level counterpart of the #11 / D5 regression). |
+| [`drag_scenarios.dart`](drag_scenarios.dart) | Mouse-dragging an event body moves it, and dragging its top edge resizes it; both fire `onEntryMove` with no paint-phase side effects (device-level counterpart of the #11 / D5 regression). |
+| [`direct_manipulation_scenarios.dart`](direct_manipulation_scenarios.dart) | Outlook-style direct manipulation (#65): desktop hover cursors (move over a body, resize over an edge, basic over empty), and a one-finger touch drag pans rather than moving the event. |
 | [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
 | [`hour_label_scenarios.dart`](hour_label_scenarios.dart) | The default `maxHour` (23) clamps a below-grid tap to hour 23, not the invalid 24 (#13 / D10). |
 | [`snapping_scenarios.dart`](snapping_scenarios.dart) | Create and drag snap event times to the single configurable `snapMinutes` interval, and agree (#14 / D8). |
-| [`span_scenarios.dart`](span_scenarios.dart) | A column-spanning event (`PlannerTime.endDay`) paints one box across its columns, hit-tests from any column it covers, and is read-only — a long-press drag doesn't move it (#47). |
+| [`span_scenarios.dart`](span_scenarios.dart) | A column-spanning event (`PlannerTime.endDay`) paints one box across its columns, hit-tests from any column it covers, and is read-only — dragging it doesn't move it (#47). |
 | [`multi_planner_scenarios.dart`](multi_planner_scenarios.dart) | Two planners on one screen keep independent scroll state (device-level counterpart of the #9 / D1 regression). |
-| [`planner_harness.dart`](planner_harness.dart) | Reusable `PlannerHarness` for multi-planner / multi-config flows, plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`, `longPressDrag`). |
+| [`planner_harness.dart`](planner_harness.dart) | Reusable `PlannerHarness` for multi-planner / multi-config flows, plus shared gesture helpers (`gridPointFor`, `createViaMenu`, `wheelScroll`, `mouseDrag`). |
 
 ## Running
 

--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -10,6 +10,7 @@ surface) can miss rendering/geometry bugs.
 | [`app_smoke_scenarios.dart`](app_smoke_scenarios.dart) | Boots the real example app; asserts a `Planner` renders and the real secondary-tap menu opens. |
 | [`drag_scenarios.dart`](drag_scenarios.dart) | Mouse-dragging an event body moves it, and dragging its top edge resizes it; both fire `onEntryMove` with no paint-phase side effects (device-level counterpart of the #11 / D5 regression). |
 | [`direct_manipulation_scenarios.dart`](direct_manipulation_scenarios.dart) | Outlook-style direct manipulation (#65): desktop hover cursors (move over a body, resize over an edge, basic over empty), and a one-finger touch drag pans rather than moving the event. |
+| [`pan_zoom_scenarios.dart`](pan_zoom_scenarios.dart) | 2D pan and wheel modifiers (#65): dragging empty canvas pans both axes; Shift+wheel scrolls the day axis; Ctrl+wheel zooms. |
 | [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
 | [`hour_label_scenarios.dart`](hour_label_scenarios.dart) | The default `maxHour` (23) clamps a below-grid tap to hour 23, not the invalid 24 (#13 / D10). |
 | [`snapping_scenarios.dart`](snapping_scenarios.dart) | Create and drag snap event times to the single configurable `snapMinutes` interval, and agree (#14 / D8). |

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -12,6 +12,7 @@ import 'highlight_column_scenarios.dart';
 import 'hour_label_scenarios.dart';
 import 'multi_planner_scenarios.dart';
 import 'overlap_scenarios.dart';
+import 'pan_zoom_scenarios.dart';
 import 'snapping_scenarios.dart';
 import 'span_scenarios.dart';
 import 'zoom_scenarios.dart';
@@ -38,6 +39,7 @@ void main() {
   hourLabelScenarios();
   multiPlannerScenarios();
   overlapScenarios();
+  panZoomScenarios();
   snappingScenarios();
   spanScenarios();
   zoomScenarios();

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -4,6 +4,7 @@ import 'accessibility_scenarios.dart';
 import 'app_smoke_scenarios.dart';
 import 'context_menu_labels_scenarios.dart';
 import 'context_menu_scenarios.dart';
+import 'direct_manipulation_scenarios.dart';
 import 'double_tap_scenarios.dart';
 import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
@@ -29,6 +30,7 @@ void main() {
   appSmokeScenarios();
   contextMenuLabelsScenarios();
   contextMenuScenarios();
+  directManipulationScenarios();
   doubleTapScenarios();
   dragScenarios();
   eventGeometryScenarios();

--- a/example/integration_test/direct_manipulation_scenarios.dart
+++ b/example/integration_test/direct_manipulation_scenarios.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/events_painter.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guards for the Outlook-style direct-manipulation model (#65):
+///
+///  * a desktop mouse hovering an event shows the cursor that matches what a
+///    press would do — `move` over the body, `resizeUpDown` over the top/bottom
+///    edge, `basic` over empty space (the discoverability cue for drag/resize);
+///  * a one-finger **touch** drag pans rather than moving the event, so
+///    scrolling stays possible and touch move/resize is left to the companion
+///    long-press callback (#66) — it must not fire `onEntryMove`.
+///
+/// Hover cursors and gesture-kind routing live in the real composed widget
+/// (MouseRegion hit-testing, the scale recognizer's device check), which an
+/// isolated widget test with no real pointer devices can miss, so these drive
+/// the real app.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void directManipulationScenarios() {
+  // The events-canvas MouseRegion is the closest MouseRegion ancestor of the
+  // events CustomPaint, so its cursor is the one the planner drives on hover.
+  MouseCursor canvasCursor(WidgetTester tester) {
+    final region = find
+        .ancestor(
+          of: find.byWidgetPredicate(
+            (w) => w is CustomPaint && w.painter is EventsPainter,
+          ),
+          matching: find.byType(MouseRegion),
+        )
+        .first;
+    return tester.widget<MouseRegion>(region).cursor;
+  }
+
+  PlannerSpec hostWith({void Function(PlannerEntry)? onEntryMove}) =>
+      PlannerSpec(
+        config: PlannerConfig(
+          labels: const ['c1', 'c2', 'c3'],
+          minHour: 0,
+          maxHour: 23,
+          onEntryMove: onEntryMove,
+        ),
+        entries: [
+          PlannerEntry(
+            id: 'evt',
+            time: PlannerTime(day: 0, hour: 4),
+            title: 'Touch me',
+            content: '',
+            color: const Color(0xFF2244AA),
+          ),
+        ],
+      );
+
+  testWidgets('hovering shows move over the body and resize over the edges',
+      (tester) async {
+    await tester.pumpWidget(PlannerHarness(planners: [hostWith()]));
+    await tester.pumpAndSettle();
+
+    // The event sits at day 0 / hour 4 -> grid rect (0,160)-(200,200) with the
+    // default 200x40 blocks. On screen it is offset by the hour column (50) and
+    // date row (50).
+    final origin = tester.getRect(find.byType(Planner)).topLeft;
+    final body = origin + const Offset(50 + 100, 50 + 180); // 20px inside top
+    final topEdge = origin + const Offset(50 + 100, 50 + 162); // <8px from top
+    final empty = origin + const Offset(50 + 100, 50 + 20); // above the event
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: empty);
+    await tester.pump();
+    expect(canvasCursor(tester), SystemMouseCursors.basic,
+        reason: 'empty space gets the default cursor');
+
+    await mouse.moveTo(body);
+    await tester.pump();
+    expect(canvasCursor(tester), SystemMouseCursors.move,
+        reason: 'the body offers a move');
+
+    await mouse.moveTo(topEdge);
+    await tester.pump();
+    expect(canvasCursor(tester), SystemMouseCursors.resizeUpDown,
+        reason: 'the top edge offers a resize');
+
+    await mouse.moveTo(empty);
+    await tester.pump();
+    expect(canvasCursor(tester), SystemMouseCursors.basic,
+        reason: 'leaving the event restores the default cursor');
+  });
+
+  testWidgets('a one-finger touch drag pans and does not move the event',
+      (tester) async {
+    final moved = <PlannerEntry>[];
+
+    await tester.pumpWidget(
+        PlannerHarness(planners: [hostWith(onEntryMove: moved.add)]));
+    await tester.pumpAndSettle();
+
+    // Press the event body (its centre) and drag with a finger. On touch a
+    // one-finger drag always pans (move/resize is reserved for #66), so the
+    // event must not move.
+    final center =
+        tester.getRect(find.byType(Planner)).topLeft + const Offset(150, 230);
+    final gesture =
+        await tester.startGesture(center, kind: PointerDeviceKind.touch);
+    await tester.pump();
+    await gesture.moveBy(const Offset(0, 40));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(moved, isEmpty,
+        reason: 'a touch drag pans the canvas; it does not move the event');
+  });
+}

--- a/example/integration_test/drag_scenarios.dart
+++ b/example/integration_test/drag_scenarios.dart
@@ -12,14 +12,14 @@ import 'planner_harness.dart';
 /// gesture handlers, so the same flow is safe.
 ///
 /// This drives the *real* composed widget (real layout, real fonts, real
-/// long-press recognition over the competing pan/scale recognizers) and uses a
-/// stateful host whose `onEntryMove` rebuilds — exactly the pattern that crashed
-/// on the old paint-side-effect code.
+/// mouse drag-move/resize over the competing pan/zoom/tap recognizers) and uses
+/// a stateful host whose `onEntryMove` rebuilds — exactly the pattern that
+/// crashed on the old paint-side-effect code.
 ///
 /// Registered from [app_test.dart]; not a standalone entry point (desktop can
 /// only launch one app per `flutter test` invocation).
 void dragScenarios() {
-  testWidgets('long-press dragging an event moves it and fires onEntryMove',
+  testWidgets('dragging an event body moves it and fires onEntryMove',
       (tester) async {
     final moved = <PlannerEntry>[];
 
@@ -34,7 +34,7 @@ void dragScenarios() {
         tester.getRect(find.byType(Planner)).topLeft + const Offset(150, 230);
 
     // Drag down exactly one block (40px == 1 hour): hour 4 -> hour 5.
-    await longPressDrag(tester, center, const Offset(0, 40));
+    await mouseDrag(tester, center, const Offset(0, 40));
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull,
@@ -44,6 +44,35 @@ void dragScenarios() {
     expect(moved.single.time.day, 0);
     expect(moved.single.time.hour, 5,
         reason: 'a one-block drag advances the event one hour');
+  });
+
+  testWidgets('dragging an event top edge resizes it and fires onEntryMove',
+      (tester) async {
+    final moved = <PlannerEntry>[];
+
+    await tester.pumpWidget(_DragHostApp(onMoved: moved.add));
+    await tester.pumpAndSettle();
+
+    // Same event: grid rect (0,160)-(200,200), so its top edge is at screen
+    // planner-local y 50 (date row) + 160 = 210, x in column 0. Press 2px inside
+    // the top (y 212), within the 8px top-handle zone, and drag the top up one
+    // block: 04:00 -> 03:00, with the bottom (05:00) fixed, so the duration grows
+    // from 60 to 120 minutes. (The committed start derives from canvasRect.top +
+    // the drag offset, so the exact press point within the handle doesn't matter.)
+    final topEdge =
+        tester.getRect(find.byType(Planner)).topLeft + const Offset(150, 212);
+
+    await mouseDrag(tester, topEdge, const Offset(0, -40));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(moved, hasLength(1),
+        reason: 'the resize committed exactly one move');
+    expect(moved.single.time.hour, 3,
+        reason: 'dragging the top edge up one block moves the start to 03:00');
+    expect(moved.single.time.duration, 120,
+        reason:
+            'the bottom edge stays put, so the duration grows to two hours');
   });
 }
 

--- a/example/integration_test/pan_zoom_scenarios.dart
+++ b/example/integration_test/pan_zoom_scenarios.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guards for the 2D pan and mouse-wheel modifiers of the
+/// direct-manipulation model (#65):
+///
+///  * dragging empty canvas pans **both** axes (the day axis used to be the only
+///    one a body drag could pan);
+///  * plain wheel scrolls the time axis (unchanged), Shift+wheel scrolls the day
+///    axis, Ctrl+wheel zooms.
+///
+/// Each effect is observed through the real create-menu time mapping
+/// (`getTimeAtPos`, which reads the live scroll/zoom): where a fixed screen point
+/// lands *after* the gesture reveals how the view moved. The gesture runs
+/// *before* any menu is opened — a context menu leaves a lingering overlay that
+/// would otherwise swallow the drag/wheel (see `multi_planner_scenarios`). This
+/// drives the real composed widget so the gesture routing (recognizer + wheel
+/// modifiers) is exercised, not just the controller maths.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void panZoomScenarios() {
+  // A grid much larger than any test window in both axes, so panning/scrolling
+  // is never clamped to zero: blockWidth 200 × 40 columns and blockHeight 60 ×
+  // 24 hours.
+  PlannerSpec bigGrid({void Function(PlannerTime)? onEntryCreate}) =>
+      PlannerSpec(
+        config: PlannerConfig(
+          labels: List.generate(40, (i) => 'c$i'),
+          minHour: 0,
+          maxHour: 23,
+          blockHeight: 60,
+          onEntryCreate: onEntryCreate,
+        ),
+      );
+
+  testWidgets('dragging empty canvas pans both the day and time axes',
+      (tester) async {
+    PlannerTime? created;
+    await tester.pumpWidget(
+        PlannerHarness(planners: [bigGrid(onEntryCreate: (t) => created = t)]));
+    await tester.pumpAndSettle();
+
+    final planner = find.byKey(PlannerHarness.keyFor(0));
+    final rect = tester.getRect(planner);
+
+    // At rest a fixed probe maps to a known cell. Events-local (150,150):
+    // day floor(150/200)=0, hour floor(150/60)=2. We assert against that
+    // analytic baseline rather than an extra create (which would open a menu and
+    // block the drag below).
+    final probe = rect.topLeft + const Offset(50 + 150, 50 + 150);
+
+    // Drag empty canvas up-and-left so later columns and later hours scroll into
+    // view. Several small steps: the scale recognizer starts only after the pan
+    // slop, so the first step seeds the drag and the rest pan ~150px per axis.
+    final from = rect.topLeft + const Offset(50 + 500, 50 + 350);
+    final gesture =
+        await tester.startGesture(from, kind: PointerDeviceKind.mouse);
+    await tester.pump();
+    for (var i = 0; i < 16; i++) {
+      await gesture.moveBy(const Offset(-10, -10));
+      await tester.pump();
+    }
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // The same screen point now maps to a later column AND a later hour — proof
+    // both axes panned (a horizontal-only pan would leave the hour at 2).
+    await createViaMenu(tester, planner, probe);
+    expect(created!.day, greaterThan(0), reason: 'the day axis panned');
+    expect(created!.hour, greaterThan(2), reason: 'the time axis panned');
+  });
+
+  testWidgets('Shift+wheel scrolls the day axis', (tester) async {
+    PlannerTime? created;
+    await tester.pumpWidget(
+        PlannerHarness(planners: [bigGrid(onEntryCreate: (t) => created = t)]));
+    await tester.pumpAndSettle();
+
+    final planner = find.byKey(PlannerHarness.keyFor(0));
+    final rect = tester.getRect(planner);
+    // At rest this probe maps to day 0 (x 100 / 200) and hour 1 (y 60 / 60).
+    final probe = rect.topLeft + const Offset(50 + 100, 50 + 60);
+
+    // Hold Shift and wheel 10 notches: the day axis scrolls 10 × scrollStep (20)
+    // = 200px == one column, so the probe now maps to day 1; the time axis is
+    // untouched. Done before any menu so the wheel isn't swallowed by an overlay.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    final mouse = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(mouse.hover(probe));
+    for (var i = 0; i < 10; i++) {
+      await tester.sendEventToBinding(mouse.scroll(const Offset(0, 20)));
+      await tester.pump();
+    }
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.pump();
+
+    await createViaMenu(tester, planner, probe);
+    expect(created!.day, 1, reason: 'Shift+wheel scrolled the day axis');
+    expect(created!.hour, 1,
+        reason: 'Shift+wheel leaves the time axis where it was');
+  });
+
+  testWidgets('Ctrl+wheel zooms the time axis', (tester) async {
+    PlannerTime? created;
+    await tester.pumpWidget(PlannerHarness(planners: [
+      PlannerSpec(
+        config: PlannerConfig(
+          labels: const ['c1', 'c2', 'c3'],
+          minHour: 0,
+          maxHour: 23,
+          onEntryCreate: (t) => created = t,
+        ),
+      ),
+    ]));
+    await tester.pumpAndSettle();
+
+    final planner = find.byKey(PlannerHarness.keyFor(0));
+    final rect = tester.getRect(planner);
+    // At rest, default blockHeight 40: events-local y 160 -> hour 4.
+    final probe = gridPointFor(rect, downFromGridTop: 160);
+
+    // Hold Ctrl and wheel up several notches to zoom in (each notch ×1.1). Rows
+    // grow taller, so the same screen point maps to an earlier hour. Done before
+    // any menu so the wheel reaches the canvas.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    final mouse = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(mouse.hover(probe));
+    for (var i = 0; i < 5; i++) {
+      await tester.sendEventToBinding(mouse.scroll(const Offset(0, -20)));
+      await tester.pump();
+    }
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+
+    await createViaMenu(tester, planner, probe);
+    expect(created!.hour, lessThan(4),
+        reason:
+            'Ctrl+wheel zoomed in, so a fixed point maps to an earlier hour');
+  });
+}

--- a/example/integration_test/planner_harness.dart
+++ b/example/integration_test/planner_harness.dart
@@ -86,13 +86,16 @@ Future<void> wheelScroll(WidgetTester tester, Offset at, int notches) async {
   }
 }
 
-/// Drags an event the way a user does: press and hold at [from] until the
-/// long-press recognizer wins the gesture arena (over pan/scale), then move by
-/// [delta] and release.
-Future<void> longPressDrag(
-    WidgetTester tester, Offset from, Offset delta) async {
-  final gesture = await tester.startGesture(from);
-  await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+/// Drags an event the desktop way: press at [from] with a mouse and drag by
+/// [delta] immediately — a precise pointer on an event body moves it (or resizes
+/// from a top/bottom edge) as soon as it moves, no long-press. The pointer-down
+/// position anchors the drag, so the committed move equals [delta] (the scale
+/// recognizer's start fires only past the pan slop, but the anchor is the press
+/// point, so no slop distance is dropped).
+Future<void> mouseDrag(WidgetTester tester, Offset from, Offset delta) async {
+  final gesture =
+      await tester.startGesture(from, kind: PointerDeviceKind.mouse);
+  await tester.pump();
   await gesture.moveBy(delta);
   await tester.pump();
   await gesture.up();

--- a/example/integration_test/snapping_scenarios.dart
+++ b/example/integration_test/snapping_scenarios.dart
@@ -10,7 +10,7 @@ import 'planner_harness.dart';
 /// interval (`PlannerConfig.snapMinutes`).
 ///
 /// These drive the *real* composed widget (real layout, real fonts, real
-/// secondary-tap and long-press gestures). `blockHeight` is set to 60 so one
+/// secondary-tap and mouse drag gestures). `blockHeight` is set to 60 so one
 /// grid pixel equals one minute, making the snapped result read directly off the
 /// pixel offset. With `snapMinutes` at its default (15), a 23-minute offset must
 /// land on 15, not 23 — and create and drag must agree.
@@ -48,7 +48,7 @@ void snappingScenarios() {
         reason: '23 raw minutes snap down to the 15-min grid');
   });
 
-  testWidgets('long-press dragging snaps the moved start to the same grid',
+  testWidgets('dragging snaps the moved start to the same grid',
       (tester) async {
     final moved = <PlannerEntry>[];
 
@@ -82,7 +82,7 @@ void snappingScenarios() {
         const Offset(150, 320);
 
     // Drag down 23px == 23 minutes: top 4:00 -> 4:23, snapped down to 4:15.
-    await longPressDrag(tester, from, const Offset(0, 23));
+    await mouseDrag(tester, from, const Offset(0, 23));
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);

--- a/example/integration_test/span_scenarios.dart
+++ b/example/integration_test/span_scenarios.dart
@@ -10,7 +10,7 @@ import 'planner_harness.dart';
 /// [PlannerTime.endDay] is set after [PlannerTime.day] renders across the whole
 /// `day..endDay` column range, is reachable by a pointer from *any* column it
 /// covers (not just the start column), and is read-only in this first cut —
-/// a long-press drag must not move it.
+/// a drag on it must not move it.
 ///
 /// The span is drawn on the `CustomPaint` canvas and hit-tested by
 /// `getEventAtPos`, neither of which an isolated widget test exercises with real
@@ -87,7 +87,7 @@ void spanScenarios() {
             'the span must hit-test from a column it covers, not just its start');
   });
 
-  testWidgets('a span is read-only: a long-press drag does not move it',
+  testWidgets('a span is read-only: dragging it does not move it',
       (tester) async {
     final moved = <String>[];
 
@@ -98,10 +98,11 @@ void spanScenarios() {
 
     final planner = tester.getRect(find.byKey(PlannerHarness.keyFor(0)));
     // Press on the span (column 0 centre) and try to drag it a full column
-    // right. A draggable event would fire onEntryMove on release; the span must
-    // not (#47 — read-only first cut).
+    // right with a mouse. A draggable event would fire onEntryMove on release;
+    // the span isn't grabbed, so the drag pans the canvas instead and onEntryMove
+    // must not fire (#47 — read-only first cut).
     final onSpan = planner.topLeft + const Offset(50 + 100, 50 + 100);
-    await longPressDrag(tester, onSpan, const Offset(200, 0));
+    await mouseDrag(tester, onSpan, const Offset(200, 0));
 
     expect(moved, isEmpty,
         reason: 'spanning events cannot be dragged/resized (#47)');

--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -136,6 +136,23 @@ class Controller {
     }
   }
 
+  /// Scrolls the day-axis by one wheel notch — the Shift+wheel horizontal scroll
+  /// (#65). [forward] (a wheel-down notch) reveals later columns by decreasing
+  /// [x]; the reverse reveals earlier ones. The step is the flat
+  /// [PlannerConfig.scrollStep]: unlike the time axis, columns are a fixed
+  /// [PlannerConfig.blockWidth] wide and don't scale with zoom, so a notch always
+  /// moves the same distance. Clamped to the same `[_maxXOffset, _minXOffset]`
+  /// bounds as a horizontal drag, so it can't reveal past the grid edges.
+  void horizontalScroll(bool forward) {
+    final step = config.scrollStep;
+    x += forward ? -step : step;
+    if (x > _minXOffset) {
+      x = _minXOffset;
+    } else if (x < _maxXOffset) {
+      x = _maxXOffset;
+    }
+  }
+
   void startZoom() {
     _previousZoom = _zoom;
   }

--- a/lib/internal/event.dart
+++ b/lib/internal/event.dart
@@ -343,14 +343,20 @@ class Event {
     return result;
   }
 
+  /// The drag a press at [gridPos] (grid space) would begin: within 8px of the
+  /// top edge resizes from the top, within 8px of the bottom resizes from the
+  /// bottom, anywhere else moves the body. Shared by [startDrag] and the
+  /// hover-cursor hit test (`Manager.dragTypeAt`) so the cursor shown over an
+  /// event matches the drag a press there would actually start.
+  DragType dragTypeForGridPoint(Offset gridPos) {
+    if ((gridPos.dy - canvasRect.top).abs() < 8) return DragType.topHandle;
+    if ((gridPos.dy - canvasRect.bottom).abs() < 8)
+      return DragType.bottomHandle;
+    return DragType.body;
+  }
+
   void startDrag(Offset pos) {
-    if ((pos.dy - canvasRect.top).abs() < 8) {
-      _dragType = DragType.topHandle;
-    } else if ((pos.dy - canvasRect.bottom).abs() < 8) {
-      _dragType = DragType.bottomHandle;
-    } else {
-      _dragType = DragType.body;
-    }
+    _dragType = dragTypeForGridPoint(pos);
     _dragStartPos = pos;
     _dragOffset = Offset.zero;
   }

--- a/lib/internal/event.dart
+++ b/lib/internal/event.dart
@@ -349,9 +349,12 @@ class Event {
   /// hover-cursor hit test (`Manager.dragTypeAt`) so the cursor shown over an
   /// event matches the drag a press there would actually start.
   DragType dragTypeForGridPoint(Offset gridPos) {
-    if ((gridPos.dy - canvasRect.top).abs() < 8) return DragType.topHandle;
-    if ((gridPos.dy - canvasRect.bottom).abs() < 8)
+    if ((gridPos.dy - canvasRect.top).abs() < 8) {
+      return DragType.topHandle;
+    }
+    if ((gridPos.dy - canvasRect.bottom).abs() < 8) {
       return DragType.bottomHandle;
+    }
     return DragType.body;
   }
 

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -261,6 +261,18 @@ class Manager {
     config.onEntryMove?.call(event.entry);
   }
 
+  /// The drag a press at [localPos] (planner-local coordinates) would begin, or
+  /// [DragType.none] when it lands on no draggable event. Drives the desktop
+  /// hover cursor (move over an event body, resize over its top/bottom edge) and
+  /// shares [Event.dragTypeForGridPoint] with [startDrag], so the cursor matches
+  /// the drag a press there would start. Spanning events are read-only (#47), so
+  /// they report [DragType.none] (no move/resize affordance).
+  DragType dragTypeAt(Offset localPos) {
+    final event = getEventAtPos(localPos);
+    if (event == null || event.entry.time.spansColumns) return DragType.none;
+    return event.dragTypeForGridPoint(_toGridPos(localPos));
+  }
+
   Event? getEventAtPos(Offset pos) {
     final Offset realPos = _toGridPos(pos);
 

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'internal/context_menu.dart';
@@ -10,6 +11,12 @@ import 'internal/date_row.dart';
 import 'internal/manager.dart';
 import 'planner_entry.dart';
 import 'planner_config.dart';
+
+/// What a single in-progress events-canvas gesture is doing. Decided when the
+/// unified [ScaleGestureRecognizer] starts and refined to [zoom] as soon as a
+/// second pointer joins, so pan and zoom no longer fight in the gesture arena
+/// (the old layout combined a horizontal-drag recognizer with scale).
+enum _GestureMode { idle, pan, zoom }
 
 class Planner extends StatefulWidget {
   final List<PlannerEntry> entries;
@@ -38,6 +45,12 @@ class _PlannerState extends State<Planner> {
   // never fed and onEntryEdit/onEntryCreate never fired (#40). Feeding the
   // detector through its controller keeps one detector in the arena.
   final PositionedTapController _tapController = PositionedTapController();
+
+  // What the current events-canvas drag is doing. Set when the unified scale
+  // recognizer starts (single pointer => pan) and switched to zoom the moment a
+  // second pointer joins, so a one-finger pan and a pinch-zoom can't both apply
+  // to the same gesture (the old detector ran horizontal-drag and scale at once).
+  _GestureMode _mode = _GestureMode.idle;
 
   @override
   void initState() {
@@ -210,37 +223,90 @@ class _PlannerState extends State<Planner> {
     );
   }
 
-  GestureDetector paintEvents() {
-    return GestureDetector(
-      onHorizontalDragStart: (detail) =>
-          _data.controller.startHorizontalDrag(detail.globalPosition.dx),
-      onHorizontalDragUpdate: (detail) =>
-          _data.controller.updateHorizontalDrag(detail.globalPosition.dx),
-      onScaleStart: ((details) => _data.controller.startZoom()),
-      onScaleUpdate: (details) =>
-          _data.controller.updateZoom(details.verticalScale),
-      onLongPressStart: (details) {
-        _data.startDrag(details.localPosition);
-      },
-      onLongPressMoveUpdate: (details) {
-        _data.updateDrag(details.localPosition);
-      },
-      onLongPressEnd: (details) {
-        _data.endDrag();
-      },
-      // Feed taps to the double-tap detector via its controller (see
-      // _tapController): onTapDown records the pending tap, onTap confirms it.
-      // hideMenu stays on the immediate tap so dismissing the menu isn't held
-      // back by the double-tap window.
-      onTapDown: (details) {
-        _tapController.onTapDown(details);
-      },
-      onTap: () {
-        _data.controller.hideMenu();
-        _tapController.onTap();
-      },
-      onSecondaryTapDown: (details) {
-        showMenu(details);
+  // --- Events-canvas gesture handlers ---------------------------------------
+  // One ScaleGestureRecognizer drives both pan and zoom (a one-finger drag pans;
+  // a multi-finger pinch zooms), replacing the old horizontal-drag + scale combo
+  // that fought in the gesture arena. Move/resize stays on the long-press
+  // recognizer for now (unchanged behaviour); the desktop immediate-drag path
+  // arrives in a later commit.
+
+  void _onScaleStart(ScaleStartDetails details) {
+    // Single pointer => pan; switched to zoom in _onScaleUpdate once a second
+    // pointer joins. Pan is horizontal-only here, matching the previous
+    // horizontal-drag recognizer; startZoom captures the pre-gesture zoom so a
+    // pinch that begins mid-gesture stays continuous.
+    _mode = _GestureMode.pan;
+    _data.controller.startHorizontalDrag(details.focalPoint.dx);
+    _data.controller.startZoom();
+  }
+
+  void _onScaleUpdate(ScaleUpdateDetails details) {
+    if (details.pointerCount >= 2) {
+      _mode = _GestureMode.zoom;
+      _data.controller.updateZoom(details.verticalScale);
+    } else if (_mode == _GestureMode.pan) {
+      _data.controller.updateHorizontalDrag(details.focalPoint.dx);
+    }
+  }
+
+  void _onScaleEnd(ScaleEndDetails details) {
+    _mode = _GestureMode.idle;
+  }
+
+  Widget paintEvents() {
+    return RawGestureDetector(
+      gestures: <Type, GestureRecognizerFactory>{
+        // Pan (one finger) + zoom (pinch) in a single recognizer.
+        ScaleGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
+          () => ScaleGestureRecognizer(),
+          (ScaleGestureRecognizer instance) {
+            instance
+              ..onStart = _onScaleStart
+              ..onUpdate = _onScaleUpdate
+              ..onEnd = _onScaleEnd;
+          },
+        ),
+        // Long-press move/resize: press an event and drag to move, or drag its
+        // top/bottom handle to resize. Drag intent (body vs edge) is decided in
+        // Event.startDrag via Manager.startDrag.
+        LongPressGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+          () => LongPressGestureRecognizer(),
+          (LongPressGestureRecognizer instance) {
+            instance
+              ..onLongPressStart = (d) {
+                _data.startDrag(d.localPosition);
+              }
+              ..onLongPressMoveUpdate = (d) {
+                _data.updateDrag(d.localPosition);
+              }
+              ..onLongPressEnd = (d) {
+                _data.endDrag();
+              };
+          },
+        ),
+        // Tap / double-tap / right-click. Taps are fed to the double-tap
+        // detector via its controller (see _tapController): onTapDown records
+        // the pending tap, onTap confirms it. hideMenu stays on the immediate
+        // tap so dismissing the menu isn't held back by the double-tap window.
+        TapGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+          () => TapGestureRecognizer(),
+          (TapGestureRecognizer instance) {
+            instance
+              ..onTapDown = (d) {
+                _tapController.onTapDown(d);
+              }
+              ..onTap = () {
+                _data.controller.hideMenu();
+                _tapController.onTap();
+              }
+              ..onSecondaryTapDown = (d) {
+                showMenu(d);
+              };
+          },
+        ),
       },
       child: ClipRect(
           child: ScrollDetector(

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'internal/context_menu.dart';
 import 'internal/controller.dart';
@@ -275,8 +276,12 @@ class _PlannerState extends State<Planner> {
       }
     }
 
+    // Empty-area (and touch) drag pans both axes within the existing clamps,
+    // reusing the controller's per-axis drag handlers (the day axis is also
+    // panned by the date row, the time axis by the hour gutter).
     _mode = _GestureMode.pan;
     _data.controller.startHorizontalDrag(details.focalPoint.dx);
+    _data.controller.startVerticalDrag(details.focalPoint.dy);
   }
 
   void _onScaleUpdate(ScaleUpdateDetails details) {
@@ -289,6 +294,7 @@ class _PlannerState extends State<Planner> {
       _data.controller.updateZoom(details.verticalScale);
     } else if (_mode == _GestureMode.pan) {
       _data.controller.updateHorizontalDrag(details.focalPoint.dx);
+      _data.controller.updateVerticalDrag(details.focalPoint.dy);
     }
   }
 
@@ -297,6 +303,25 @@ class _PlannerState extends State<Planner> {
       _data.endDrag();
     }
     _mode = _GestureMode.idle;
+  }
+
+  /// Routes a mouse-wheel notch by keyboard modifier (#65): plain wheel scrolls
+  /// the time axis (unchanged), Shift+wheel scrolls the day axis, Ctrl+wheel
+  /// zooms (clamped to `minZoom`/`maxZoom` by the controller). The vertical
+  /// `dy > 0` sign drives all three so they agree on notch direction; a notch
+  /// with no vertical delta (e.g. a pure horizontal trackpad scroll) is ignored.
+  void _handleWheel(PointerScrollEvent event) {
+    final dy = event.scrollDelta.dy;
+    if (dy == 0) return;
+    final keys = HardwareKeyboard.instance;
+    if (keys.isControlPressed) {
+      _data.controller.startZoom();
+      _data.controller.updateZoom(dy < 0 ? 1.1 : 0.9);
+    } else if (keys.isShiftPressed) {
+      _data.controller.horizontalScroll(dy > 0);
+    } else {
+      _data.controller.verticalScroll(dy > 0);
+    }
   }
 
   /// Maps a hover [position] (events-canvas-local) to the cursor that signals
@@ -365,13 +390,7 @@ class _PlannerState extends State<Planner> {
           valueListenable: _cursor,
           child: ClipRect(
             child: ScrollDetector(
-              onPointerScroll: (event) {
-                if (event.scrollDelta.dy > 0) {
-                  _data.controller.verticalScroll(true);
-                } else {
-                  _data.controller.verticalScroll(false);
-                }
-              },
+              onPointerScroll: _handleWheel,
               child: Container(
                   color: _data.config.plannerBackground,
                   child: CustomPaint(
@@ -404,13 +423,7 @@ class _PlannerState extends State<Planner> {
           _data.controller.updateVerticalDrag(details.globalPosition.dy)),
       child: ClipRect(
         child: ScrollDetector(
-          onPointerScroll: (event) {
-            if (event.scrollDelta.dy > 0) {
-              _data.controller.verticalScroll(true);
-            } else {
-              _data.controller.verticalScroll(false);
-            }
-          },
+          onPointerScroll: _handleWheel,
           child: Container(
             width: _data.config.hourColumnWidth,
             color: _data.config.hourBackground,

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'internal/context_menu.dart';
 import 'internal/controller.dart';
+import 'internal/event.dart';
 import 'internal/events_painter.dart';
 import 'internal/hour_column.dart';
 import 'internal/scroll_detector.dart';
@@ -13,10 +14,12 @@ import 'planner_entry.dart';
 import 'planner_config.dart';
 
 /// What a single in-progress events-canvas gesture is doing. Decided when the
-/// unified [ScaleGestureRecognizer] starts and refined to [zoom] as soon as a
-/// second pointer joins, so pan and zoom no longer fight in the gesture arena
-/// (the old layout combined a horizontal-drag recognizer with scale).
-enum _GestureMode { idle, pan, zoom }
+/// unified [ScaleGestureRecognizer] starts — by hit-testing the press point on a
+/// precise pointer ([moveResize] on an event, [pan] on empty space) and always
+/// [pan] on touch — then refined to [zoom] as soon as a second pointer joins, so
+/// pan, zoom and move/resize no longer fight in the gesture arena (the old
+/// layout combined a horizontal-drag recognizer with scale and a long-press).
+enum _GestureMode { idle, pan, zoom, moveResize }
 
 class Planner extends StatefulWidget {
   final List<PlannerEntry> entries;
@@ -47,10 +50,30 @@ class _PlannerState extends State<Planner> {
   final PositionedTapController _tapController = PositionedTapController();
 
   // What the current events-canvas drag is doing. Set when the unified scale
-  // recognizer starts (single pointer => pan) and switched to zoom the moment a
-  // second pointer joins, so a one-finger pan and a pinch-zoom can't both apply
-  // to the same gesture (the old detector ran horizontal-drag and scale at once).
+  // recognizer starts and switched to zoom the moment a second pointer joins, so
+  // pan, zoom and move/resize can't all apply to the same gesture (the old
+  // detector ran horizontal-drag, scale and long-press at once).
   _GestureMode _mode = _GestureMode.idle;
+
+  // The kind and local position of the most recent pointer-down, captured by the
+  // thin Listener below. The kind decides drag intent (precise pointer =>
+  // press-and-drag an event to move/resize; touch => one-finger drag pans), and
+  // the down position anchors a move/resize so the event follows the pointer
+  // with no dead zone (the scale recognizer only fires onStart after the pan
+  // slop, so anchoring on the recognizer's start would drop that slop distance).
+  PointerDeviceKind _lastPointerKind = PointerDeviceKind.touch;
+  Offset _pointerDownPos = Offset.zero;
+
+  // The desktop hover cursor over the events canvas: move over an event body,
+  // resizeUpDown over its top/bottom edge, basic otherwise. Held in a notifier
+  // so only the MouseRegion rebuilds on a hover change, not the whole Planner.
+  final ValueNotifier<MouseCursor> _cursor =
+      ValueNotifier<MouseCursor>(SystemMouseCursors.basic);
+
+  /// Whether [kind] is a precise pointer (a mouse) that gets the Outlook-style
+  /// immediate drag-move/resize. Touch keeps one-finger drag as pan; its
+  /// move/resize affordance is the long-press callback (the companion #66).
+  bool _isPrecise(PointerDeviceKind kind) => kind == PointerDeviceKind.mouse;
 
   @override
   void initState() {
@@ -65,6 +88,12 @@ class _PlannerState extends State<Planner> {
         !identical(oldWidget.entries, widget.entries)) {
       _data.update(config: widget.config, entries: widget.entries);
     }
+  }
+
+  @override
+  void dispose() {
+    _cursor.dispose();
+    super.dispose();
   }
 
   @override
@@ -224,24 +253,38 @@ class _PlannerState extends State<Planner> {
   }
 
   // --- Events-canvas gesture handlers ---------------------------------------
-  // One ScaleGestureRecognizer drives both pan and zoom (a one-finger drag pans;
-  // a multi-finger pinch zooms), replacing the old horizontal-drag + scale combo
-  // that fought in the gesture arena. Move/resize stays on the long-press
-  // recognizer for now (unchanged behaviour); the desktop immediate-drag path
-  // arrives in a later commit.
+  // One ScaleGestureRecognizer drives pan, zoom and (desktop) move/resize: a
+  // multi-finger pinch zooms; a one-finger drag pans, except on a precise
+  // pointer pressed on an event, where it moves the body or resizes the edge —
+  // the Outlook-style immediate drag, no long-press. This replaces the old
+  // horizontal-drag + scale + long-press combo that fought in the gesture arena.
 
   void _onScaleStart(ScaleStartDetails details) {
-    // Single pointer => pan; switched to zoom in _onScaleUpdate once a second
-    // pointer joins. Pan is horizontal-only here, matching the previous
-    // horizontal-drag recognizer; startZoom captures the pre-gesture zoom so a
-    // pinch that begins mid-gesture stays continuous.
+    // Decide intent from the press point captured at pointer-down. A precise
+    // pointer on an event grabs it (move on the body, resize on an edge); on
+    // empty space, or on touch, the gesture pans. startZoom captures the
+    // pre-gesture zoom so a pinch that begins mid-gesture stays continuous; the
+    // single->second-pointer switch to zoom happens in _onScaleUpdate.
+    _data.controller.startZoom();
+
+    if (_isPrecise(_lastPointerKind)) {
+      _data.startDrag(_pointerDownPos);
+      if (_data.draggedEvent != null) {
+        _mode = _GestureMode.moveResize;
+        return;
+      }
+    }
+
     _mode = _GestureMode.pan;
     _data.controller.startHorizontalDrag(details.focalPoint.dx);
-    _data.controller.startZoom();
   }
 
   void _onScaleUpdate(ScaleUpdateDetails details) {
-    if (details.pointerCount >= 2) {
+    // A move/resize is single-pointer on a mouse, so it never coexists with a
+    // pinch; keep following the pointer.
+    if (_mode == _GestureMode.moveResize) {
+      _data.updateDrag(details.localFocalPoint);
+    } else if (details.pointerCount >= 2) {
       _mode = _GestureMode.zoom;
       _data.controller.updateZoom(details.verticalScale);
     } else if (_mode == _GestureMode.pan) {
@@ -250,83 +293,106 @@ class _PlannerState extends State<Planner> {
   }
 
   void _onScaleEnd(ScaleEndDetails details) {
+    if (_mode == _GestureMode.moveResize) {
+      _data.endDrag();
+    }
     _mode = _GestureMode.idle;
   }
 
+  /// Maps a hover [position] (events-canvas-local) to the cursor that signals
+  /// what a press there would do: move over an event body, resizeUpDown over its
+  /// top/bottom edge, basic over empty space — the desktop discoverability cue.
+  void _updateHoverCursor(Offset position) {
+    final cursor = switch (_data.dragTypeAt(position)) {
+      DragType.body => SystemMouseCursors.move,
+      DragType.topHandle ||
+      DragType.bottomHandle =>
+        SystemMouseCursors.resizeUpDown,
+      DragType.none => SystemMouseCursors.basic,
+    };
+    _cursor.value = cursor;
+  }
+
   Widget paintEvents() {
-    return RawGestureDetector(
-      gestures: <Type, GestureRecognizerFactory>{
-        // Pan (one finger) + zoom (pinch) in a single recognizer.
-        ScaleGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
-          () => ScaleGestureRecognizer(),
-          (ScaleGestureRecognizer instance) {
-            instance
-              ..onStart = _onScaleStart
-              ..onUpdate = _onScaleUpdate
-              ..onEnd = _onScaleEnd;
-          },
-        ),
-        // Long-press move/resize: press an event and drag to move, or drag its
-        // top/bottom handle to resize. Drag intent (body vs edge) is decided in
-        // Event.startDrag via Manager.startDrag.
-        LongPressGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
-          () => LongPressGestureRecognizer(),
-          (LongPressGestureRecognizer instance) {
-            instance
-              ..onLongPressStart = (d) {
-                _data.startDrag(d.localPosition);
-              }
-              ..onLongPressMoveUpdate = (d) {
-                _data.updateDrag(d.localPosition);
-              }
-              ..onLongPressEnd = (d) {
-                _data.endDrag();
-              };
-          },
-        ),
-        // Tap / double-tap / right-click. Taps are fed to the double-tap
-        // detector via its controller (see _tapController): onTapDown records
-        // the pending tap, onTap confirms it. hideMenu stays on the immediate
-        // tap so dismissing the menu isn't held back by the double-tap window.
-        TapGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
-          () => TapGestureRecognizer(),
-          (TapGestureRecognizer instance) {
-            instance
-              ..onTapDown = (d) {
-                _tapController.onTapDown(d);
-              }
-              ..onTap = () {
-                _data.controller.hideMenu();
-                _tapController.onTap();
-              }
-              ..onSecondaryTapDown = (d) {
-                showMenu(d);
-              };
-          },
-        ),
+    // The outer Listener records the kind and position of each pointer-down (a
+    // thin pass-through, it claims nothing) so the scale recognizer can tell a
+    // mouse from a finger and anchor a move/resize at the true press point.
+    return Listener(
+      onPointerDown: (event) {
+        _lastPointerKind = event.kind;
+        _pointerDownPos = event.localPosition;
       },
-      child: ClipRect(
-          child: ScrollDetector(
-        onPointerScroll: (event) {
-          if (event.scrollDelta.dy > 0) {
-            _data.controller.verticalScroll(true);
-          } else {
-            _data.controller.verticalScroll(false);
-          }
+      child: RawGestureDetector(
+        gestures: <Type, GestureRecognizerFactory>{
+          // Pan (one finger) + zoom (pinch) + desktop move/resize, all in one
+          // recognizer so they share an arena instead of fighting in it.
+          ScaleGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
+            () => ScaleGestureRecognizer(),
+            (ScaleGestureRecognizer instance) {
+              instance
+                ..onStart = _onScaleStart
+                ..onUpdate = _onScaleUpdate
+                ..onEnd = _onScaleEnd;
+            },
+          ),
+          // Tap / double-tap / right-click. Taps are fed to the double-tap
+          // detector via its controller (see _tapController): onTapDown records
+          // the pending tap, onTap confirms it. hideMenu stays on the immediate
+          // tap so dismissing the menu isn't held back by the double-tap window.
+          TapGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+            () => TapGestureRecognizer(),
+            (TapGestureRecognizer instance) {
+              instance
+                ..onTapDown = (d) {
+                  _tapController.onTapDown(d);
+                }
+                ..onTap = () {
+                  _data.controller.hideMenu();
+                  _tapController.onTap();
+                }
+                ..onSecondaryTapDown = (d) {
+                  showMenu(d);
+                };
+            },
+          ),
         },
-        child: Container(
-            color: _data.config.plannerBackground,
-            child: CustomPaint(
-              painter: EventsPainter(
-                manager: _data,
-                repaint: _data.controller.triggerUpdate,
-              ),
-              child: Container(),
-            )),
-      )),
+        // Hover cursor (desktop discoverability): the MouseRegion rebuilds on a
+        // cursor change via the notifier; the canvas below is passed as `child`
+        // so it isn't rebuilt with it.
+        child: ValueListenableBuilder<MouseCursor>(
+          valueListenable: _cursor,
+          child: ClipRect(
+            child: ScrollDetector(
+              onPointerScroll: (event) {
+                if (event.scrollDelta.dy > 0) {
+                  _data.controller.verticalScroll(true);
+                } else {
+                  _data.controller.verticalScroll(false);
+                }
+              },
+              child: Container(
+                  color: _data.config.plannerBackground,
+                  child: CustomPaint(
+                    painter: EventsPainter(
+                      manager: _data,
+                      repaint: _data.controller.triggerUpdate,
+                    ),
+                    child: Container(),
+                  )),
+            ),
+          ),
+          builder: (context, cursor, child) {
+            return MouseRegion(
+              cursor: cursor,
+              onHover: (event) => _updateHoverCursor(event.localPosition),
+              onExit: (_) => _cursor.value = SystemMouseCursors.basic,
+              child: child,
+            );
+          },
+        ),
+      ),
     );
   }
 

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -178,4 +178,54 @@ void main() {
       expect(hoursPerNotch(4.0), closeTo(hoursPerNotch(1.0), 1e-9));
     });
   });
+
+  // Shift+wheel horizontal scroll (#65). Columns are a fixed blockWidth, so —
+  // unlike verticalScroll — the step does NOT scale with zoom, and it clamps to
+  // the same bounds as a horizontal drag.
+  group('horizontalScroll (Shift+wheel, #65)', () {
+    test('a forward notch scrolls the day axis (x decreases by scrollStep)',
+        () {
+      final controller = Controller(makeConfig()); // default scrollStep 20
+      controller.horizontalScroll(true);
+      expect(controller.x, -20);
+    });
+
+    test('a backward notch reverses it', () {
+      final controller = Controller(makeConfig());
+      controller.horizontalScroll(true); // x -> -20
+      controller.horizontalScroll(false); // x -> 0
+      expect(controller.x, 0);
+    });
+
+    test('cannot scroll right past x = 0', () {
+      final controller = Controller(makeConfig());
+      controller.horizontalScroll(false);
+      expect(controller.x, 0, reason: 'clamped to _minXOffset');
+    });
+
+    test('honours a custom scrollStep from the config', () {
+      final controller = Controller(
+          PlannerConfig(labels: const ['A', 'B', 'C'], scrollStep: 50));
+      controller.horizontalScroll(true);
+      expect(controller.x, -50);
+    });
+
+    test('does not scale with zoom (columns are a fixed width)', () {
+      final controller = Controller(makeConfig());
+      controller.startZoom();
+      controller.updateZoom(2.0);
+      controller.horizontalScroll(true);
+      expect(controller.x, -20, reason: 'the day-axis step ignores zoom');
+    });
+
+    test('is a no-op when the grid is narrower than the viewport (#64 clamp)',
+        () {
+      // 3 labels × blockWidth 200 = 600 px of grid; canvas 1600 px wide.
+      final controller =
+          Controller(PlannerConfig(labels: const ['A', 'B', 'C']));
+      controller.setSize(const Size(1600, 900));
+      controller.horizontalScroll(true);
+      expect(controller.x, 0, reason: 'grid fully visible — nothing to scroll');
+    });
+  });
 }

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/event.dart';
 import 'package:planner/internal/manager.dart';
 import 'package:planner/planner.dart';
 
@@ -140,6 +141,55 @@ void main() {
       final time = makeManager().getTimeAtPos(const Offset(250, 120));
       expect(time.day, 1);
       expect(time.hour, 11);
+    });
+  });
+
+  // The drag a press would begin, used for the desktop hover cursor (#65) and
+  // shared with Event.startDrag: within 8px of the top/bottom edge resizes,
+  // anywhere else inside the event moves the body, and empty space (or a
+  // read-only spanning event, #47) reports none.
+  group('dragTypeAt classifies the press point', () {
+    // Default blockWidth 200, blockHeight 40, minHour 0; an entry at day 0 /
+    // hour 9 occupies grid rect (0,360)-(200,400). No scroll/zoom, so
+    // planner-local coordinates equal grid coordinates.
+    Manager makeManager() => Manager(
+          config: PlannerConfig(labels: const ['A', 'B']),
+          entries: [makeEntry('1', 0)],
+        );
+
+    test('the body reports DragType.body', () {
+      expect(makeManager().dragTypeAt(const Offset(100, 380)), DragType.body);
+    });
+
+    test('within 8px of the top edge reports topHandle', () {
+      expect(
+          makeManager().dragTypeAt(const Offset(100, 362)), DragType.topHandle);
+    });
+
+    test('within 8px of the bottom edge reports bottomHandle', () {
+      expect(makeManager().dragTypeAt(const Offset(100, 398)),
+          DragType.bottomHandle);
+    });
+
+    test('empty space reports none', () {
+      expect(makeManager().dragTypeAt(const Offset(100, 100)), DragType.none);
+    });
+
+    test('a spanning event is read-only and reports none (#47)', () {
+      final manager = Manager(
+        config: PlannerConfig(labels: const ['A', 'B', 'C']),
+        entries: [
+          PlannerEntry(
+            id: 'span',
+            time: PlannerTime(day: 0, endDay: 1, hour: 9),
+            title: 'span',
+            content: '',
+            color: const Color(0xFF112233),
+          ),
+        ],
+      );
+      // Centre of the span's body in column 0 (grid rect top 360..400).
+      expect(manager.dragTypeAt(const Offset(100, 380)), DragType.none);
     });
   });
 }

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -41,13 +41,14 @@ void main() {
     }
   }
 
-  // Press and hold past the long-press timeout (so the long-press recognizer
-  // wins the gesture arena over pan/scale, exactly as a real user dragging an
-  // event), then move and release.
-  Future<void> longPressDrag(
-      WidgetTester tester, Offset from, Offset delta) async {
-    final gesture = await tester.startGesture(from);
-    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+  // Press an event with a mouse and drag immediately (the Outlook-style desktop
+  // gesture: a precise pointer moves/resizes an event as soon as it drags, no
+  // long-press). The pointer-down position anchors the drag, so the committed
+  // move equals [delta].
+  Future<void> mouseDrag(WidgetTester tester, Offset from, Offset delta) async {
+    final gesture =
+        await tester.startGesture(from, kind: PointerDeviceKind.mouse);
+    await tester.pump();
     await gesture.moveBy(delta);
     await tester.pump();
     await gesture.up();
@@ -276,10 +277,10 @@ void main() {
   // Regression for D5 (#11): drag detection and the onEntryMove callback used to
   // run *inside* EventsPainter.paint(). A host's onEntryMove almost always
   // updates app state (setState), and calling setState during paint throws
-  // "setState() called during build". Driving a real long-press drag whose
-  // handler rebuilds therefore crashes on the old paint-side-effect code and
-  // succeeds now that drag lives in the gesture layer.
-  testWidgets('long-press drag moves an event without painting side effects',
+  // "setState() called during build". Driving a real drag whose handler
+  // rebuilds therefore crashes on the old paint-side-effect code and succeeds
+  // now that drag lives in the gesture layer.
+  testWidgets('dragging an event moves it without painting side effects',
       (tester) async {
     const key = ValueKey('planner');
     final moved = <PlannerEntry>[];
@@ -321,7 +322,7 @@ void main() {
         tester.getRect(find.byKey(key)).topLeft + const Offset(150, 430);
 
     // Drag down exactly one block (40px == 1 hour).
-    await longPressDrag(tester, center, const Offset(0, 40));
+    await mouseDrag(tester, center, const Offset(0, 40));
 
     expect(tester.takeException(), isNull,
         reason: 'onEntryMove must not fire during paint');


### PR DESCRIPTION
## Summary

Reworks the events-canvas gesture model to match the Outlook / Google-Calendar interaction people already know, while staying correct on touch (#65). Delivered as three focused commits: (1) unify the recognizer stack, (2) desktop immediate drag + cursors, (3) 2D pan + wheel modifiers.

## Linked issue
Closes #65

## Changes
- **Unified recognizer stack:** one `RawGestureDetector` driving a single `ScaleGestureRecognizer` for pan + zoom + (desktop) move/resize, plus a `TapGestureRecognizer` for tap/double-tap/right-click. Replaces the old horizontal-drag + scale + long-press combo, so pan and zoom no longer fight in the gesture arena.
- **Desktop immediate drag (precise pointer):** press an event body and drag to move, or drag its top/bottom edge to resize — no long-press. Intent is decided at the press point (captured by a thin `Listener`) and reuses the shared body-vs-edge hit test (`Event.dragTypeForGridPoint` / `Manager.dragTypeAt`, also used by `Event.startDrag`).
- **Hover cursors:** `move` over an event body, `resizeUpDown` over its edges, `basic` over empty space — the desktop discoverability cue (`MouseRegion`, driven by a `ValueNotifier<MouseCursor>` so only it rebuilds).
- **2D pan:** dragging empty canvas pans both axes within the existing clamps.
- **Wheel modifiers** (events canvas + hour gutter): plain wheel scrolls the time axis (unchanged), `Shift`+wheel scrolls the day axis (new `Controller.horizontalScroll` — flat step, clamped like a horizontal drag), `Ctrl`+wheel zooms (clamped to `minZoom`/`maxZoom`).
- **Touch:** a one-finger drag always pans; a pinch zooms.
- Unchanged: double-tap/right-click edit/create, the context menu, and the +/- zoom buttons.

### Intentional scope notes
- **Touch move/resize is dropped** here on purpose: per the issue, the long-press slot is freed for the `onEntryLongPress` companion (**#66**). Until #66 lands, touch users move/resize via no pointer gesture (edit/delete still reachable via double-tap, right-click, and the a11y actions). Spanning events stay read-only (#47).
- **"Zoom about the pointer/focal point"** (marked *optional* in the issue) is **deferred** — zoom stays about the origin to limit risk. Easy follow-up if wanted.

## Test plan
- [x] `flutter analyze` clean
- [x] unit/widget tests pass (`flutter test`) — **127** tests (added `Manager.dragTypeAt` classification + `Controller.horizontalScroll` coverage; migrated the drag widget test to a mouse drag)
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — **25** tests, including new coverage for **top-edge resize**, **hover cursors**, **touch-drag-pans**, **2D pan**, **Shift+wheel**, and **Ctrl+wheel**; existing drag/snapping/span scenarios migrated from long-press to mouse drag.

## Notes / screenshots
- Pinch-zoom on touch isn't a dedicated integration test (multi-touch pinch is awkward to drive in the harness); it's handled by the unified recognizer's `pointerCount >= 2` path.
- The new pan/wheel integration tests gesture *before* opening any menu, because a context menu leaves a lingering overlay that would otherwise swallow the drag/wheel (same constraint `multi_planner_scenarios` documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)