### PR TITLE
feat: expose onEntryLongPress for host-defined touch actions (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Added `PlannerConfig.onEntryLongPress`, fired with the long-pressed
+  `PlannerEntry`. This is the primary way to act on an event by **touch** (touch
+  has no right-click, and a one-finger drag now pans, so long-press is the
+  freed-up gesture); a desktop long-press fires it too. The widget stays
+  presentation-only — it takes no action of its own (no built-in selection,
+  highlight, or menu), so the host decides the response. `null` (the default) and
+  a long-press on empty space are both no-ops.
 - Added column-spanning (multi-day) events. Set `PlannerTime.endDay` to a
   column index after `day` and the event renders across the whole `day..endDay`
   range; `null` (the default) or any value `<= day` is a single-column event, so

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -27,7 +27,10 @@ rectangle positioned by time. The user can:
 - **Desktop drag-to-edit (#65):** press an event body and drag to move it, or
   drag its top/bottom edge to resize — immediately, no long-press. Hovering shows
   a `move` / `resizeUpDown` cursor as the cue. On **touch**, a one-finger drag
-  pans; event move/resize is reserved for the `onEntryLongPress` callback (#66).
+  pans.
+- **Long-press** an event to fire `onEntryLongPress` with that entry (#66) — the
+  touch-reachable hook for acting on an event (touch has no right-click). The
+  widget stays presentation-only; the host decides the response.
 - **Double-tap / right-click** to open a context menu that fires
   `onEntryCreate` / `onEntryEdit` / `onEntryDelete` / `onEntryMove` callbacks.
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ hours, and let users pan, zoom, and drag events to move or resize them.
 ## Features
 
 - Multiple labelled columns with an hour grid drawn on a single `CustomPaint`.
-- Horizontal panning across columns; vertical pan + mouse-wheel scroll across hours.
-- Zoom the time axis with pinch gestures or the built-in +/- buttons; finer grid
-  lines fade in as you zoom.
-- Drag an event to move it, or drag its top/bottom handle to resize it.
-- Context menu (right-click or double-tap) to create, edit, and delete events.
+- 2D panning (drag the empty canvas) plus single-axis pan via the date row / hour
+  gutter, and mouse-wheel scroll with `Shift` / `Ctrl` modifiers.
+- Zoom the time axis with pinch, `Ctrl`+wheel, or the built-in +/- buttons; finer
+  grid lines fade in as you zoom.
+- Desktop drag-to-edit: press an event to move it or drag its top/bottom edge to
+  resize, with hover cursors as cues. Touch keeps one-finger drag for panning and
+  exposes a long-press hook (`onEntryLongPress`) for host-defined event actions.
+- Create / edit / delete via double-tap or a right-click context menu.
+- Per-event accessibility semantics (edit / delete / move) for screen readers.
 - Customizable colors and text styles for the grid, labels, events, and menu.
+
+See [Interactions](#interactions) below for the full mouse and touch gesture map.
 
 ## Getting started
 
@@ -112,6 +118,7 @@ A complete, runnable demo lives in [`example/`](example/lib/main.dart).
 | `onEntryEdit(PlannerEntry)` | An event is double-tapped or "Edit Event" is chosen. |
 | `onEntryDelete(PlannerEntry)` | "Delete Event" is chosen from the context menu. |
 | `onEntryMove(PlannerEntry)` | A drag-move or handle-resize finishes; the entry's `time` is already updated. |
+| `onEntryLongPress(PlannerEntry)` | An event is long-pressed — the touch hook for host-defined actions (see [Interactions](#interactions)). |
 
 > Your callbacks own the data. Update your own list of entries (and call
 > `setState`) in response — the widget reports interactions but does not persist them.
@@ -163,6 +170,62 @@ wash that reads on the default dark background — override it for a different t
 |-------|-------------|---------|
 | `highlightedColumn` | `null` | Index into `labels` of the column to emphasize. |
 | `highlightColumnColor` | translucent white | Fill painted across that column. |
+
+## Interactions
+
+The widget reports user actions through the `onEntry*` callbacks; it never mutates
+your data itself. The gesture set adapts to the input device: a precise pointer
+(mouse) gets immediate drag-to-edit, while touch reserves one-finger drag for
+panning and surfaces event actions through a long-press.
+
+### Mouse / desktop
+
+| Gesture | Result |
+|---------|--------|
+| Drag the empty canvas | Pan both axes (day + time) at once. |
+| Drag the date row | Pan the day axis only. |
+| Drag the hour gutter | Pan the time axis only. |
+| Press an event body + drag | Move the event immediately (no long-press); fires `onEntryMove` on release. |
+| Press an event's top/bottom edge + drag | Resize the event; fires `onEntryMove` on release. |
+| Hover an event | Cursor hints the action: `move` over the body, `resizeUpDown` over an edge. |
+| Mouse wheel | Scroll the time axis. |
+| `Shift` + wheel | Scroll the day axis. |
+| `Ctrl` + wheel | Zoom the time axis. |
+| +/- buttons | Zoom the time axis (hide with `showZoomControls: false`). |
+| Double-click an event | `onEntryEdit`. |
+| Double-click an empty slot | `onEntryCreate`. |
+| Right-click an event | Context menu → Edit / Delete (`onEntryEdit` / `onEntryDelete`). |
+| Right-click an empty slot | Context menu → Create (`onEntryCreate`). |
+| Long-press an event | `onEntryLongPress` — the same hook touch uses. |
+
+One wheel notch always advances the same amount of *time* regardless of zoom; tune
+the base step with `scrollStep`.
+
+### Touch
+
+| Gesture | Result |
+|---------|--------|
+| One-finger drag | Pan both axes (day + time) at once. |
+| Two-finger pinch | Zoom the time axis. |
+| Double-tap an event | `onEntryEdit`. |
+| Double-tap an empty slot | `onEntryCreate`. |
+| Long-press an event | `onEntryLongPress` with that entry. |
+| Long-press an empty slot | Nothing. |
+
+Touch has no right-click and reserves one-finger drag for panning, so **long-press
+is how a touch user acts on an event**. The widget stays presentation-only: it
+hands the pressed `PlannerEntry` to `onEntryLongPress` and takes no action of its
+own (no built-in selection, highlight, or menu), so the host decides the response —
+show an action sheet, a selection UI, a delete confirmation, or start a move flow.
+To move an event by touch, drive it from this callback; immediate drag-move/resize
+is a desktop-only affordance.
+
+### Accessibility
+
+The event canvas is a single `CustomPaint`, so each event also exposes a semantics
+node for screen readers: activate to edit, dismiss to delete, and increase/decrease
+to nudge it an hour later/earlier (`onEntryMove`). Only the actions whose callback
+you wire are offered.
 
 ## Additional information
 

--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -11,6 +11,7 @@ surface) can miss rendering/geometry bugs.
 | [`drag_scenarios.dart`](drag_scenarios.dart) | Mouse-dragging an event body moves it, and dragging its top edge resizes it; both fire `onEntryMove` with no paint-phase side effects (device-level counterpart of the #11 / D5 regression). |
 | [`direct_manipulation_scenarios.dart`](direct_manipulation_scenarios.dart) | Outlook-style direct manipulation (#65): desktop hover cursors (move over a body, resize over an edge, basic over empty), and a one-finger touch drag pans rather than moving the event. |
 | [`pan_zoom_scenarios.dart`](pan_zoom_scenarios.dart) | 2D pan and wheel modifiers (#65): dragging empty canvas pans both axes; Shift+wheel scrolls the day axis; Ctrl+wheel zooms. |
+| [`long_press_scenarios.dart`](long_press_scenarios.dart) | A touch long-press on an event fires `onEntryLongPress` with that entry; a long-press on empty space is a no-op (#66). |
 | [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
 | [`hour_label_scenarios.dart`](hour_label_scenarios.dart) | The default `maxHour` (23) clamps a below-grid tap to hour 23, not the invalid 24 (#13 / D10). |
 | [`snapping_scenarios.dart`](snapping_scenarios.dart) | Create and drag snap event times to the single configurable `snapMinutes` interval, and agree (#14 / D8). |

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -10,6 +10,7 @@ import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
 import 'highlight_column_scenarios.dart';
 import 'hour_label_scenarios.dart';
+import 'long_press_scenarios.dart';
 import 'multi_planner_scenarios.dart';
 import 'overlap_scenarios.dart';
 import 'pan_zoom_scenarios.dart';
@@ -37,6 +38,7 @@ void main() {
   eventGeometryScenarios();
   highlightColumnScenarios();
   hourLabelScenarios();
+  longPressScenarios();
   multiPlannerScenarios();
   overlapScenarios();
   panZoomScenarios();

--- a/example/integration_test/long_press_scenarios.dart
+++ b/example/integration_test/long_press_scenarios.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+/// End-to-end coverage for #66: long-press exposes a host hook for acting on an
+/// event by touch.
+///
+/// Touch has no right-click, and with the #65 interaction overhaul a one-finger
+/// drag pans — so long-press is the freed-up gesture. `PlannerConfig` surfaces it
+/// as `onEntryLongPress`; the widget stays presentation-only and just hands the
+/// pressed entry to the host (no built-in selection/menu).
+///
+/// This drives the *real* composed widget (real layout, real fonts, real gesture
+/// recognition over the competing scale/tap recognizers in the shared arena)
+/// with a genuine touch long-press, so it exercises the wiring a widget test on
+/// the recognizer in isolation can't.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void longPressScenarios() {
+  testWidgets('long-pressing an event fires onEntryLongPress with the entry',
+      (tester) async {
+    final longPressed = <PlannerEntry>[];
+
+    await tester.pumpWidget(_LongPressHostApp(onLongPress: longPressed.add));
+    await tester.pumpAndSettle();
+
+    // The single event sits at day 0 / hour 9 -> grid rect (0,360)-(200,400)
+    // with the default 200x40 blocks. On screen it is offset by the hour column
+    // (50) and date row (50); its centre is therefore planner-local (150, 430).
+    final center =
+        tester.getRect(find.byType(Planner)).topLeft + const Offset(150, 430);
+    await tester.longPressAt(center);
+    await tester.pumpAndSettle();
+
+    expect(longPressed, hasLength(1),
+        reason: 'long-pressing an event must fire onEntryLongPress');
+    expect(longPressed.single.id, 'evt',
+        reason: 'onEntryLongPress receives the long-pressed entry');
+  });
+
+  testWidgets('long-pressing empty grid does not fire onEntryLongPress',
+      (tester) async {
+    final longPressed = <PlannerEntry>[];
+
+    await tester.pumpWidget(_LongPressHostApp(onLongPress: longPressed.add));
+    await tester.pumpAndSettle();
+
+    // events-local (100, 200) past the hour column (50) and date row (50):
+    // column 0, hour 5 in the unscrolled grid — clear of the hour-9 event.
+    final at = tester.getRect(find.byType(Planner)).topLeft +
+        const Offset(50 + 100, 50 + 200);
+    await tester.longPressAt(at);
+    await tester.pumpAndSettle();
+
+    expect(longPressed, isEmpty,
+        reason: 'a long-press on empty space is a no-op (#66)');
+  });
+}
+
+/// A minimal real app hosting one [Planner] with a single event at day 0 /
+/// hour 9, recording long-press callbacks.
+class _LongPressHostApp extends StatelessWidget {
+  const _LongPressHostApp({required this.onLongPress});
+
+  final void Function(PlannerEntry) onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryLongPress: onLongPress,
+          ),
+          entries: [
+            PlannerEntry(
+              id: 'evt',
+              time: PlannerTime(day: 0, hour: 9),
+              title: 'Meeting',
+              content: '',
+              color: const Color(0xFF2244AA),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -110,6 +110,12 @@ class _MyHomePageState extends State<MyHomePage> {
               },
               onEntryDelete: (entry) {
                 debugPrint('deleting entry: ' + entry.title);
+              },
+              // The freed-up touch gesture (#66): the widget is presentation-
+              // only, so the host decides the response. A real app would show a
+              // selection UI / action sheet here.
+              onEntryLongPress: (entry) {
+                debugPrint('long-pressed entry: ' + entry.title);
               }),
           entries: entries,
         )

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -305,6 +305,19 @@ class _PlannerState extends State<Planner> {
     _mode = _GestureMode.idle;
   }
 
+  /// Fires [PlannerConfig.onEntryLongPress] when a long-press lands on an event
+  /// (#66) — the freed-up touch gesture for acting on one (touch has no
+  /// right-click, and a one-finger drag now pans); a desktop long-press fires it
+  /// too. The widget takes no action itself: the host decides the response. A
+  /// long-press on empty space, or one with no callback wired, is a no-op.
+  void _onLongPress(LongPressStartDetails details) {
+    final onLongPress = _data.config.onEntryLongPress;
+    if (onLongPress == null) return;
+    final event = _data.getEventAtPos(details.localPosition);
+    if (event == null) return;
+    onLongPress(event.entry);
+  }
+
   /// Routes a mouse-wheel notch by keyboard modifier (#65): plain wheel scrolls
   /// the time axis (unchanged), Shift+wheel scrolls the day axis, Ctrl+wheel
   /// zooms (clamped to `minZoom`/`maxZoom` by the controller). The vertical
@@ -380,6 +393,19 @@ class _PlannerState extends State<Planner> {
                 ..onSecondaryTapDown = (d) {
                   showMenu(d);
                 };
+            },
+          ),
+          // Long-press -> onEntryLongPress (#66). Shares this arena with the
+          // scale and tap recognizers: a still press past the long-press timeout
+          // wins here, while a press that moves past the pan slop lets the scale
+          // recognizer take the gesture, so long-press never steals a pan or a
+          // desktop drag (this is the same arena the old layout ran a long-press
+          // in). Always registered; with no callback wired it's an inert no-op.
+          LongPressGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+            () => LongPressGestureRecognizer(),
+            (LongPressGestureRecognizer instance) {
+              instance.onLongPressStart = _onLongPress;
             },
           ),
         },

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -138,6 +138,20 @@ class PlannerConfig {
   Function(PlannerEntry)? onEntryDelete;
   Function(PlannerEntry)? onEntryMove;
 
+  /// Fired when the user long-presses an event, with the pressed [PlannerEntry].
+  /// This is the primary way to act on an event by **touch**: touch has no
+  /// right-click, and a one-finger drag now pans, so long-press is the freed-up
+  /// gesture (#66). It also fires on a desktop long-press.
+  ///
+  /// The widget stays presentation-only and takes no action of its own — it
+  /// neither selects nor highlights the event nor shows a menu. The host decides
+  /// the response (open its own action sheet / selection UI, delete, start a move
+  /// flow, …), so this single hook is more flexible than a baked-in touch UI.
+  ///
+  /// When `null` (the default) a long-press is a no-op. A long-press on empty
+  /// space is always a no-op — create stays on double-tap / right-click.
+  Function(PlannerEntry)? onEntryLongPress;
+
   PlannerConfig({
     required this.labels,
     this.minHour = 0,
@@ -173,6 +187,7 @@ class PlannerConfig {
     this.onEntryDelete,
     this.onEntryEdit,
     this.onEntryMove,
+    this.onEntryLongPress,
     this.dateRowHeight = 50,
     this.hourColumnWidth = 50,
   });

--- a/test/planner_widget_test.dart
+++ b/test/planner_widget_test.dart
@@ -111,6 +111,7 @@ void main() {
     void Function(PlannerEntry)? onEdit,
     void Function(PlannerEntry)? onDelete,
     void Function(PlannerTime)? onCreate,
+    void Function(PlannerEntry)? onLongPress,
   }) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
@@ -123,6 +124,7 @@ void main() {
             onEntryEdit: onEdit,
             onEntryDelete: onDelete,
             onEntryCreate: onCreate,
+            onEntryLongPress: onLongPress,
           ),
           entries: [entry],
         ),
@@ -572,6 +574,72 @@ void main() {
           reason: 'the tapped point maps to day 0 / hour 5');
       expect(edited, isEmpty,
           reason: 'an empty-grid hit creates, it does not edit');
+    });
+  });
+
+  // Touch has no right-click and a one-finger drag now pans, so long-press is
+  // the freed-up gesture for acting on an event (#66). PlannerConfig exposes it
+  // as onEntryLongPress; the widget stays presentation-only and just hands the
+  // pressed entry to the host. These drive the real composed Planner through the
+  // long-press recognizer that shares the events arena with scale and tap.
+  group('long-press (#66)', () {
+    testWidgets('long-pressing an event fires onEntryLongPress with the entry',
+        (tester) async {
+      const key = ValueKey('planner');
+      final longPressed = <PlannerEntry>[];
+      final edited = <PlannerEntry>[];
+      final created = <PlannerTime>[];
+      final entry = eventAtHour9();
+      final rect = await pumpEntryPlanner(tester, key, entry,
+          onEdit: edited.add,
+          onCreate: created.add,
+          onLongPress: longPressed.add);
+
+      // The event's centre is planner-local (150, 430) (see eventAtHour9).
+      await tester.longPressAt(rect.topLeft + const Offset(150, 430));
+      await tester.pump();
+
+      expect(longPressed, hasLength(1),
+          reason: 'long-pressing an event must fire onEntryLongPress');
+      expect(identical(longPressed.single, entry), isTrue,
+          reason: 'onEntryLongPress receives the long-pressed entry');
+      expect(edited, isEmpty,
+          reason: 'long-press is its own gesture, it does not edit');
+      expect(created, isEmpty, reason: 'a hit on an event does not create');
+    });
+
+    testWidgets('long-pressing empty grid does not fire onEntryLongPress',
+        (tester) async {
+      const key = ValueKey('planner');
+      final longPressed = <PlannerEntry>[];
+      final entry = eventAtHour9();
+      final rect = await pumpEntryPlanner(tester, key, entry,
+          onLongPress: longPressed.add);
+
+      // events-local (100, 200) past the hour column (50) and date row (50):
+      // column 0, hour 5 in the unscrolled grid — clear of the hour-9 event.
+      await tester.longPressAt(rect.topLeft + const Offset(50 + 100, 50 + 200));
+      await tester.pump();
+
+      expect(longPressed, isEmpty,
+          reason: 'a long-press on empty space is a no-op (#66)');
+    });
+
+    testWidgets('with no callback wired, long-pressing an event is a no-op',
+        (tester) async {
+      const key = ValueKey('planner');
+      final entry = eventAtHour9();
+      // onLongPress intentionally omitted (null).
+      final rect = await pumpEntryPlanner(tester, key, entry);
+
+      await tester.longPressAt(rect.topLeft + const Offset(150, 430));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull,
+          reason: 'a null onEntryLongPress must not throw');
+      // No built-in selection/menu appears (the widget stays presentation-only).
+      expect(find.text('Edit Event'), findsNothing);
+      expect(find.text('Delete Event'), findsNothing);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `PlannerConfig.onEntryLongPress`, the touch-reachable hook for acting on an event. Touch has no right-click, and the #65 interaction overhaul made one-finger drag pan — freeing the long-press gesture. A long-press that lands on an event fires the callback with that `PlannerEntry`; the widget stays presentation-only and lets the host decide the response (action sheet, selection UI, delete, move flow, …). A long-press on empty space, or with no callback wired, is a no-op.

## Linked issue
Closes #66

## Changes
- **`PlannerConfig.onEntryLongPress`** — new documented `Function(PlannerEntry)?` field + constructor param.
- **`planner_class.dart`** — added a `LongPressGestureRecognizer` to the events-canvas `RawGestureDetector` (the same shared arena the pre-#65 layout ran a long-press in, so it coexists with scale/tap and never steals a pan or desktop drag), plus an `_onLongPress` handler that hit-tests the press and fires the callback only on an event hit.
- **Tests** — 3 widget tests (event hit → callback; empty-space no-op; null-callback no-op) and a new end-to-end `long_press_scenarios.dart` (event → callback; empty-space no-op), registered in `app_test.dart` with an integration README row.
- **Docs / example** — `README.md` gains a full **Interactions** section (mouse first, then touch) + `onEntryLongPress` in the callbacks table; `CHANGELOG.md`, `PROJECT_OVERVIEW.md`, and `example/lib/main.dart` updated.

## Test plan
- [x] `flutter analyze` clean
- [x] unit/widget tests pass (`flutter test`) — 130 passed, incl. 3 new long-press tests
- [x] integration/e2e tests pass (`flutter test integration_test -d windows`) — 27 passed, incl. 2 new long-press scenarios
- [x] Confirmed the positive test **fails** with the recognizer wiring disabled (the no-op tests correctly still pass), so it genuinely exercises the new path

## Notes / screenshots
User-visible gesture change, so an integration test is included per the acceptance criteria. This completes the interaction-overhaul series (#64/#65/#66); the README now documents the full mouse/touch gesture map.