### PR TITLE
fix: rebuild event a11y semantics on scroll/zoom (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Fixed event accessibility semantics not updating when the canvas is scrolled
+  or zoomed. A screen reader now reaches *every* event — not just those that were
+  on screen the last time the data changed or the canvas was laid out — and each
+  event's semantics node now tracks the scroll/zoom so its hit-area and focus
+  highlight stay aligned as the user pans. Previously off-viewport events were
+  culled and never re-exposed (the canvas has no a11y scroll action to bring them
+  back), and a scrolled event kept a stale node rect.
 - Added `PlannerConfig.onEntryLongPress`, fired with the long-pressed
   `PlannerEntry`. This is the primary way to act on an event by **touch** (touch
   has no right-click, and a one-finger drag now pans, so long-press is the

--- a/example/integration_test/accessibility_scenarios.dart
+++ b/example/integration_test/accessibility_scenarios.dart
@@ -3,6 +3,8 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
 
+import 'planner_harness.dart';
+
 /// End-to-end guard for #21 (PROJECT_OVERVIEW D12): the planner is drawn on a
 /// single `CustomPaint` canvas, which is one opaque node to a screen reader, so
 /// events were neither perceivable nor actionable by assistive technology.
@@ -78,6 +80,94 @@ void accessibilityScenarios() {
     // the one we constructed, so read the moved hour off the reported instance.
     expect(moved.single.id, 'standup');
     expect(moved.single.time.hour, 10);
+
+    handle.dispose();
+  });
+
+  testWidgets('an event below the viewport is still exposed to a11y (#56)',
+      (tester) async {
+    // The events canvas has no accessibility scroll-into-view action, so an event
+    // off the bottom of the viewport must still get a (non-hidden) semantics node
+    // — otherwise a screen-reader user could never reach it. With the default
+    // ~550px-tall canvas, hour 20 (grid y=800) starts well below the fold.
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: PlannerConfig(
+            labels: const ['Mon', 'Tue', 'Wed'],
+            minHour: 0,
+            maxHour: 23,
+          ),
+          entries: [
+            PlannerEntry(
+              id: 'late',
+              time: PlannerTime(day: 0, hour: 20),
+              title: 'Late',
+              content: '',
+              color: const Color(0xFF2244AA),
+            ),
+          ],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final owner =
+        tester.renderObject(find.byType(Planner)).owner!.semanticsOwner!;
+    final node = _findByLabelPrefix(owner, 'Late');
+    final data = node.getSemanticsData();
+    expect(data.label, startsWith('Late, Mon, 20:00'));
+    expect(data.flagsCollection.isHidden, isFalse,
+        reason: 'an off-viewport event must stay reachable, not hidden');
+
+    handle.dispose();
+  });
+
+  testWidgets('scrolling the canvas updates an event node rect (#56)',
+      (tester) async {
+    // RenderCustomPaint repaints on scroll but never rebuilds semantics on its
+    // own, so without the widget-layer poke an event node keeps the rect it had
+    // when last built. Scroll the time axis and confirm the node's rect actually
+    // moves up — proof the semantics were rebuilt against the new scroll offset.
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: PlannerConfig(
+            labels: const ['Mon', 'Tue', 'Wed'],
+            minHour: 0,
+            maxHour: 23,
+          ),
+          entries: [
+            PlannerEntry(
+              id: 'standup',
+              time: PlannerTime(day: 0, hour: 9),
+              title: 'Standup',
+              content: '',
+              color: const Color(0xFF2244AA),
+            ),
+          ],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final owner =
+        tester.renderObject(find.byType(Planner)).owner!.semanticsOwner!;
+    final before = _findByLabelPrefix(owner, 'Standup').rect.top;
+
+    // Five wheel notches down the time axis (20px each at zoom 1 = 100px up).
+    await wheelScroll(tester, tester.getCenter(find.byType(Planner)), 5);
+    await tester.pumpAndSettle();
+
+    final after = _findByLabelPrefix(owner, 'Standup').rect.top;
+    expect(after, lessThan(before),
+        reason: 'the node rect must track the scroll, not stay frozen');
+    expect(before - after, closeTo(100, 0.5),
+        reason: 'five 20px notches move the event up by 100px');
 
     handle.dispose();
   });

--- a/lib/internal/events_painter.dart
+++ b/lib/internal/events_painter.dart
@@ -33,8 +33,19 @@ class EventsPainter extends CustomPainter {
 
   // Expose each event to assistive technology (#21). A CustomPaint canvas is one
   // opaque semantics node, so screen readers can otherwise neither perceive
-  // events nor act on them. For every event currently in view we emit one node
-  // carrying its description (title, time, duration) and the host's actions.
+  // events nor act on them. For *every* event — not just the on-screen ones — we
+  // emit one node carrying its description (title, time, duration) and the host's
+  // actions.
+  //
+  // We deliberately do NOT cull off-viewport events (#56): this canvas exposes no
+  // accessibility scroll-into-view action, so a screen-reader user can't scroll a
+  // culled event back in — culling would make it permanently unreachable. Off-
+  // canvas nodes are still reachable: a RenderCustomPaint's CustomPainterSemantics
+  // children are not subject to the ancestor ClipRect's semantic culling. The
+  // node's `rect` is the event's *live* on-screen rect; scrolling/zooming only
+  // bumps the paint-listenable (markNeedsPaint, never markNeedsSemanticsUpdate),
+  // so `_PlannerState` separately pokes this canvas to rebuild its semantics on
+  // pan/zoom (see `_rebuildEventSemantics`), keeping each rect tracking the view.
   //
   // The actions map onto first-class semantics actions, NOT customSemanticsActions:
   // RenderCustomPaint forwards only the built-in SemanticsProperties callbacks to
@@ -53,15 +64,12 @@ class EventsPainter extends CustomPainter {
 
   List<CustomPainterSemantics> _buildSemantics(Size size) {
     final config = manager.config;
-    final viewport = Offset.zero & size;
     final nodes = <CustomPainterSemantics>[];
 
     for (final event in manager.events) {
+      // A node per event regardless of scroll position (see semanticsBuilder):
+      // its rect is the live on-screen rect, even when that lies off-canvas.
       final rect = event.screenRect;
-      // Skip events scrolled out of view: an off-canvas rect is no perceivable
-      // target. Semantics rebuild on scroll (shouldRebuildSemantics tracks
-      // shouldRepaint), so a scrolled-in event reappears.
-      if (!rect.overlaps(viewport)) continue;
 
       final canEdit = config.onEntryEdit != null;
       // Spanning events are read-only in this first cut (#47): they can't be

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -71,6 +71,16 @@ class _PlannerState extends State<Planner> {
   final ValueNotifier<MouseCursor> _cursor =
       ValueNotifier<MouseCursor>(SystemMouseCursors.basic);
 
+  // Identifies the events-canvas RenderCustomPaint so a scroll/zoom can rebuild
+  // its accessibility semantics (#56). RenderCustomPaint wires the painter's
+  // `repaint` listenable to markNeedsPaint only — never markNeedsSemanticsUpdate
+  // — so a pan/zoom (which just ticks triggerUpdate) repaints the events but
+  // leaves their semantics nodes frozen at the rects they had when last built.
+  // We listen to that same notifier and poke this canvas to rebuild its
+  // semantics, so each event node's rect tracks the view (keeping touch-
+  // exploration hit-areas and the AT focus highlight correct as the user pans).
+  final GlobalKey _eventsCanvasKey = GlobalKey();
+
   /// Whether [kind] is a precise pointer (a mouse) that gets the Outlook-style
   /// immediate drag-move/resize. Touch keeps one-finger drag as pan; its
   /// move/resize affordance is the long-press callback (the companion #66).
@@ -80,6 +90,21 @@ class _PlannerState extends State<Planner> {
   void initState() {
     super.initState();
     _data = Manager(config: widget.config, entries: widget.entries);
+    // Rebuild the event semantics whenever the view changes (#56). The
+    // controller is preserved across rebuilds (Manager.update keeps it), so this
+    // listener stays valid for the life of the State.
+    _data.controller.triggerUpdate.addListener(_rebuildEventSemantics);
+  }
+
+  /// Rebuilds the events-canvas accessibility semantics so each event node's
+  /// rect tracks the current scroll/zoom (#56). Fired on every controller
+  /// update: RenderCustomPaint only repaints (not re-semantics) on the `repaint`
+  /// listenable, so without this poke a scrolled event keeps its stale node rect.
+  /// A no-op until the canvas is mounted (`currentContext` is null before then).
+  void _rebuildEventSemantics() {
+    _eventsCanvasKey.currentContext
+        ?.findRenderObject()
+        ?.markNeedsSemanticsUpdate();
   }
 
   @override
@@ -93,6 +118,7 @@ class _PlannerState extends State<Planner> {
 
   @override
   void dispose() {
+    _data.controller.triggerUpdate.removeListener(_rebuildEventSemantics);
     _cursor.dispose();
     super.dispose();
   }
@@ -420,6 +446,7 @@ class _PlannerState extends State<Planner> {
               child: Container(
                   color: _data.config.plannerBackground,
                   child: CustomPaint(
+                    key: _eventsCanvasKey,
                     painter: EventsPainter(
                       manager: _data,
                       repaint: _data.controller.triggerUpdate,

--- a/test/event_semantics_test.dart
+++ b/test/event_semantics_test.dart
@@ -7,12 +7,14 @@ import 'package:planner/planner.dart';
 void main() {
   // #21: the planner is drawn on a single CustomPaint canvas, which is one opaque
   // node to a screen reader. EventsPainter now provides a semanticsBuilder that
-  // emits one node per visible event — describing it (title/day/time/duration)
-  // and exposing its actions via first-class semantics callbacks (activate=edit,
+  // emits one node per event — describing it (title/day/time/duration) and
+  // exposing its actions via first-class semantics callbacks (activate=edit,
   // dismiss=delete, increase/decrease=move later/earlier; customSemanticsActions
-  // are not used because RenderCustomPaint drops them). These tests drive that
-  // builder directly: a unit-level guard on the labels, action gating, the rect,
-  // and the move/clamp behaviour.
+  // are not used because RenderCustomPaint drops them). #56: it emits a node for
+  // *every* event regardless of scroll position (no viewport cull), with the
+  // rect tracking the current scroll offset. These tests drive that builder
+  // directly: a unit-level guard on the labels, action gating, the rect (and that
+  // it follows the scroll), no culling, and the move/clamp behaviour.
 
   PlannerEntry entryAt({
     String id = 'e',
@@ -49,8 +51,8 @@ void main() {
         entries: entries,
       );
 
-  // A viewport tall enough to reach any hour 0..23 (24 * 40px = 960), so the
-  // off-screen filter never hides the event under test unless that's the point.
+  // The builder ignores `size` (it no longer culls to the viewport, #56); the
+  // default is just a representative canvas size.
   List<CustomPainterSemantics> buildFor(Manager manager,
       [Size size = const Size(800, 1000)]) {
     final painter = EventsPainter(
@@ -179,12 +181,29 @@ void main() {
     expect(moved, isEmpty, reason: 'a no-op nudge must not fire onEntryMove');
   });
 
-  test('events scrolled out of the viewport emit no semantics node', () {
-    // Day 0 / hour 9 -> grid rect (0,360)-(200,400). With no scroll the rect is
-    // unchanged; a viewport only 100px tall cannot overlap it, so it is omitted.
+  test('emits a node for an off-viewport event (no viewport cull, #56)', () {
+    // Day 0 / hour 9 -> on-screen rect (0,360)-(200,400). Even a viewport far too
+    // short to contain it still emits the node: this canvas has no a11y scroll
+    // action, so a culled event would be permanently unreachable. The node is
+    // emitted with its true (here off-canvas) rect.
     final manager = managerWith(entries: [entryAt(hour: 9)]);
-    expect(buildFor(manager, const Size(800, 100)), isEmpty);
-    // The same event is reported once the viewport is tall enough to reach it.
-    expect(buildFor(manager, const Size(800, 600)), hasLength(1));
+    final nodes = buildFor(manager, const Size(800, 100));
+    expect(nodes, hasLength(1));
+    expect(nodes.single.rect, manager.events.single.screenRect);
+  });
+
+  test('the node rect follows the controller scroll offset (#56)', () {
+    // The semantics rect is the event's live on-screen rect, so once the view is
+    // scrolled the rebuilt node reports the new position (the widget layer pokes
+    // markNeedsSemanticsUpdate on scroll so this rebuild actually happens).
+    final manager = managerWith(entries: [entryAt(hour: 9)]);
+    final before = buildFor(manager).single.rect;
+
+    manager.controller.y = -120; // scroll the time axis up by 120px
+    final after = buildFor(manager).single.rect;
+
+    expect(after, manager.events.single.screenRect);
+    expect(after.top, before.top - 120,
+        reason: 'the node rect moves with the scroll, not frozen');
   });
 }


### PR DESCRIPTION
## Summary
Event accessibility semantics were culled to the viewport in `EventsPainter._buildSemantics`, on the false premise that semantics rebuild on scroll. `RenderCustomPaint` wires a painter's `repaint` listenable to `markNeedsPaint` only — never `markNeedsSemanticsUpdate` — so an event off-viewport at the last relayout/data-change never gained a semantics node when scrolled into view, and a screen-reader user could not perceive it. This fixes that with two reinforcing changes.

## Linked issue
Closes #56

## Changes
- **`lib/internal/events_painter.dart` — drop the viewport cull.** Emit a semantics node for *every* event, not just on-screen ones. This canvas exposes no accessibility scroll-into-view action, so a culled off-viewport event is permanently unreachable; off-canvas `CustomPainterSemantics` children are *not* subject to the ancestor `ClipRect`'s semantic culling (verified empirically), so they stay reachable. Rewrote the inaccurate comment.
- **`lib/planner_class.dart` — rebuild semantics on scroll/zoom.** A listener on `controller.triggerUpdate` pokes `markNeedsSemanticsUpdate()` on the events canvas (via a `GlobalKey`), so each event node's `rect` tracks the view (touch-exploration hit-areas and the AT focus highlight stay aligned as the user pans). Registered in `initState`, removed in `dispose`. This re-runs only `_buildSemantics` (O(events)) — no `Grid` reallocation and no widget rebuild, so the existing repaint-listenable performance design is preserved.
- **`test/event_semantics_test.dart`** — replaced the old "off-viewport → no node" test (which encoded the buggy contract) with a no-cull guard plus a rect-follows-scroll contract test; updated header/helper comments.
- **`example/integration_test/accessibility_scenarios.dart`** — two end-to-end scenarios: an off-viewport event stays exposed (non-hidden) to the real `SemanticsOwner`, and a wheel-scroll moves the event's node `rect`.
- **`CHANGELOG.md`** — Unreleased bug-fix entry.

## Test plan
- [x] `flutter analyze` clean
- [x] unit/widget tests pass — `flutter test` (131/131), including the updated `event_semantics_test.dart`
- [x] integration/e2e tests pass — `flutter test integration_test -d windows` from `example/` (29/29), including the two new `#56` scenarios
- [x] regression confirmed: with the lib fix stashed, the unit no-cull guard and both `#56` integration guards **fail** on the unpatched code (no node for the off-viewport event; node rect frozen at 360.0), then pass once the fix is restored

## Notes / screenshots
A screen-reader-only user has no way to scroll this canvas through assistive tech, which is why the fix had to *both* stop culling (so off-viewport events are reachable at all) *and* rebuild on scroll (so the reachable nodes' rects stay correct for touch exploration). Either change alone is insufficient.
