### PR TITLE
feat: optional date <-> column-index calendar helpers (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Added optional, **non-core** calendar helpers in `package:planner/calendar.dart`
+  (a separate import — *not* part of the main `planner.dart` barrel) so building an
+  ordinary date-based week calendar on top of the date-agnostic widget is a few
+  lines, without `DateTime` entering the widget API (ADR 0001 / #49). A
+  `CalendarWindow` owns the `date ↔ column-index` mapping for a window of N days:
+  build it directly or week-align it with `CalendarWindow.week(anchor: …)`, map
+  dates to columns (`indexOf` / `dateAt` / `contains`), step weeks (`next` /
+  `previous`), derive `PlannerConfig.labels` (`labels()`, defaulting to a localized
+  `EEE d` via `intl`) and the `highlightedColumn` "today" index (`todayColumn`), and
+  convert your own dated events into `PlannerEntry`/`PlannerTime` for the current
+  window (`timeFor` / `entriesFor`, with column-spanning support via an `end` date).
+  Adds `intl` as a dependency (used only by these helpers for the default label
+  format).
 - Fixed event accessibility semantics not updating when the canvas is scrolled
   or zoomed. A screen reader now reaches *every* event — not just those that were
   on screen the last time the data changed or the canvas was laid out — and each

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -185,8 +185,9 @@ Severity: 🔴 blocker/bug · 🟠 important · 🟡 polish.
 - Add the genuine widget-level primitives as additive, non-breaking follow-ups:
   ✅ highlight-column ("today" style, #46 — `PlannerConfig.highlightedColumn`),
   ✅ event column-span (multi-day, #47 — `PlannerTime.endDay` +
-  `PlannerConfig.spanOverlap`), all-day band (#48), optional
-  `date ↔ index` consumer helpers (#49).
+  `PlannerConfig.spanOverlap`), all-day band (#48), ✅ optional
+  `date ↔ index` consumer helpers (#49 — `CalendarWindow` in the non-core
+  `lib/calendar.dart`).
 - **D11** overlap/column layout. Accessibility (`Semantics`), localization of menu strings.
 
 ### P3 — Polish & tooling

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ custom-painted canvas. Show several labelled columns side by side, each split in
 hours, and let users pan, zoom, and drag events to move or resize them.
 
 > **Note on the model:** `planner` is column-based, not date-based. A "day" is an
-> *index* into the `labels` list you provide — there are no real calendar dates yet.
-> This makes it a flexible scheduler for any set of columns (days, rooms, machines,
-> lanes …). See [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md) for the roadmap toward
-> full `DateTime` support.
+> *index* into the `labels` list you provide — there are no real calendar dates in
+> the core. This keeps it a flexible scheduler for any set of columns (days, rooms,
+> machines, lanes …). For an ordinary date-based week calendar, the optional
+> [calendar helpers](#building-a-date-based-week-calendar) map dates ↔ columns on
+> top of this model; the core stays date-agnostic by design (see
+> [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md)).
 
 <!-- TODO: add a screenshot or GIF of the widget here, e.g. -->
 <!-- ![planner demo](doc/demo.gif) -->
@@ -170,6 +172,91 @@ wash that reads on the default dark background — override it for a different t
 |-------|-------------|---------|
 | `highlightedColumn` | `null` | Index into `labels` of the column to emphasize. |
 | `highlightColumnColor` | translucent white | Fill painted across that column. |
+
+## Building a date-based week calendar
+
+The core widget is date-agnostic, but most calendars want real `DateTime`s. The
+optional, **non-core** helpers in `package:planner/calendar.dart` own the
+`date ↔ column-index` mapping for you, so the common week-calendar case stays a few
+lines without `DateTime` ever entering the widget API. Import it explicitly — it is
+**not** part of the main `planner.dart` barrel:
+
+```dart
+import 'package:planner/planner.dart';
+import 'package:planner/calendar.dart'; // opt-in calendar helpers
+```
+
+A `CalendarWindow` is a window of N consecutive days. Hold one in your state, derive
+the widget inputs from it, and step weeks with `next` / `previous`:
+
+```dart
+class WeekCalendar extends StatefulWidget {
+  const WeekCalendar({super.key, required this.meetings});
+  final List<Meeting> meetings; // your own dated event model
+
+  @override
+  State<WeekCalendar> createState() => _WeekCalendarState();
+}
+
+class _WeekCalendarState extends State<WeekCalendar> {
+  // The current week, snapped to its Monday.
+  CalendarWindow window = CalendarWindow.week(anchor: DateTime.now());
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(children: [
+          IconButton(
+            onPressed: () => setState(() => window = window.previous),
+            icon: const Icon(Icons.chevron_left),
+          ),
+          IconButton(
+            onPressed: () => setState(() => window = window.next),
+            icon: const Icon(Icons.chevron_right),
+          ),
+        ]),
+        Expanded(
+          child: Planner(
+            config: PlannerConfig(
+              labels: window.labels(), // e.g. ['Mon 8', 'Tue 9', … ] via intl
+              highlightedColumn: window.todayColumn, // "today", or null off-week
+            ),
+            // Map your dated events into the window; ones outside it are dropped.
+            entries: window.entriesFor(
+              widget.meetings,
+              start: (m) => m.startsAt,
+              duration: (m) => m.length,
+              build: (m, time) => PlannerEntry(
+                id: m.id,
+                time: time,
+                title: m.title,
+                content: '',
+                color: m.color,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+`labels()` defaults to a localized `EEE d` (e.g. `Mon 8`) via `intl`; pass your own
+`String Function(DateTime)` for a different format or locale. `todayColumn` returns
+`null` when today isn't in the window, which `highlightedColumn` already treats as
+"no highlight".
+
+| `CalendarWindow` member | Purpose |
+|-------------------------|---------|
+| `CalendarWindow({start, dayCount})` / `.week({anchor, firstWeekday, dayCount})` | A window of `dayCount` days from `start`, or the week containing `anchor`. |
+| `dateAt(i)` / `indexOf(date)` / `offsetOf(date)` / `contains(date)` | Map between dates and column indices. |
+| `dates` / `next` / `previous` | The column dates; step one window forward / back. |
+| `labels([format])` | Column headers for `PlannerConfig.labels` (default `intl` `EEE d`). |
+| `todayColumn` | Index for `PlannerConfig.highlightedColumn` (today, or `null`). |
+| `timeFor(start, {duration, end})` | A `PlannerTime` for a dated event, or `null` if outside the window. |
+| `entriesFor(events, {start, build, duration, end})` | Build the `PlannerEntry` list from your own dated events. |
 
 ## Interactions
 

--- a/docs/decisions/0001-time-model-day-index.md
+++ b/docs/decisions/0001-time-model-day-index.md
@@ -75,9 +75,10 @@ non-breaking follow-up issues:
 - **All-day band** ([#48](https://github.com/pebble-world/planner/issues/48)) — a
   row above the time grid for all-day / full-column entries.
 - **Optional consumer-side date helpers**
-  ([#49](https://github.com/pebble-world/planner/issues/49)) — a small
-  `date ↔ index` utility / week-builder (non-core) so the common calendar case is
-  easy without changing the core model.
+  ([#49](https://github.com/pebble-world/planner/issues/49)) — ✅ done: a small
+  `date ↔ index` utility / week-builder (`CalendarWindow` in the non-core
+  `package:planner/calendar.dart`, not in the main barrel) so the common calendar
+  case is easy without changing the core model.
 
 These are tracked as follow-up issues spun out of #19.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -98,6 +98,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/calendar.dart
+++ b/lib/calendar.dart
@@ -1,0 +1,231 @@
+/// Optional, **non-core** calendar helpers for building an ordinary week-style
+/// calendar on top of the date-agnostic [Planner] widget.
+///
+/// The widget itself has no notion of calendar dates: a `day` is just an index
+/// into `PlannerConfig.labels` (ADR 0001 / #19). That keeps it a flexible
+/// "N labelled columns × hours" grid, but it leaves a consumer building a real
+/// week-calendar to own the `date ↔ column-index` mapping, week-stepping, and
+/// "today" detection. This library ships those as a small, self-contained
+/// utility so the common case is easy **without** changing the core model.
+///
+/// It is intentionally a *separate* import — it is **not** re-exported from
+/// `package:planner/planner.dart`. Pull it in explicitly when you want it:
+///
+/// ```dart
+/// import 'package:planner/planner.dart';
+/// import 'package:planner/calendar.dart';
+/// ```
+///
+/// Everything here is pure data: it produces `PlannerConfig.labels`, a
+/// `highlightedColumn` index, and `PlannerEntry`/`PlannerTime` values that you
+/// feed to the widget yourself.
+library;
+
+import 'package:intl/intl.dart';
+
+import 'planner_entry.dart';
+import 'planner_time.dart';
+
+/// A fixed window of [dayCount] consecutive calendar days starting at [start],
+/// and the `date ↔ column-index` mapping between those days and the planner's
+/// columns. Column `0` is [start]; column `i` is the date `i` days later.
+///
+/// This is the bridge between real `DateTime`s and the widget's opaque day
+/// indices. A consumer holds the current window, derives the widget inputs from
+/// it ([labels], [todayColumn], [entriesFor]), and steps weeks with [next] /
+/// [previous]. The widget never sees a `DateTime`.
+///
+/// Immutable and equatable, so it works as a state value you can diff.
+class CalendarWindow {
+  /// The date of column `0`, normalized to date-only (local midnight). The
+  /// time-of-day of the value passed to the constructor is dropped, so every
+  /// window aligns to whole calendar days.
+  final DateTime start;
+
+  /// The number of columns (consecutive days) in the window — match this to
+  /// `PlannerConfig.labels.length`. A 7-day week is the default; pass `5` for a
+  /// work week, `1` for a single day, etc.
+  final int dayCount;
+
+  /// Creates a window of [dayCount] days beginning on [start]'s calendar day.
+  CalendarWindow({required DateTime start, this.dayCount = 7})
+      : assert(dayCount > 0, 'dayCount must be positive'),
+        start = DateTime(start.year, start.month, start.day);
+
+  /// A week-aligned window: the [dayCount]-day window whose first column is the
+  /// most recent [firstWeekday] on or before [anchor].
+  ///
+  /// [firstWeekday] uses the `DateTime.monday`..`DateTime.sunday` constants
+  /// (`1`..`7`) and defaults to Monday, so `CalendarWindow.week(anchor: …)`
+  /// snaps any date in a week to that week's Monday. Pass
+  /// `firstWeekday: DateTime.sunday` for Sunday-first locales, or a smaller
+  /// [dayCount] (e.g. `5`) for a Monday–Friday work week.
+  factory CalendarWindow.week({
+    required DateTime anchor,
+    int firstWeekday = DateTime.monday,
+    int dayCount = 7,
+  }) {
+    final date = DateTime(anchor.year, anchor.month, anchor.day);
+    final back = (date.weekday - firstWeekday) % 7; // 0..6, never negative
+    return CalendarWindow(start: _addDays(date, -back), dayCount: dayCount);
+  }
+
+  /// The date shown in column [index], normalized to date-only. [index] is not
+  /// range-checked — values outside `0..dayCount-1` still return the date that
+  /// many days from [start] (useful for peeking just past the edges).
+  DateTime dateAt(int index) => _addDays(start, index);
+
+  /// The column offset of [date] from column `0`, **unclamped**: `0` for
+  /// [start]'s day, negative for days before the window, and `>= dayCount` for
+  /// days after it. [indexOf] is this restricted to days inside the window.
+  ///
+  /// Only the calendar day matters; [date]'s time-of-day is ignored.
+  int offsetOf(DateTime date) => _daysBetween(start, date);
+
+  /// The column index of [date] within this window, or `null` if its calendar
+  /// day falls outside `start .. start + dayCount - 1`.
+  int? indexOf(DateTime date) {
+    final i = offsetOf(date);
+    return (i >= 0 && i < dayCount) ? i : null;
+  }
+
+  /// Whether [date]'s calendar day falls within the window.
+  bool contains(DateTime date) => indexOf(date) != null;
+
+  /// The date of every column, in order (length == [dayCount]).
+  List<DateTime> get dates => [for (var i = 0; i < dayCount; i++) dateAt(i)];
+
+  /// The next window of the same length — i.e. step forward one window (one
+  /// week for the default `dayCount: 7`). Use for "next week" navigation.
+  CalendarWindow get next =>
+      CalendarWindow(start: _addDays(start, dayCount), dayCount: dayCount);
+
+  /// The previous window of the same length — step back one window.
+  CalendarWindow get previous =>
+      CalendarWindow(start: _addDays(start, -dayCount), dayCount: dayCount);
+
+  /// The column labels for `PlannerConfig.labels`, one per column.
+  ///
+  /// [format] turns each column's date into its header string; when omitted it
+  /// defaults to a localized `EEE d` (e.g. `Mon 8`) via `intl`'s [DateFormat],
+  /// honouring [Intl.defaultLocale]. Pass your own for a different format or
+  /// explicit locale, e.g. `labels((d) => DateFormat.MMMEd('fr_FR').format(d))`.
+  List<String> labels([String Function(DateTime date)? format]) {
+    final fmt = format ?? _defaultLabel;
+    return [for (final d in dates) fmt(d)];
+  }
+
+  /// The column index of today (`DateTime.now()`), or `null` if today is
+  /// outside this window. Feed it straight to `PlannerConfig.highlightedColumn`
+  /// for a "today" highlight (a `null` highlights nothing, which is exactly the
+  /// right behaviour when today is in another week).
+  int? get todayColumn => indexOf(DateTime.now());
+
+  /// The `PlannerTime` placing an event that starts at [start] and lasts
+  /// [duration] in this window, or `null` if [start]'s calendar day is outside
+  /// the window. The column comes from [start]'s date; the row comes from its
+  /// wall-clock [DateTime.hour] / [DateTime.minute]; [duration] is rounded to
+  /// whole minutes (clamped to a `1` minimum).
+  ///
+  /// Pass [end] to make the event span columns (#47): its column range becomes
+  /// `start .. end`, clamped to the window's last column if [end] runs past the
+  /// edge. The span renders as a band at the [start] time repeated across those
+  /// columns — the model is index-based, not a true running multi-day range
+  /// (ADR 0001). An [end] that is not after [start]'s column is ignored, giving
+  /// a single-column event.
+  PlannerTime? timeFor(
+    DateTime start, {
+    Duration duration = const Duration(hours: 1),
+    DateTime? end,
+  }) {
+    final day = indexOf(start);
+    if (day == null) return null;
+
+    int? endDay;
+    if (end != null) {
+      final lastOffset = offsetOf(end);
+      if (lastOffset > day) {
+        endDay = lastOffset >= dayCount ? dayCount - 1 : lastOffset;
+      }
+    }
+
+    final minutes = duration.inMinutes;
+    return PlannerTime(
+      day: day,
+      endDay: endDay,
+      hour: start.hour,
+      minutes: start.minute,
+      duration: minutes < 1 ? 1 : minutes,
+    );
+  }
+
+  /// Builds the `PlannerEntry` list for this window from your own dated
+  /// [events], dropping any whose start date falls outside the window.
+  ///
+  /// [start] reads each event's start `DateTime`; [build] turns an event plus
+  /// its computed [PlannerTime] into a `PlannerEntry` (you own the id, title,
+  /// colour and styles). [duration] supplies each event's length (default one
+  /// hour) and [end] an optional end date for a column-spanning event (#47) —
+  /// both via callbacks so they read from your own model:
+  ///
+  /// ```dart
+  /// final entries = window.entriesFor(
+  ///   myMeetings,
+  ///   start: (m) => m.startsAt,
+  ///   duration: (m) => m.length,
+  ///   build: (m, time) => PlannerEntry(
+  ///     id: m.id, time: time, title: m.title, content: m.notes,
+  ///     color: m.color,
+  ///   ),
+  /// );
+  /// ```
+  List<PlannerEntry> entriesFor<T>(
+    Iterable<T> events, {
+    required DateTime Function(T event) start,
+    required PlannerEntry Function(T event, PlannerTime time) build,
+    Duration Function(T event)? duration,
+    DateTime Function(T event)? end,
+  }) {
+    final result = <PlannerEntry>[];
+    for (final event in events) {
+      final time = timeFor(
+        start(event),
+        duration: duration?.call(event) ?? const Duration(hours: 1),
+        end: end?.call(event),
+      );
+      if (time != null) result.add(build(event, time));
+    }
+    return result;
+  }
+
+  static String _defaultLabel(DateTime date) =>
+      DateFormat('EEE d').format(date);
+
+  /// Adds [days] to [date] via the `DateTime` constructor (which normalizes
+  /// month/year overflow) rather than `Duration` arithmetic, so it lands on the
+  /// right calendar day even across a daylight-saving transition.
+  static DateTime _addDays(DateTime date, int days) =>
+      DateTime(date.year, date.month, date.day + days);
+
+  /// Whole calendar days from [from] to [to]. Both are reduced to date-only and
+  /// the hour difference is divided by 24 and rounded, so a 23- or 25-hour DST
+  /// day still counts as one day.
+  static int _daysBetween(DateTime from, DateTime to) {
+    final a = DateTime(from.year, from.month, from.day);
+    final b = DateTime(to.year, to.month, to.day);
+    return (b.difference(a).inHours / 24).round();
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CalendarWindow &&
+          other.start == start &&
+          other.dayCount == dayCount;
+
+  @override
+  int get hashCode => Object.hash(start, dayCount);
+
+  @override
+  String toString() => 'CalendarWindow(start: $start, dayCount: $dayCount)';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  # Used only by the optional, non-core calendar helpers (lib/calendar.dart) for
+  # the default date-label formatting; a wide range so it co-resolves with apps
+  # that pin intl via flutter_localizations.
+  intl: ">=0.18.0 <0.21.0"
 
 dev_dependencies:
   flutter_test:

--- a/test/calendar_planner_test.dart
+++ b/test/calendar_planner_test.dart
@@ -1,0 +1,75 @@
+// Composition test for the calendar helpers (#49): it drives the *real*
+// Planner with inputs derived entirely from a CalendarWindow — labels,
+// highlighted column, and entries built from dated events — and asserts the
+// date math lands events/highlight in the right columns once the widget paints
+// them. This is the end-to-end bridge from `DateTime`s to rendered geometry
+// that the pure-data calendar_test.dart can't cover on its own.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/events_painter.dart';
+
+import 'package:planner/calendar.dart';
+import 'package:planner/planner.dart';
+
+void main() {
+  Finder eventsCanvas() => find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is EventsPainter,
+      );
+
+  testWidgets(
+      'a CalendarWindow drives labels, highlight, and entry geometry on the real widget',
+      (tester) async {
+    // A Monday-first week; Wednesday is column 2.
+    final window = CalendarWindow.week(anchor: DateTime(2026, 6, 10));
+    final wednesday = window.dateAt(2);
+
+    // One dated event on Wednesday at 09:00, mapped through the helper.
+    final entries = window.entriesFor(
+      [(at: wednesday.add(const Duration(hours: 9)))],
+      start: (e) => e.at,
+      build: (e, time) => PlannerEntry(
+        id: 'evt',
+        time: time,
+        title: 'Meeting',
+        content: '',
+        color: const Color(0xFF2244AA),
+      ),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: PlannerConfig(
+            labels: window.labels(),
+            minHour: 0,
+            maxHour: 23,
+            // The helper says which column is "today's" Wednesday.
+            highlightedColumn: window.indexOf(wednesday),
+            highlightColumnColor: const Color(0xFF00FF00),
+          ),
+          entries: entries,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // labels() produced one header per column.
+    expect(window.labels(), hasLength(7));
+
+    // With the default 200x40 grid, column 2 occupies grid x 400..600. The
+    // green highlight fills that whole column; the event (fill = colour at
+    // alpha 0x64) sits in it at hour 9 -> top 360, height 40.
+    expect(
+      eventsCanvas(),
+      paints
+        ..rect(
+          rect: const Rect.fromLTWH(400, 0, 200, 960),
+          color: const Color(0xFF00FF00),
+        )
+        ..rect(
+          rect: const Rect.fromLTWH(400, 360, 200, 40),
+          color: const Color(0x642244AA),
+        ),
+    );
+  });
+}

--- a/test/calendar_test.dart
+++ b/test/calendar_test.dart
@@ -1,0 +1,296 @@
+// Unit tests for the optional, non-core calendar helpers (lib/calendar.dart,
+// #49). These are pure data: a `date <-> column-index` window, week alignment,
+// label/"today" derivation, and dated-event -> PlannerTime/PlannerEntry mapping.
+// They exercise the helper in isolation; calendar_planner_test.dart then drives
+// the real Planner with this output.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+import 'package:planner/calendar.dart';
+import 'package:planner/planner.dart';
+
+void main() {
+  // A concrete window used across the mapping tests: 7 days from 2026-06-08.
+  CalendarWindow week() => CalendarWindow(start: DateTime(2026, 6, 8));
+
+  group('construction', () {
+    test('normalizes start to date-only (drops the time component)', () {
+      final w = CalendarWindow(start: DateTime(2026, 6, 8, 17, 45, 30));
+      expect(w.start, DateTime(2026, 6, 8));
+      expect(w.dayCount, 7); // default
+    });
+
+    test('rejects a non-positive dayCount', () {
+      expect(() => CalendarWindow(start: DateTime(2026, 6, 8), dayCount: 0),
+          throwsA(isA<AssertionError>()));
+    });
+  });
+
+  group('date <-> index mapping', () {
+    test('dateAt walks consecutive calendar days from the start', () {
+      final w = week();
+      expect(w.dateAt(0), DateTime(2026, 6, 8));
+      expect(w.dateAt(3), DateTime(2026, 6, 11));
+      expect(w.dateAt(6), DateTime(2026, 6, 14));
+    });
+
+    test('dateAt normalizes across month and year boundaries', () {
+      expect(
+        CalendarWindow(start: DateTime(2026, 1, 30), dayCount: 5).dates,
+        [
+          DateTime(2026, 1, 30),
+          DateTime(2026, 1, 31),
+          DateTime(2026, 2, 1),
+          DateTime(2026, 2, 2),
+          DateTime(2026, 2, 3),
+        ],
+      );
+      expect(
+        CalendarWindow(start: DateTime(2025, 12, 31), dayCount: 2).dates,
+        [DateTime(2025, 12, 31), DateTime(2026, 1, 1)],
+      );
+    });
+
+    test('indexOf returns the column inside the window, null outside', () {
+      final w = week();
+      expect(w.indexOf(DateTime(2026, 6, 8)), 0);
+      expect(w.indexOf(DateTime(2026, 6, 11, 23, 59)), 3); // time ignored
+      expect(w.indexOf(DateTime(2026, 6, 14)), 6);
+      expect(w.indexOf(DateTime(2026, 6, 7)), isNull); // day before
+      expect(w.indexOf(DateTime(2026, 6, 15)), isNull); // day after
+    });
+
+    test('offsetOf is the unclamped offset (negative / past the edge)', () {
+      final w = week();
+      expect(w.offsetOf(DateTime(2026, 6, 8)), 0);
+      expect(w.offsetOf(DateTime(2026, 6, 5)), -3);
+      expect(w.offsetOf(DateTime(2026, 6, 20)), 12);
+    });
+
+    test('contains matches indexOf', () {
+      final w = week();
+      expect(w.contains(DateTime(2026, 6, 10)), isTrue);
+      expect(w.contains(DateTime(2026, 6, 1)), isFalse);
+    });
+
+    test('dates has one entry per column', () {
+      expect(week().dates, hasLength(7));
+      expect(CalendarWindow(start: DateTime(2026, 6, 8), dayCount: 5).dates,
+          hasLength(5));
+    });
+  });
+
+  group('week alignment', () {
+    test('snaps any day to its Monday by default', () {
+      // 2026-06-10 is a Wednesday; the Monday-first week starts 2026-06-08.
+      final w = CalendarWindow.week(anchor: DateTime(2026, 6, 10, 14, 0));
+      expect(w.start.weekday, DateTime.monday);
+      expect(w.start, DateTime(2026, 6, 8));
+      expect(w.contains(DateTime(2026, 6, 10)), isTrue);
+      expect(w.offsetOf(DateTime(2026, 6, 10)), inInclusiveRange(0, 6));
+    });
+
+    test('honours a Sunday-first week', () {
+      final w = CalendarWindow.week(
+          anchor: DateTime(2026, 6, 10), firstWeekday: DateTime.sunday);
+      expect(w.start.weekday, DateTime.sunday);
+      expect(w.start, DateTime(2026, 6, 7));
+    });
+
+    test('an anchor already on the first weekday returns itself', () {
+      final monday = CalendarWindow.week(anchor: DateTime(2026, 6, 10)).start;
+      expect(CalendarWindow.week(anchor: monday).start, monday);
+    });
+
+    test('supports a shorter work week', () {
+      final w = CalendarWindow.week(anchor: DateTime(2026, 6, 10), dayCount: 5);
+      expect(w.dayCount, 5);
+      expect(w.dates.last, DateTime(2026, 6, 12)); // Mon..Fri
+    });
+  });
+
+  group('stepping', () {
+    test('next / previous shift by a whole window', () {
+      final w = week();
+      expect(w.next.start, DateTime(2026, 6, 15));
+      expect(w.next.dayCount, 7);
+      expect(w.previous.start, DateTime(2026, 6, 1));
+    });
+
+    test('a 5-day window steps by 5 days', () {
+      final w = CalendarWindow(start: DateTime(2026, 6, 8), dayCount: 5);
+      expect(w.next.start, DateTime(2026, 6, 13));
+    });
+  });
+
+  group('labels', () {
+    test('uses a custom formatter for every column', () {
+      final w = week();
+      expect(
+        w.labels((d) => '${d.month}/${d.day}'),
+        ['6/8', '6/9', '6/10', '6/11', '6/12', '6/13', '6/14'],
+      );
+    });
+
+    test('defaults to a localized "EEE d" via intl', () {
+      Intl.defaultLocale = 'en_US';
+      final w = CalendarWindow.week(anchor: DateTime(2026, 6, 10)); // Mon start
+      final labels = w.labels();
+      expect(labels, hasLength(7));
+      expect(labels.first, DateFormat('EEE d', 'en_US').format(w.start));
+      expect(labels.first, startsWith('Mon')); // 2026-06-08 is a Monday
+    });
+  });
+
+  group('todayColumn', () {
+    test('is the column of today when today is in the window', () {
+      final today = DateTime.now();
+      final w = CalendarWindow(start: today, dayCount: 7);
+      expect(w.todayColumn, 0);
+    });
+
+    test('is null when today is outside the window', () {
+      final lastWeek = CalendarWindow(start: DateTime(2000, 1, 1), dayCount: 7);
+      expect(lastWeek.todayColumn, isNull);
+    });
+  });
+
+  group('timeFor', () {
+    test('places a dated event in its column at its wall-clock time', () {
+      final w = week();
+      final t = w.timeFor(DateTime(2026, 6, 10, 9, 30));
+      expect(t, isNotNull);
+      expect(t!.day, 2);
+      expect(t.hour, 9);
+      expect(t.minutes, 30);
+      expect(t.duration, 60); // default one hour
+      expect(t.endDay, isNull);
+    });
+
+    test('returns null for a date outside the window', () {
+      final w = week();
+      expect(w.timeFor(DateTime(2026, 6, 7, 9)), isNull);
+      expect(w.timeFor(DateTime(2026, 6, 15, 9)), isNull);
+    });
+
+    test('uses the given duration, rounded to a 1-minute minimum', () {
+      final w = week();
+      expect(
+          w
+              .timeFor(DateTime(2026, 6, 8, 9),
+                  duration: Duration(minutes: 90))!
+              .duration,
+          90);
+      expect(
+          w.timeFor(DateTime(2026, 6, 8, 9), duration: Duration.zero)!.duration,
+          1);
+    });
+
+    test('an end date after the start column spans columns (#47)', () {
+      final w = week();
+      final t = w.timeFor(DateTime(2026, 6, 9, 8), end: DateTime(2026, 6, 11));
+      expect(t!.day, 1);
+      expect(t.endDay, 3);
+      expect(t.spansColumns, isTrue);
+    });
+
+    test('an end date past the window clamps to the last column', () {
+      final w = week();
+      final t = w.timeFor(DateTime(2026, 6, 9, 8), end: DateTime(2026, 7, 1));
+      expect(t!.day, 1);
+      expect(t.endDay, 6); // dayCount - 1
+    });
+
+    test('an end not after the start column is ignored', () {
+      final w = week();
+      expect(
+          w.timeFor(DateTime(2026, 6, 9, 8), end: DateTime(2026, 6, 9))!.endDay,
+          isNull);
+      expect(
+          w.timeFor(DateTime(2026, 6, 9, 8), end: DateTime(2026, 6, 8))!.endDay,
+          isNull);
+    });
+  });
+
+  group('entriesFor', () {
+    test('maps dated events and drops those outside the window', () {
+      final w = week();
+      final events = [
+        (id: 'a', at: DateTime(2026, 6, 8, 9), len: Duration(minutes: 30)),
+        (id: 'b', at: DateTime(2026, 6, 10, 14), len: Duration(hours: 2)),
+        (
+          id: 'c',
+          at: DateTime(2026, 6, 99),
+          len: Duration(hours: 1)
+        ), // 6/99 -> out
+      ];
+
+      final entries = w.entriesFor(
+        events,
+        start: (e) => e.at,
+        duration: (e) => e.len,
+        build: (e, time) => PlannerEntry(
+          id: e.id,
+          time: time,
+          title: e.id,
+          content: '',
+          color: const Color(0xFF2244AA),
+        ),
+      );
+
+      expect(entries, hasLength(2)); // 'c' dropped
+      expect(entries[0].id, 'a');
+      expect(entries[0].time.day, 0);
+      expect(entries[0].time.duration, 30);
+      expect(entries[1].id, 'b');
+      expect(entries[1].time.day, 2);
+      expect(entries[1].time.hour, 14);
+      expect(entries[1].time.duration, 120);
+    });
+
+    test('defaults the duration to one hour when no callback is given', () {
+      final w = week();
+      final entries = w.entriesFor(
+        [DateTime(2026, 6, 8, 9)],
+        start: (d) => d,
+        build: (d, time) => PlannerEntry(
+            id: 'x', time: time, title: 'x', content: '', color: Colors.red),
+      );
+      expect(entries.single.time.duration, 60);
+    });
+
+    test('passes an end callback through to span columns', () {
+      final w = week();
+      final entries = w.entriesFor(
+        [(start: DateTime(2026, 6, 9), end: DateTime(2026, 6, 11))],
+        start: (e) => e.start,
+        end: (e) => e.end,
+        build: (e, time) => PlannerEntry(
+            id: 'span',
+            time: time,
+            title: 'span',
+            content: '',
+            color: Colors.green),
+      );
+      expect(entries.single.time.day, 1);
+      expect(entries.single.time.endDay, 3);
+    });
+  });
+
+  group('value semantics', () {
+    test('== and hashCode compare start and dayCount', () {
+      final a = CalendarWindow(start: DateTime(2026, 6, 8, 12), dayCount: 7);
+      final b = CalendarWindow(start: DateTime(2026, 6, 8), dayCount: 7);
+      final c = CalendarWindow(start: DateTime(2026, 6, 8), dayCount: 5);
+      expect(a, b); // time-of-day normalized away
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+    });
+
+    test('toString is readable', () {
+      expect(CalendarWindow(start: DateTime(2026, 6, 8)).toString(),
+          contains('dayCount: 7'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds optional, **non-core** calendar helpers so building an ordinary date-based
week calendar on top of the date-agnostic `Planner` is a few lines — without
`DateTime` ever entering the widget API (follow-up from #19 / ADR 0001). A single
`CalendarWindow` value type in a new `package:planner/calendar.dart` owns the
`date ↔ column-index` mapping; it is a **separate import**, deliberately *not*
re-exported from the main `planner.dart` barrel, so the core stays date-agnostic.

## Linked issue
Closes #49

## Changes
- **`lib/calendar.dart` (new):** `CalendarWindow` covering all three requirements:
  - **date ↔ index:** `dateAt` / `indexOf` / `offsetOf` / `contains` (DST-safe —
    wall-clock day arithmetic via the `DateTime` constructor, not `Duration`).
  - **week-builder:** `CalendarWindow.week(anchor:, firstWeekday:, dayCount:)`,
    `labels()` (default localized `EEE d` via `intl`, overridable with a
    `String Function(DateTime)`), `todayColumn` → `PlannerConfig.highlightedColumn`,
    and `next` / `previous` for week-stepping.
  - **events mapper:** `timeFor()` and generic `entriesFor<T>()` turn your own dated
    events into `PlannerEntry` / `PlannerTime`, dropping out-of-window ones, with
    column-spanning support (`end` date → `PlannerTime.endDay`, #47).
- **`pubspec.yaml`:** add `intl` (`>=0.18.0 <0.21.0`, wide so it co-resolves with
  apps that pin it via `flutter_localizations`) — used **only** by these helpers for
  the default label format.
- **Tests:** `test/calendar_test.dart` (29 unit tests) and
  `test/calendar_planner_test.dart` (drives the real `Planner` from helper output).
- **Docs:** README "Building a date-based week calendar" section + snippet,
  CHANGELOG entry, and #49 marked done in ADR 0001 and PROJECT_OVERVIEW.
- `example/pubspec.lock`: transitive `intl` (tracked; only root `pubspec.lock` is
  gitignored).

## Test plan
- [x] `flutter analyze` clean (no issues)
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] unit/widget tests pass — `flutter test`: **161 pass** (incl. 30 new)
- [x] integration/e2e tests pass — `flutter test integration_test -d windows` from
  `example/`: **29 scenarios pass** (confirms the example app still builds with the
  new `intl` dependency)

> **On the integration layer:** no *new* example-app integration test was added.
> This change is consumer-side, pure-data logic (no rendering/layout/navigation of
> its own) fully covered by unit tests, plus `calendar_planner_test.dart` which
> drives the real composed `Planner` with the helper's output and asserts a dated
> event and the "today" highlight land in the right columns end-to-end. The widget's
> rendering of arbitrary `labels`/`entries` is already covered by the existing
> integration suite (run above to confirm the `intl` dep didn't break the build).

## Notes
The issue specifies labels "formatted via `intl`", so `intl` is added as a
dependency to provide a sensible default format. The *code* is opt-in (separate
import), though the *dependency* now applies to all consumers; `intl` is near-
universal in Flutter and the constraint is wide to avoid resolution conflicts.
