### PR TITLE
feat: all-day band above the time grid (#48)

### DIFF
--- a/example/integration_test/all_day_band_scenarios.dart
+++ b/example/integration_test/all_day_band_scenarios.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/all_day_band.dart';
+import 'package:planner/internal/events_painter.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for the all-day band (#48): an entry flagged
+/// [PlannerTime.allDay] renders as a chip in a band *between* the date row and
+/// the time grid — under its column, spanning `day..endDay` for a multi-day
+/// all-day event — instead of being hour-positioned. The band auto-sizes to its
+/// stacked lanes and is omitted entirely when there are no all-day events.
+///
+/// The band is painted on its own `CustomPaint` canvas and its placement falls
+/// out of the real `Column`/`Row` composition, neither of which an isolated
+/// widget test exercises with real layout/fonts. So this drives the real
+/// composed widget and asserts both what the band canvas paints and where it
+/// lands relative to the date row and grid.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void allDayBandScenarios() {
+  // Scope `paints` assertions to each canvas so surrounding chrome can't match.
+  Finder allDayCanvas() => find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is AllDayBand,
+      );
+  Finder eventsCanvas() => find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is EventsPainter,
+      );
+
+  PlannerSpec withEntries(List<PlannerEntry> entries) => PlannerSpec(
+        config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'], minHour: 0, maxHour: 23),
+        entries: entries,
+      );
+
+  PlannerEntry allDay(String id, {required int day, int? endDay}) =>
+      PlannerEntry(
+        id: id,
+        time: PlannerTime(day: day, endDay: endDay, allDay: true),
+        title: id,
+        content: '',
+        color: const Color(0xFF2244AA),
+      );
+
+  testWidgets('an all-day chip paints in a band between the date row and grid',
+      (tester) async {
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        withEntries([allDay('holiday', day: 1)])
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    // Default geometry: hour column 50 wide, 200-wide columns, 24px lane, 2px
+    // band padding + 2px chip inset. Column 1's chip is therefore the box
+    // x 252..448, y 4..24 in the band canvas, filled with entry.color at alpha
+    // 100 (0x642244AA). A timed event would instead paint down in the grid.
+    expect(
+      allDayCanvas(),
+      paints
+        ..rect(
+          rect: const Rect.fromLTRB(252, 4, 448, 24),
+          color: const Color(0x642244AA),
+        ),
+    );
+
+    // The band sits below the 50px date row and the grid begins below the band
+    // (its height is one lane + padding = 28) — proving the band is inserted
+    // between them in the real composition, not overlaid on either.
+    final bandRect = tester.getRect(allDayCanvas());
+    final gridTop = tester.getRect(eventsCanvas()).top;
+    expect(bandRect.top, 50);
+    expect(gridTop, greaterThanOrEqualTo(bandRect.bottom));
+  });
+
+  testWidgets('a multi-day all-day event spans its columns in the band',
+      (tester) async {
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        withEntries([allDay('conf', day: 0, endDay: 1)])
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    // Columns 0..1 => one chip two columns wide: x 52..448 (gutter 50 + 2 inset
+    // .. gutter + 2*200 - 2), still in lane 0. A single-column chip would only
+    // reach x 248 — the 396-wide box is the spanning behaviour.
+    expect(
+      allDayCanvas(),
+      paints
+        ..rect(
+          rect: const Rect.fromLTRB(52, 4, 448, 24),
+          color: const Color(0x642244AA),
+        ),
+    );
+  });
+
+  testWidgets('no band is shown and the grid is flush when none are all-day',
+      (tester) async {
+    await tester.pumpWidget(PlannerHarness(
+      planners: [
+        withEntries([
+          PlannerEntry(
+            id: 'meeting',
+            time: PlannerTime(day: 0, hour: 9, duration: 60),
+            title: 'Meeting',
+            content: '',
+            color: const Color(0xFF2244AA),
+          ),
+        ]),
+      ],
+    ));
+    await tester.pumpAndSettle();
+
+    expect(allDayCanvas(), findsNothing);
+    // With no band the grid is flush under the 50px date row — the band reclaims
+    // its space rather than leaving an empty strip.
+    expect(tester.getRect(eventsCanvas()).top, 50);
+  });
+}

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -1,6 +1,7 @@
 import 'package:integration_test/integration_test.dart';
 
 import 'accessibility_scenarios.dart';
+import 'all_day_band_scenarios.dart';
 import 'app_smoke_scenarios.dart';
 import 'context_menu_labels_scenarios.dart';
 import 'context_menu_scenarios.dart';
@@ -29,6 +30,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   accessibilityScenarios();
+  allDayBandScenarios();
   appSmokeScenarios();
   contextMenuLabelsScenarios();
   contextMenuScenarios();

--- a/lib/internal/all_day_band.dart
+++ b/lib/internal/all_day_band.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import 'all_day_event.dart';
+import 'manager.dart';
+
+/// Paints the all-day band (#48): the row of chips above the time grid for
+/// events flagged [PlannerTime.allDay]. The host `Planner` only mounts this
+/// painter when there is at least one all-day event (the band auto-sizes to its
+/// lanes and is omitted at zero height otherwise), so [paint] always has chips.
+///
+/// The band's background is supplied by the wrapping `Container`, so this only
+/// draws the [AllDayEvent] chips. Like [DateRow] it repaints on the controller's
+/// update listenable (so a day-axis pan re-lays the chips) and otherwise only
+/// when the event data revision changes.
+class AllDayBand extends CustomPainter {
+  final Manager manager;
+
+  // The manager's data revision when this delegate was built; compared in
+  // shouldRepaint so the band repaints only when the data changed, not on every
+  // unrelated parent rebuild (#25 / D6). Pan/zoom repaints come via `repaint`.
+  final int _revision;
+
+  AllDayBand({required this.manager, required Listenable repaint})
+      : _revision = manager.revision,
+        super(repaint: repaint);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    for (final AllDayEvent event in manager.allDayEvents) {
+      event.paint(canvas);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant AllDayBand oldDelegate) =>
+      _revision != oldDelegate._revision;
+}

--- a/lib/internal/all_day_event.dart
+++ b/lib/internal/all_day_event.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../planner.dart';
+import 'manager.dart';
+
+/// Vertical inset above the first lane and below the last — the gap between the
+/// band's chips and its top/bottom edge. The band's total height is
+/// `laneCount * laneHeight + 2 * allDayBandVerticalPadding`.
+const double allDayBandVerticalPadding = 2.0;
+
+/// Inset applied to every chip inside its lane/column cell, so adjacent chips
+/// (and stacked lanes) read as separate boxes rather than a solid block.
+const double allDayChipInset = 2.0;
+
+/// A single all-day event (#48) rendered as a chip in the all-day band above the
+/// time grid. Unlike a timed [Event] it is not positioned by hour/minute: it
+/// occupies the columns `entry.time.day..entry.time.lastDay` (so a multi-day
+/// all-day event spans columns the same index-based way #47 events do) and the
+/// [lane] it was packed into (concurrent all-day events stack into separate
+/// lanes — see [Manager]'s all-day layout).
+///
+/// Render-only in this first cut, mirroring how spanning events shipped (#47):
+/// chips are painted but not draggable, editable, or hit-tested, and carry no
+/// accessibility node yet. Geometry tracks only the horizontal scroll
+/// ([Controller.offset]'s `dx`) — the band is a fixed header strip, so it
+/// neither zooms nor scrolls with the time axis.
+class AllDayEvent {
+  final PlannerEntry entry;
+  final Manager manager;
+
+  /// Which stacked lane (row) within the band this chip occupies. Lane 0 is the
+  /// topmost; [Manager] assigns it by first-fit packing on the column axis.
+  final int lane;
+
+  late final TextPainter _titlePainter;
+  late final Paint _fillPaint, _strokePaint;
+
+  AllDayEvent(
+      {required this.entry, required this.manager, required this.lane}) {
+    _fillPaint = Paint()
+      ..color = entry.color.withAlpha(100)
+      ..style = PaintingStyle.fill;
+    _strokePaint = Paint()
+      ..color = entry.color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1;
+
+    // Lay the title out once, ellipsized to the chip's (scroll-independent)
+    // width, so painting is allocation-free.
+    final width = _gridRect.width;
+    _titlePainter = TextPainter(
+      text: TextSpan(text: entry.title, style: entry.titleStyle),
+      textAlign: TextAlign.left,
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+      ellipsis: '...',
+    )..layout(maxWidth: (width - 10).clamp(0.0, double.infinity));
+  }
+
+  /// The chip rectangle in the band's own coordinate space (no horizontal
+  /// scroll applied): spans columns `day..lastDay` horizontally and sits in its
+  /// [lane] vertically, inset on every side by [allDayChipInset].
+  ///
+  /// The band canvas spans the full planner width (it sits above the hour column
+  /// too, like the date row), so each column's left edge is offset by the hour
+  /// column's width to line up with the event grid below — the same `pos`
+  /// convention `DateRow`/`DateLabel` use.
+  Rect get _gridRect {
+    final config = manager.config;
+    final blockWidth = config.blockWidth.toDouble();
+    final laneHeight = config.allDayBandLaneHeight;
+    final time = entry.time;
+
+    final columnLeft = config.hourColumnWidth + time.day * blockWidth;
+    final left = columnLeft + allDayChipInset;
+    final right = columnLeft + time.columnSpan * blockWidth - allDayChipInset;
+    final top = allDayBandVerticalPadding + lane * laneHeight + allDayChipInset;
+    final bottom = top + laneHeight - 2 * allDayChipInset;
+    return Rect.fromLTRB(left, top, right, bottom);
+  }
+
+  /// The chip's on-screen rectangle: its [_gridRect] shifted by the current
+  /// horizontal scroll only (the band doesn't move vertically or zoom). Exposed
+  /// so tests can assert placement without scraping the canvas.
+  Rect get screenRect => _gridRect.translate(manager.controller.offset.dx, 0);
+
+  void paint(Canvas canvas) {
+    final rect = screenRect;
+    canvas.drawRect(rect, _fillPaint);
+    canvas.drawRect(rect, _strokePaint);
+
+    canvas.save();
+    canvas.clipRect(rect);
+    // Left-pad the text and centre it vertically within the chip.
+    final textTop = rect.top + (rect.height - _titlePainter.height) / 2;
+    _titlePainter.paint(canvas, Offset(rect.left + 5, textTop));
+    canvas.restore();
+  }
+}

--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -44,6 +44,12 @@ class Controller {
   double _canvasWidth = 0;
   double _canvasHeight = 0;
 
+  // Vertical chrome reserved above the time grid besides the date row — the
+  // all-day band's height (#48), or 0 when no band is shown. Subtracted from the
+  // grid viewport when computing the time-axis scroll clamp so the grid can't
+  // over-scroll by the band's height.
+  double _reservedHeight = 0;
+
   MenuType menuType = MenuType.none;
   Offset? menuPos;
   Event? menuEvent;
@@ -73,6 +79,15 @@ class Controller {
     }
   }
 
+  /// Records the height of the chrome reserved above the time grid besides the
+  /// date row — the all-day band (#48). Recomputes the scroll clamp so the grid
+  /// viewport excludes the band. A no-op when the height is unchanged.
+  void setReservedHeight(double height) {
+    if (height == _reservedHeight) return;
+    _reservedHeight = height;
+    _calculateOffsets();
+  }
+
   void _calculateOffsets() {
     _minXOffset = 0;
     _maxXOffset =
@@ -80,7 +95,7 @@ class Controller {
     _minYOffset = 0;
     _maxYOffset = 0 -
         (((config.blockHeight * zoom) * (config.maxHour - config.minHour + 1) -
-            (_canvasHeight - config.dateRowHeight)));
+            (_canvasHeight - config.dateRowHeight - _reservedHeight)));
     if (_maxXOffset > 0) {
       _maxXOffset = 0;
     }

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../planner.dart';
+import 'all_day_event.dart';
 import 'controller.dart';
 import 'event.dart';
 
@@ -9,6 +10,16 @@ class Manager {
   List<PlannerEntry> entries;
   final Controller controller;
   final List<Event> events = [];
+
+  /// The all-day events (#48), packed into stacked lanes for the all-day band.
+  /// Built from entries whose [PlannerTime.allDay] is set; those are kept out of
+  /// [events] (the hour-positioned grid) entirely. Empty when none are all-day,
+  /// in which case the band is omitted and [allDayBandHeight] is zero.
+  final List<AllDayEvent> allDayEvents = [];
+
+  /// How many stacked lanes the all-day band needs — the height of the busiest
+  /// overlap of all-day events. Zero when there are no all-day events.
+  int allDayLaneCount = 0;
 
   // Bumped every time the event set is rebuilt (construct / update). Painters
   // snapshot it and compare it in shouldRepaint, so the canvas repaints — and
@@ -48,13 +59,69 @@ class Manager {
 
   void _buildEvents() {
     events.clear();
+    final allDayInputs = <PlannerEntry>[];
     for (PlannerEntry entry in entries) {
-      events.add(Event(entry: entry, manager: this));
+      // All-day entries render in the band, not the hour grid, so they're kept
+      // out of `events` (and thus out of overlap layout, hit-testing and drag).
+      if (entry.time.allDay) {
+        allDayInputs.add(entry);
+      } else {
+        events.add(Event(entry: entry, manager: this));
+      }
     }
     _layoutOverlaps();
+    _layoutAllDay(allDayInputs);
     _rebuildDayIndex();
+    // The band reserves vertical space above the grid, so the time-axis scroll
+    // clamp must account for it (else the grid can over-scroll by the band's
+    // height). Re-applied whenever the all-day layout can have changed.
+    controller.setReservedHeight(allDayBandHeight);
     _revision++;
   }
+
+  /// Packs the all-day events (#48) into stacked lanes for the band. Each event
+  /// covers columns `day..lastDay` (a multi-day all-day event spans columns the
+  /// same index-based way #47 does), and concurrent ones — those sharing any
+  /// column — must not share a lane. First-fit on the column axis (sorted by
+  /// start column, then end) gives the standard side-by-side stacking with the
+  /// fewest lanes, mirroring the per-column time packing in [_layoutDayColumn].
+  void _layoutAllDay(List<PlannerEntry> allDayInputs) {
+    allDayEvents.clear();
+
+    final sorted = [...allDayInputs]..sort((a, b) {
+        final byStart = a.time.day.compareTo(b.time.day);
+        return byStart != 0
+            ? byStart
+            : a.time.lastDay.compareTo(b.time.lastDay);
+      });
+
+    // The last column (inclusive) used by each open lane. A lane is free for an
+    // event starting at `day` once its previous occupant ended before `day`.
+    final laneLastColumn = <int>[];
+    for (final entry in sorted) {
+      final start = entry.time.day;
+      final end = entry.time.lastDay;
+      var lane = laneLastColumn.indexWhere((last) => last < start);
+      if (lane == -1) {
+        lane = laneLastColumn.length;
+        laneLastColumn.add(end);
+      } else {
+        laneLastColumn[lane] = end;
+      }
+      allDayEvents.add(AllDayEvent(entry: entry, manager: this, lane: lane));
+    }
+
+    allDayLaneCount = laneLastColumn.length;
+  }
+
+  /// The height the all-day band occupies above the time grid: enough for every
+  /// stacked lane plus the band's top/bottom padding, or `0` when there are no
+  /// all-day events (the band is then omitted entirely). Drives both the band
+  /// widget's height and the controller's scroll-clamp reservation.
+  double get allDayBandHeight => allDayLaneCount == 0
+      ? 0
+      : allDayLaneCount * config.allDayBandLaneHeight +
+          2 * allDayBandVerticalPadding;
 
   /// Rebuilds the [_eventsByDay] hit-test buckets from the current [events].
   /// One linear pass, called only when the event set or an event's day can have

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -2,6 +2,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'internal/all_day_band.dart';
 import 'internal/context_menu.dart';
 import 'internal/controller.dart';
 import 'internal/event.dart';
@@ -130,6 +131,10 @@ class _PlannerState extends State<Planner> {
       return Column(
         children: [
           paintDates(),
+          // The all-day band (#48) sits between the date row and the time grid.
+          // It self-sizes to its lanes and is omitted entirely (no widget, no
+          // reserved space) when there are no all-day events.
+          if (_data.allDayBandHeight > 0) paintAllDayBand(),
           Expanded(
             child: Row(
               children: [
@@ -207,6 +212,33 @@ class _PlannerState extends State<Planner> {
           color: _data.config.dateBackground,
           child: CustomPaint(
             painter: DateRow(
+              manager: _data,
+              repaint: _data.controller.triggerUpdate,
+            ),
+            child: Container(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// The all-day band (#48): a fixed strip of chips above the time grid for
+  /// events flagged [PlannerTime.allDay]. Like the date row directly above it,
+  /// it pans the day axis on a horizontal drag (so it isn't a dead zone) and
+  /// tracks the horizontal scroll, but it does not zoom or scroll with the time
+  /// axis. Only mounted when there is at least one all-day event.
+  Widget paintAllDayBand() {
+    return GestureDetector(
+      onHorizontalDragStart: (detail) =>
+          _data.controller.startHorizontalDrag(detail.globalPosition.dx),
+      onHorizontalDragUpdate: (detail) =>
+          _data.controller.updateHorizontalDrag(detail.globalPosition.dx),
+      child: ClipRect(
+        child: Container(
+          height: _data.allDayBandHeight,
+          color: _data.config.allDayBandBackground,
+          child: CustomPaint(
+            painter: AllDayBand(
               manager: _data,
               repaint: _data.controller.triggerUpdate,
             ),

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -65,6 +65,19 @@ class PlannerConfig {
   double dateRowHeight;
   double hourColumnWidth;
 
+  /// Height, in logical pixels, of one stacked lane in the all-day band (#48).
+  /// All-day events ([PlannerTime.allDay]) render as chips above the time grid;
+  /// concurrent ones (sharing a column) stack into separate lanes, and the band
+  /// auto-sizes to the number of lanes used. The band is omitted entirely (zero
+  /// height) when there are no all-day events, so this has no effect then.
+  double allDayBandLaneHeight;
+
+  /// Background fill of the all-day band (#48). Defaults to a dark grey close to
+  /// the [plannerBackground] so the band reads as the top of the column area;
+  /// override it to match a light theme or to set it off from the grid. Ignored
+  /// when there are no all-day events (the band isn't shown).
+  Color allDayBandBackground;
+
   TextStyle hourLabelStyle;
   TextStyle dateLabelStyle;
   TextStyle contextMenuTextStyle;
@@ -180,6 +193,8 @@ class PlannerConfig {
     this.zoomButtonColor,
     this.zoomButtonIconColor = Colors.white,
     this.scrollStep = 20,
+    this.allDayBandLaneHeight = 24,
+    this.allDayBandBackground = const Color.fromARGB(255, 60, 60, 60),
     this.plannerBackground = const Color.fromARGB(255, 50, 50, 50),
     this.horizontalLineColor = const Color.fromARGB(255, 100, 100, 100),
     this.verticalLineColor = const Color.fromARGB(255, 150, 150, 150),

--- a/lib/planner_time.dart
+++ b/lib/planner_time.dart
@@ -8,6 +8,12 @@
 /// enters the model (ADR 0001). [endDay] of `null` (or any value `<= day`) is a
 /// single-column event, the default.
 ///
+/// An event may instead be **all-day** (#48): when [allDay] is `true` the event
+/// is not positioned by [hour]/[minutes]/[duration] at all — those are ignored —
+/// and instead renders as a chip in the all-day band above the time grid, under
+/// its column ([day], or across `day..endDay` for a multi-day all-day event).
+/// Still index-based; no `DateTime` (ADR 0001).
+///
 /// Immutable (#27): every field is `final`, so a drag/resize or accessibility
 /// nudge produces a *new* instance via [copyWith] rather than mutating in place,
 /// which keeps diffing predictable and lets value [==] decide when anything
@@ -25,12 +31,20 @@ class PlannerTime {
   final int minutes;
   final int duration;
 
+  /// Whether this is an all-day event (#48). When `true` the event renders in
+  /// the all-day band above the time grid rather than at an hour position, so
+  /// [hour]/[minutes]/[duration] are ignored for layout; only [day] (and
+  /// [endDay] for a multi-day all-day event) decide which column(s) it covers.
+  /// Defaults to `false` — an ordinary hour-positioned event.
+  final bool allDay;
+
   PlannerTime(
       {this.day = 0,
       this.endDay,
       this.hour = 0,
       this.minutes = 0,
-      this.duration = 60});
+      this.duration = 60,
+      this.allDay = false});
 
   /// The last column the event covers, inclusive and never before [day]: the
   /// raw [endDay] when it lies after [day], otherwise [day] itself. Geometry and
@@ -45,13 +59,19 @@ class PlannerTime {
 
   /// Returns a copy with the given fields replaced; omitted fields are kept.
   PlannerTime copyWith(
-          {int? day, int? endDay, int? hour, int? minutes, int? duration}) =>
+          {int? day,
+          int? endDay,
+          int? hour,
+          int? minutes,
+          int? duration,
+          bool? allDay}) =>
       PlannerTime(
         day: day ?? this.day,
         endDay: endDay ?? this.endDay,
         hour: hour ?? this.hour,
         minutes: minutes ?? this.minutes,
         duration: duration ?? this.duration,
+        allDay: allDay ?? this.allDay,
       );
 
   @override
@@ -62,12 +82,13 @@ class PlannerTime {
           other.endDay == endDay &&
           other.hour == hour &&
           other.minutes == minutes &&
-          other.duration == duration;
+          other.duration == duration &&
+          other.allDay == allDay;
 
   @override
-  int get hashCode => Object.hash(day, endDay, hour, minutes, duration);
+  int get hashCode => Object.hash(day, endDay, hour, minutes, duration, allDay);
 
   @override
   String toString() =>
-      'PlannerTime(day: $day, endDay: $endDay, hour: $hour, minutes: $minutes, duration: $duration)';
+      'PlannerTime(day: $day, endDay: $endDay, hour: $hour, minutes: $minutes, duration: $duration, allDay: $allDay)';
 }

--- a/test/all_day_band_test.dart
+++ b/test/all_day_band_test.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/all_day_band.dart';
+import 'package:planner/internal/all_day_event.dart';
+import 'package:planner/internal/events_painter.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+
+// All-day band (#48): an entry flagged PlannerTime.allDay renders as a chip in
+// a band above the time grid (under its column, spanning day..endDay for a
+// multi-day all-day event) instead of being hour-positioned. Concurrent all-day
+// events stack into lanes and the band auto-sizes to them; it's omitted at zero
+// height when there are none. The flag stays index-based (no DateTime; ADR
+// 0001), and the band is render-only in this first cut (mirrors the #47 span).
+
+void main() {
+  // PlannerConfig defaults the test geometry relies on.
+  const hourColumnWidth = 50.0;
+  const blockWidth = 200;
+  const laneHeight = 24.0;
+
+  Manager managerWith(
+    List<PlannerEntry> entries, {
+    List<String> labels = const ['A', 'B', 'C'],
+  }) =>
+      Manager(
+        config: PlannerConfig(labels: labels, minHour: 0),
+        entries: entries,
+      );
+
+  PlannerEntry allDayAt(String id, {required int day, int? endDay}) =>
+      PlannerEntry(
+        id: id,
+        time: PlannerTime(day: day, endDay: endDay, allDay: true),
+        title: id,
+        content: '',
+        color: const Color(0xFF2244AA),
+      );
+
+  PlannerEntry timedAt(String id, {required int day, required int hour}) =>
+      PlannerEntry(
+        id: id,
+        time: PlannerTime(day: day, hour: hour, duration: 60),
+        title: id,
+        content: '',
+        color: const Color(0xFF112233),
+      );
+
+  double bandHeightFor(int lanes) =>
+      lanes == 0 ? 0 : lanes * laneHeight + 2 * allDayBandVerticalPadding;
+
+  group('PlannerTime.allDay model', () {
+    test('defaults to false (an ordinary timed event)', () {
+      expect(PlannerTime(day: 0, hour: 9).allDay, isFalse);
+    });
+
+    test('copyWith carries allDay, and value equality includes it', () {
+      final base = PlannerTime(day: 0, allDay: true);
+      expect(base.copyWith(day: 1).allDay, isTrue);
+      expect(base.copyWith(allDay: false).allDay, isFalse);
+
+      expect(PlannerTime(day: 0, allDay: true),
+          equals(PlannerTime(day: 0, allDay: true)));
+      expect(PlannerTime(day: 0, allDay: true),
+          isNot(equals(PlannerTime(day: 0))));
+      expect(PlannerTime(day: 0, allDay: true).hashCode,
+          PlannerTime(day: 0, allDay: true).hashCode);
+    });
+
+    test('toString surfaces allDay', () {
+      expect(PlannerTime(day: 0, allDay: true).toString(),
+          contains('allDay: true'));
+    });
+  });
+
+  group('Manager partitions all-day from timed events', () {
+    test('an all-day entry is kept out of the hour-grid events list', () {
+      final manager = managerWith([
+        allDayAt('holiday', day: 0),
+        timedAt('meeting', day: 0, hour: 9),
+      ]);
+
+      expect(manager.events.map((e) => e.entry.id), ['meeting'],
+          reason: 'only the timed entry is an hour-positioned Event');
+      expect(manager.allDayEvents.map((e) => e.entry.id), ['holiday']);
+    });
+
+    test('an all-day entry is not hit-tested on the grid (render-only)', () {
+      final manager = managerWith([allDayAt('holiday', day: 0)]);
+      // A point anywhere in column 0's grid resolves to no event: the all-day
+      // entry lives in the band, not the hour grid.
+      expect(manager.getEventAtPos(const Offset(100, 100)), isNull);
+    });
+  });
+
+  group('lane packing', () {
+    int laneOf(Manager m, String id) =>
+        m.allDayEvents.firstWhere((e) => e.entry.id == id).lane;
+
+    test('a single all-day event takes lane 0', () {
+      final manager = managerWith([allDayAt('a', day: 1)]);
+      expect(manager.allDayLaneCount, 1);
+      expect(laneOf(manager, 'a'), 0);
+    });
+
+    test('two all-day events in the same column stack into separate lanes', () {
+      final manager = managerWith([
+        allDayAt('a', day: 1),
+        allDayAt('b', day: 1),
+      ]);
+      expect(manager.allDayLaneCount, 2);
+      expect(laneOf(manager, 'a'), 0);
+      expect(laneOf(manager, 'b'), 1);
+    });
+
+    test('all-day events in different columns share one lane', () {
+      final manager = managerWith([
+        allDayAt('a', day: 0),
+        allDayAt('b', day: 2),
+      ]);
+      expect(manager.allDayLaneCount, 1);
+      expect(laneOf(manager, 'a'), 0);
+      expect(laneOf(manager, 'b'), 0);
+    });
+
+    test('a multi-day span and a column it covers stack', () {
+      // 'span' covers columns 0..2; 'b' sits in column 1, which the span
+      // crosses, so they overlap and must not share a lane.
+      final manager = managerWith([
+        allDayAt('span', day: 0, endDay: 2),
+        allDayAt('b', day: 1),
+      ]);
+      expect(manager.allDayLaneCount, 2);
+      expect(laneOf(manager, 'span'), 0); // sorts first (start column 0)
+      expect(laneOf(manager, 'b'), 1);
+    });
+  });
+
+  group('band height', () {
+    test('is zero when there are no all-day events', () {
+      final manager = managerWith([timedAt('m', day: 0, hour: 9)]);
+      expect(manager.allDayLaneCount, 0);
+      expect(manager.allDayBandHeight, 0);
+    });
+
+    test('grows by one lane height per stacked lane', () {
+      final one = managerWith([allDayAt('a', day: 0)]);
+      expect(one.allDayBandHeight, bandHeightFor(1));
+
+      final two = managerWith([
+        allDayAt('a', day: 0),
+        allDayAt('b', day: 0),
+      ]);
+      expect(two.allDayBandHeight, bandHeightFor(2));
+    });
+  });
+
+  group('chip geometry', () {
+    test('a single-column chip lines up under its column (past the gutter)',
+        () {
+      // day 1: column left = hourColumnWidth + 1*blockWidth = 250, inset 2 on
+      // every side; lane 0 sits below the band's top padding.
+      final chip = managerWith([allDayAt('a', day: 1)]).allDayEvents.single;
+      expect(chip.screenRect, const Rect.fromLTRB(252, 4, 448, 24));
+    });
+
+    test('a multi-day chip spans day..endDay columns', () {
+      // day 0..2 => 3 columns wide: left = gutter + 2 inset = 52,
+      // right = gutter + 3*blockWidth - 2 = 648.
+      final chip = managerWith([allDayAt('span', day: 0, endDay: 2)])
+          .allDayEvents
+          .single;
+      expect(chip.screenRect,
+          const Rect.fromLTRB(52, 4, hourColumnWidth + 3 * blockWidth - 2, 24));
+    });
+
+    test('a second lane sits one lane height below the first', () {
+      final manager = managerWith([
+        allDayAt('a', day: 0),
+        allDayAt('b', day: 0),
+      ]);
+      final b = manager.allDayEvents.firstWhere((e) => e.entry.id == 'b');
+      // lane 1: top = padding + 1*laneHeight + inset = 2 + 24 + 2 = 28.
+      expect(b.screenRect.top, 28);
+      expect(b.screenRect.bottom, 28 + laneHeight - 2 * allDayChipInset);
+    });
+  });
+
+  group('controller reserves the band height in the scroll clamp', () {
+    // A taller header (the band) shrinks the time-grid viewport, so the bottom
+    // hour stays reachable: the max downward scroll must grow by exactly the
+    // band's height. Without the reservation the last row would be cut off.
+    Manager sized(List<PlannerEntry> entries) {
+      final m = managerWith(entries);
+      m.controller.setSize(const Size(800, 500));
+      return m;
+    }
+
+    double maxDownScroll(Manager m) {
+      // Scroll well past the end (verticalScroll(true) moves toward later hours,
+      // the way a wheel-down notch does); y clamps to the max downward offset.
+      for (var i = 0; i < 200; i++) {
+        m.controller.verticalScroll(true);
+      }
+      return m.controller.y;
+    }
+
+    test('two stacked lanes push the clamp down by the band height', () {
+      final none = maxDownScroll(sized([timedAt('m', day: 0, hour: 9)]));
+      final band = maxDownScroll(sized([
+        allDayAt('a', day: 0),
+        allDayAt('b', day: 0),
+      ]));
+      expect(band, none - bandHeightFor(2));
+    });
+  });
+
+  group('widget rendering', () {
+    Finder allDayCanvas() => find.byWidgetPredicate(
+          (w) => w is CustomPaint && w.painter is AllDayBand,
+        );
+    Finder eventsCanvas() => find.byWidgetPredicate(
+          (w) => w is CustomPaint && w.painter is EventsPainter,
+        );
+
+    Future<void> pump(WidgetTester tester, List<PlannerEntry> entries) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Planner(
+            config: PlannerConfig(
+                labels: const ['c1', 'c2', 'c3'], minHour: 0, maxHour: 23),
+            entries: entries,
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('no band is mounted when there are no all-day events',
+        (tester) async {
+      await pump(tester, [timedAt('m', day: 0, hour: 9)]);
+      expect(allDayCanvas(), findsNothing);
+      expect(eventsCanvas(), findsOneWidget);
+    });
+
+    testWidgets('the band paints a chip under its column', (tester) async {
+      await pump(tester, [allDayAt('a', day: 1)]);
+
+      expect(allDayCanvas(), findsOneWidget);
+      // Chip fill is entry.color at alpha 100 (0x642244AA), at the geometry the
+      // chip-geometry unit test pins down.
+      expect(
+        allDayCanvas(),
+        paints
+          ..rect(
+            rect: const Rect.fromLTRB(252, 4, 448, 24),
+            color: const Color(0x642244AA),
+          ),
+      );
+    });
+
+    testWidgets('the band sits between the date row and the time grid',
+        (tester) async {
+      await pump(tester, [allDayAt('a', day: 0)]);
+      final bandTop = tester.getRect(allDayCanvas()).top;
+      final gridTop = tester.getRect(eventsCanvas()).top;
+      // Date row default height is 50, so the band starts at y=50 and the grid
+      // begins below it.
+      expect(bandTop, 50);
+      expect(gridTop, greaterThanOrEqualTo(bandTop + bandHeightFor(1)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds an optional **all-day band** between the date row and the hour grid. Entries flagged `PlannerTime.allDay` render as chips in that band under their column (or across `day..endDay` for a multi-day all-day event) instead of being hour-positioned. The flag stays index-based — no `DateTime` enters the API (ADR 0001) — and this is a **render-only first cut**, mirroring how column-spanning events shipped read-only (#47).

## Linked issue
Closes #48

## Changes
- **Model** (`planner_time.dart`): new `bool allDay` flag (default `false`); wired into ctor, `copyWith`, `==`, `hashCode`, `toString`. All-day entries are partitioned out of the hour-grid `events` entirely.
- **Config** (`planner_config.dart`): `allDayBandLaneHeight` (24) and `allDayBandBackground`.
- **Layout** (`manager.dart` / `controller.dart`): first-fit lane packing on the column axis, so concurrent all-day events stack and a multi-day one spans its columns as one chip. The band self-sizes to its lanes and is **omitted at zero height** when there are none; the controller reserves the band height so the time grid's scroll clamp keeps the bottom hour reachable.
- **Painter** (`all_day_event.dart`, `all_day_band.dart`, new): chips offset past the hour gutter like `DateRow`, tracking the day-axis pan but not zooming/scrolling with the time axis.
- **Widget** (`planner_class.dart`): inserts the band between the date row and grid; pans the day axis on horizontal drag like the date row.

## Scope / follow-up
Render-only first cut: all-day chips aren't draggable, hit-tested, or exposed to accessibility yet — tracked in **#72**. The example app is unchanged (the band is zero-height without all-day entries, so existing smoke scenarios are untouched).

## Test plan
- [x] `flutter analyze` clean
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] unit/widget tests pass (`flutter test`) — **179 pass**, incl. 18 new in `test/all_day_band_test.dart` (model, partitioning, lane packing, band height, chip geometry, scroll-clamp reservation, rendering/omission)
- [x] integration/e2e tests pass (`flutter test integration_test/app_test.dart -d windows`) — **32 pass**, incl. 3 new in `all_day_band_scenarios.dart` (chip renders between date row and grid, multi-day chip spans columns, band omitted when none)