### PR TITLE
feat: interactive + accessible all-day band, opt-in (#72)

### DIFF
--- a/example/integration_test/all_day_band_scenarios.dart
+++ b/example/integration_test/all_day_band_scenarios.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/internal/all_day_band.dart';
 import 'package:planner/internal/events_painter.dart';
@@ -31,7 +33,10 @@ void allDayBandScenarios() {
 
   PlannerSpec withEntries(List<PlannerEntry> entries) => PlannerSpec(
         config: PlannerConfig(
-            labels: const ['c1', 'c2', 'c3'], minHour: 0, maxHour: 23),
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            showAllDayBand: true),
         entries: entries,
       );
 
@@ -42,6 +47,37 @@ void allDayBandScenarios() {
         title: id,
         content: '',
         color: const Color(0xFF2244AA),
+      );
+
+  // Default geometry (gutter 50, 200-wide columns, 24px lane, 2px band padding):
+  // an all-day chip for `day` sits in the band at planner-local y≈64 (date row 50
+  // + lane-0 centre 14). The column-1 chip used by these scenarios spans
+  // planner-local x 252..448, so its centre is x≈350; empty column 0 is x≈150.
+  Offset chipPoint(Rect planner) => planner.topLeft + const Offset(350, 64);
+  Offset emptyBandPoint(Rect planner) =>
+      planner.topLeft + const Offset(150, 64);
+
+  // A planner whose all-day band is enabled and wired to the given callbacks, so
+  // a scenario can observe which entry/time an interaction routed to.
+  PlannerSpec wired({
+    required List<PlannerEntry> entries,
+    void Function(PlannerEntry)? onEdit,
+    void Function(PlannerEntry)? onDelete,
+    void Function(PlannerTime)? onCreate,
+    void Function(PlannerEntry)? onLongPress,
+  }) =>
+      PlannerSpec(
+        config: PlannerConfig(
+          labels: const ['c1', 'c2', 'c3'],
+          minHour: 0,
+          maxHour: 23,
+          showAllDayBand: true,
+          onEntryEdit: onEdit,
+          onEntryDelete: onDelete,
+          onEntryCreate: onCreate,
+          onEntryLongPress: onLongPress,
+        ),
+        entries: entries,
       );
 
   testWidgets('an all-day chip paints in a band between the date row and grid',
@@ -119,4 +155,187 @@ void allDayBandScenarios() {
     // its space rather than leaving an empty strip.
     expect(tester.getRect(eventsCanvas()).top, 50);
   });
+
+  // --- Interaction parity (#72) ---------------------------------------------
+  // These drive real gestures on the real composed band (its own GestureDetector
+  // sharing an arena with the day-axis horizontal drag, and the context menu
+  // lifted to the planner-wide Stack so it can overflow the thin band over the
+  // grid). An isolated widget test exercises none of that composition.
+
+  testWidgets('double-tapping an all-day chip fires onEntryEdit',
+      (tester) async {
+    final edited = <PlannerEntry>[];
+    await tester.pumpWidget(PlannerHarness(planners: [
+      wired(entries: [allDay('holiday', day: 1)], onEdit: edited.add),
+    ]));
+    await tester.pumpAndSettle();
+
+    await _doubleTapAt(tester, chipPoint(tester.getRect(find.byType(Planner))));
+
+    expect(edited.single.id, 'holiday',
+        reason: 'a chip double-tap edits, mirroring the timed grid');
+  });
+
+  testWidgets('double-tapping empty band space creates an all-day event',
+      (tester) async {
+    final created = <PlannerTime>[];
+    await tester.pumpWidget(PlannerHarness(planners: [
+      wired(entries: [allDay('holiday', day: 1)], onCreate: created.add),
+    ]));
+    await tester.pumpAndSettle();
+
+    // Empty column 0 (the chip is in column 1).
+    await _doubleTapAt(
+        tester, emptyBandPoint(tester.getRect(find.byType(Planner))));
+
+    expect(created.single.allDay, isTrue);
+    expect(created.single.day, 0,
+        reason: 'create maps to the tapped column, flagged all-day');
+  });
+
+  testWidgets('right-clicking a chip opens edit/delete; Edit fires onEntryEdit',
+      (tester) async {
+    final edited = <PlannerEntry>[];
+    await tester.pumpWidget(PlannerHarness(planners: [
+      wired(
+          entries: [allDay('holiday', day: 1)],
+          onEdit: edited.add,
+          onDelete: (_) {}),
+    ]));
+    await tester.pumpAndSettle();
+
+    await _rightClickAt(
+        tester, chipPoint(tester.getRect(find.byType(Planner))));
+
+    // The chip opens the entry menu (edit/delete), not the create menu — proof
+    // the band-local right-click hit-tested the chip and the lifted menu renders.
+    expect(find.text('Edit Event'), findsOneWidget);
+    expect(find.text('Delete Event'), findsOneWidget);
+    expect(find.text('Create Event'), findsNothing);
+
+    await tester.tap(find.text('Edit Event'));
+    await tester.pumpAndSettle();
+    expect(edited.single.id, 'holiday');
+  });
+
+  testWidgets('right-clicking empty band space offers Create (all-day)',
+      (tester) async {
+    final created = <PlannerTime>[];
+    await tester.pumpWidget(PlannerHarness(planners: [
+      wired(entries: [allDay('holiday', day: 1)], onCreate: created.add),
+    ]));
+    await tester.pumpAndSettle();
+
+    await _rightClickAt(
+        tester, emptyBandPoint(tester.getRect(find.byType(Planner))));
+
+    expect(find.text('Create Event'), findsOneWidget);
+    expect(find.text('Edit Event'), findsNothing);
+
+    await tester.tap(find.text('Create Event'));
+    await tester.pumpAndSettle();
+    expect(created.single.allDay, isTrue);
+    expect(created.single.day, 0);
+  });
+
+  testWidgets('long-pressing an all-day chip fires onEntryLongPress',
+      (tester) async {
+    final longPressed = <PlannerEntry>[];
+    await tester.pumpWidget(PlannerHarness(planners: [
+      wired(entries: [allDay('holiday', day: 1)], onLongPress: longPressed.add),
+    ]));
+    await tester.pumpAndSettle();
+
+    await tester.longPressAt(chipPoint(tester.getRect(find.byType(Planner))));
+    await tester.pumpAndSettle();
+
+    expect(longPressed.single.id, 'holiday',
+        reason: 'long-press is the touch path to act on a chip');
+  });
+
+  testWidgets('the band exposes each chip and its actions to a11y',
+      (tester) async {
+    final handle = tester.ensureSemantics();
+    final edited = <PlannerEntry>[];
+    final deleted = <PlannerEntry>[];
+    await tester.pumpWidget(PlannerHarness(planners: [
+      wired(
+          entries: [allDay('Holiday', day: 1)],
+          onEdit: edited.add,
+          onDelete: deleted.add),
+    ]));
+    await tester.pumpAndSettle();
+
+    final owner =
+        tester.renderObject(find.byType(Planner)).owner!.semanticsOwner!;
+    final node = _findByLabelPrefix(owner, 'Holiday');
+    // Label reads title, column ('c2' is column index 1), and "all day".
+    expect(node.getSemanticsData().label, 'Holiday, c2, all day');
+
+    owner.performAction(node.id, SemanticsAction.tap);
+    await tester.pump();
+    expect(edited.single.id, 'Holiday');
+
+    owner.performAction(node.id, SemanticsAction.dismiss);
+    await tester.pump();
+    expect(deleted.single.id, 'Holiday');
+
+    handle.dispose();
+  });
+
+  testWidgets('no band is shown when disabled, even with all-day entries',
+      (tester) async {
+    await tester.pumpWidget(PlannerHarness(planners: [
+      PlannerSpec(
+        // showAllDayBand defaults to false — the opt-in gate is off.
+        config: PlannerConfig(
+            labels: const ['c1', 'c2', 'c3'], minHour: 0, maxHour: 23),
+        entries: [allDay('holiday', day: 1)],
+      ),
+    ]));
+    await tester.pumpAndSettle();
+
+    expect(allDayCanvas(), findsNothing);
+    expect(tester.getRect(eventsCanvas()).top, 50,
+        reason: 'with the band off the grid is flush under the date row');
+  });
+}
+
+/// Double-taps at [at]: two primary taps within the double-tap window, the way
+/// the GestureDetector's double-tap recognizer expects them.
+Future<void> _doubleTapAt(WidgetTester tester, Offset at) async {
+  await tester.tapAt(at);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tapAt(at);
+  await tester.pumpAndSettle();
+}
+
+/// Right-clicks (secondary press) at [at] and settles, opening the context menu
+/// via `onSecondaryTapDown`.
+Future<void> _rightClickAt(WidgetTester tester, Offset at) async {
+  final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+/// Returns the first semantics node under [owner] whose label starts with
+/// [prefix]. CustomPaint semantics are raw `SemanticsNode`s, so a widget finder
+/// can't reach them — the tree is walked directly.
+SemanticsNode _findByLabelPrefix(SemanticsOwner owner, String prefix) {
+  SemanticsNode? found;
+  void visit(SemanticsNode node) {
+    if (found == null && node.getSemanticsData().label.startsWith(prefix)) {
+      found = node;
+    }
+    node.visitChildren((child) {
+      visit(child);
+      return found == null;
+    });
+  }
+
+  visit(owner.rootSemanticsNode!);
+  expect(found, isNotNull,
+      reason: 'no semantics node labelled "$prefix…" was found');
+  return found!;
 }

--- a/lib/internal/all_day_band.dart
+++ b/lib/internal/all_day_band.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 
 import 'all_day_event.dart';
 import 'manager.dart';
@@ -29,6 +30,43 @@ class AllDayBand extends CustomPainter {
     for (final AllDayEvent event in manager.allDayEvents) {
       event.paint(canvas);
     }
+  }
+
+  // Expose each all-day chip to assistive technology (#72), bringing the band to
+  // parity with the timed-event canvas (#21/#56). Mirrors [EventsPainter]'s
+  // semantics: one node per chip carrying its description and the host's actions,
+  // mapped onto first-class semantics actions (RenderCustomPaint drops
+  // customSemanticsActions) — activate (onTap) -> edit, dismiss (onDismiss) ->
+  // delete. There is no increase/decrease: an all-day chip has no time axis to
+  // nudge along (drag/resize is out of scope for #72). A node is emitted for
+  // every chip regardless of horizontal scroll; its rect is the chip's live
+  // on-screen rect, so `_PlannerState` pokes this canvas to rebuild semantics on
+  // a day-axis pan (the `repaint` listenable only triggers markNeedsPaint), the
+  // same way it does for the event canvas. Stable per-chip keys (the entry id)
+  // keep node identity across those rebuilds.
+  @override
+  SemanticsBuilderCallback get semanticsBuilder => _buildSemantics;
+
+  List<CustomPainterSemantics> _buildSemantics(Size size) {
+    final config = manager.config;
+    final canEdit = config.onEntryEdit != null;
+    final canDelete = config.onEntryDelete != null;
+
+    return [
+      for (final AllDayEvent chip in manager.allDayEvents)
+        CustomPainterSemantics(
+          key: ValueKey(chip.entry.id),
+          rect: chip.screenRect,
+          properties: SemanticsProperties(
+            label: chip.semanticsLabel,
+            textDirection: TextDirection.ltr,
+            button: canEdit,
+            enabled: true,
+            onTap: canEdit ? () => manager.editAllDayEvent(chip) : null,
+            onDismiss: canDelete ? () => manager.deleteAllDayEvent(chip) : null,
+          ),
+        ),
+    ];
   }
 
   @override

--- a/lib/internal/all_day_event.dart
+++ b/lib/internal/all_day_event.dart
@@ -19,11 +19,14 @@ const double allDayChipInset = 2.0;
 /// [lane] it was packed into (concurrent all-day events stack into separate
 /// lanes — see [Manager]'s all-day layout).
 ///
-/// Render-only in this first cut, mirroring how spanning events shipped (#47):
-/// chips are painted but not draggable, editable, or hit-tested, and carry no
-/// accessibility node yet. Geometry tracks only the horizontal scroll
-/// ([Controller.offset]'s `dx`) — the band is a fixed header strip, so it
-/// neither zooms nor scrolls with the time axis.
+/// Interactive at parity with timed events (#72): a chip is hit-tested
+/// ([Manager.getAllDayEventAtPos]) so it can be edited (double-tap), acted on
+/// via the context menu (right-click) or [PlannerConfig.onEntryLongPress], and
+/// it carries an accessibility node ([AllDayBand]) with edit/delete actions. It
+/// is still not draggable/resizable — moving between columns or converting
+/// to/from a timed event is out of scope (#72). Geometry tracks only the
+/// horizontal scroll ([Controller.offset]'s `dx`) — the band is a fixed header
+/// strip, so it neither zooms nor scrolls with the time axis.
 class AllDayEvent {
   final PlannerEntry entry;
   final Manager manager;
@@ -81,8 +84,40 @@ class AllDayEvent {
 
   /// The chip's on-screen rectangle: its [_gridRect] shifted by the current
   /// horizontal scroll only (the band doesn't move vertically or zoom). Exposed
-  /// so tests can assert placement without scraping the canvas.
+  /// so tests can assert placement without scraping the canvas, and used to
+  /// hit-test the chip ([Manager.getAllDayEventAtPos]) and to place its
+  /// accessibility node ([AllDayBand]).
   Rect get screenRect => _gridRect.translate(manager.controller.offset.dx, 0);
+
+  /// A screen-reader description of this chip — its title, the column label(s)
+  /// it covers, and that it is an all-day event (#72). Mirrors
+  /// [Event.semanticsLabel] but carries no time span: an all-day event isn't
+  /// hour-positioned. A multi-day chip reads its first..last column labels (e.g.
+  /// "Conference, Mon to Wed, all day"). English-only for now, matching the
+  /// (also unlocalized) timed-event label and context-menu strings.
+  String get semanticsLabel {
+    final labels = manager.config.labels;
+    final time = entry.time;
+    String? labelAt(int i) =>
+        (i >= 0 && i < labels.length && labels[i].isNotEmpty)
+            ? labels[i]
+            : null;
+
+    final start = labelAt(time.day);
+    final end = labelAt(time.lastDay);
+    final String? dayPart;
+    if (time.spansColumns && start != null && end != null) {
+      dayPart = '$start to $end';
+    } else {
+      dayPart = start ?? end;
+    }
+
+    return [
+      entry.title,
+      if (dayPart != null) dayPart,
+      'all day',
+    ].join(', ');
+  }
 
   void paint(Canvas canvas) {
     final rect = screenRect;

--- a/lib/internal/context_menu.dart
+++ b/lib/internal/context_menu.dart
@@ -56,9 +56,9 @@ class _ContextMenuState extends State<ContextMenu> {
             ),
             onPressed: () {
               if (widget.manager.config.onEntryEdit != null &&
-                  widget.manager.controller.menuEvent != null) {
+                  widget.manager.controller.menuEntry != null) {
                 widget.manager.config
-                    .onEntryEdit!(widget.manager.controller.menuEvent!.entry);
+                    .onEntryEdit!(widget.manager.controller.menuEntry!);
               }
               widget.manager.controller.hideMenu();
             },
@@ -72,9 +72,10 @@ class _ContextMenuState extends State<ContextMenu> {
             child: Text(widget.manager.config.contextMenuDeleteLabel,
                 style: widget.manager.config.contextMenuDeleteTextStyle),
             onPressed: () {
-              if (widget.manager.config.onEntryDelete != null) {
+              if (widget.manager.config.onEntryDelete != null &&
+                  widget.manager.controller.menuEntry != null) {
                 widget.manager.config
-                    .onEntryDelete!(widget.manager.controller.menuEvent!.entry);
+                    .onEntryDelete!(widget.manager.controller.menuEntry!);
               }
               widget.manager.controller.hideMenu();
               setState(() {});

--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../planner.dart';
-import 'event.dart';
 
 enum MenuType {
   planner,
@@ -51,8 +50,17 @@ class Controller {
   double _reservedHeight = 0;
 
   MenuType menuType = MenuType.none;
+
+  /// The menu's top-left position in **planner-local** coordinates (the whole
+  /// widget's box), so the single overlay can sit over either the time grid or
+  /// the all-day band (#72). The widget layer converts each surface's local hit
+  /// position into this space before calling [showEventMenu]/[showPlannerMenu].
   Offset? menuPos;
-  Event? menuEvent;
+
+  /// The entry the entry-menu (edit/delete) acts on. A [PlannerEntry] rather
+  /// than an [Event] so the same menu serves both timed events and all-day chips
+  /// (#72) — both carry a [PlannerEntry], which is all edit/delete need.
+  PlannerEntry? menuEntry;
   PlannerTime? menuTime;
   Function? _onCloseMenu;
 
@@ -180,10 +188,13 @@ class Controller {
     triggerUpdate.value++;
   }
 
-  void showEventMenu(Offset pos, Event? event, Function onClose) {
+  /// Opens the entry menu (edit/delete) for [entry] at planner-local [pos]. The
+  /// caller (timed grid or all-day band) passes the chip's/event's
+  /// [PlannerEntry], so the same menu serves both surfaces (#72).
+  void showEventMenu(Offset pos, PlannerEntry entry, Function onClose) {
     menuPos = pos;
     menuType = MenuType.entry;
-    menuEvent = event;
+    menuEntry = entry;
     menuTime = null;
     _onCloseMenu = onClose;
   }
@@ -191,13 +202,17 @@ class Controller {
   void showPlannerMenu(Offset pos, PlannerTime time, Function onClose) {
     menuPos = pos;
     menuType = MenuType.planner;
-    menuEvent = null;
+    menuEntry = null;
     menuTime = time;
+    // Wire the close callback here too (it was previously only set for the entry
+    // menu), so dismissing the create menu rebuilds the host like the entry menu
+    // does — needed now that the all-day band also opens the create menu (#72).
+    _onCloseMenu = onClose;
   }
 
   void hideMenu() {
     menuType = MenuType.none;
-    menuEvent = null;
+    menuEntry = null;
     menuTime = null;
     if (_onCloseMenu != null) {
       _onCloseMenu!();

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -13,8 +13,9 @@ class Manager {
 
   /// The all-day events (#48), packed into stacked lanes for the all-day band.
   /// Built from entries whose [PlannerTime.allDay] is set; those are kept out of
-  /// [events] (the hour-positioned grid) entirely. Empty when none are all-day,
-  /// in which case the band is omitted and [allDayBandHeight] is zero.
+  /// [events] (the hour-positioned grid) entirely. Empty — so the band is
+  /// omitted and [allDayBandHeight] is zero — when none are all-day or the band
+  /// is disabled ([PlannerConfig.showAllDayBand] is `false`, the default).
   final List<AllDayEvent> allDayEvents = [];
 
   /// How many stacked lanes the all-day band needs — the height of the busiest
@@ -63,8 +64,11 @@ class Manager {
     for (PlannerEntry entry in entries) {
       // All-day entries render in the band, not the hour grid, so they're kept
       // out of `events` (and thus out of overlap layout, hit-testing and drag).
+      // The band is opt-in (#72): when [PlannerConfig.showAllDayBand] is off,
+      // all-day entries aren't collected at all, so the band stays empty and
+      // they render nowhere (they have no hour position to fall back to).
       if (entry.time.allDay) {
-        allDayInputs.add(entry);
+        if (config.showAllDayBand) allDayInputs.add(entry);
       } else {
         events.add(Event(entry: entry, manager: this));
       }
@@ -116,8 +120,9 @@ class Manager {
 
   /// The height the all-day band occupies above the time grid: enough for every
   /// stacked lane plus the band's top/bottom padding, or `0` when there are no
-  /// all-day events (the band is then omitted entirely). Drives both the band
-  /// widget's height and the controller's scroll-clamp reservation.
+  /// all-day events or the band is disabled ([PlannerConfig.showAllDayBand]) —
+  /// the band is then omitted entirely. Drives both the band widget's height and
+  /// the controller's scroll-clamp reservation.
   double get allDayBandHeight => allDayLaneCount == 0
       ? 0
       : allDayLaneCount * config.allDayBandLaneHeight +
@@ -309,6 +314,19 @@ class Manager {
   /// "Delete" action, mirroring the context menu's "Delete Event".
   void deleteEvent(Event event) => config.onEntryDelete?.call(event.entry);
 
+  /// Fires [PlannerConfig.onEntryEdit] for an all-day [chip] — the band's
+  /// counterpart to [editEvent], reached by double-tap, the context menu, or the
+  /// chip's a11y "activate" action (#72). All-day chips have no time axis, so
+  /// (unlike timed events) they expose no move/nudge — only edit and delete.
+  void editAllDayEvent(AllDayEvent chip) =>
+      config.onEntryEdit?.call(chip.entry);
+
+  /// Fires [PlannerConfig.onEntryDelete] for an all-day [chip] — the band's
+  /// counterpart to [deleteEvent], reached by the context menu or the chip's
+  /// a11y "dismiss" action (#72).
+  void deleteAllDayEvent(AllDayEvent chip) =>
+      config.onEntryDelete?.call(chip.entry);
+
   /// Shifts [event] by [hourDelta] whole hours, clamped to
   /// `[config.minHour, config.maxHour]`, then re-lays out overlaps, repaints,
   /// and fires [PlannerConfig.onEntryMove]. A screen-reader user can't drag, so
@@ -389,6 +407,33 @@ class Manager {
     }
 
     return PlannerTime(day: day, hour: hour, minutes: minutes);
+  }
+
+  /// The all-day chip under [bandLocalPos], or `null` if the point hits empty
+  /// band space (#72). [bandLocalPos] is in the band canvas's own coordinate
+  /// space — the same space [AllDayEvent.screenRect] lives in (full planner
+  /// width, horizontal scroll already applied) — so a chip is hit when its
+  /// on-screen rect contains the point. A linear scan: all-day chips are few and
+  /// aren't day-bucketed like the timed [events].
+  AllDayEvent? getAllDayEventAtPos(Offset bandLocalPos) {
+    for (final AllDayEvent chip in allDayEvents) {
+      if (chip.screenRect.contains(bandLocalPos)) return chip;
+    }
+    return null;
+  }
+
+  /// The all-day [PlannerTime] a tap on empty band space at [bandLocalPos]
+  /// (band-canvas coordinates) maps to — the band's counterpart to
+  /// [getTimeAtPos] on the grid (#72). Undoes the horizontal scroll and the
+  /// hour-gutter offset to find the column under the point, clamps it to a valid
+  /// column, and flags it [PlannerTime.allDay] so create-on-empty-band yields an
+  /// all-day entry. There is no hour/minute — an all-day time isn't positioned.
+  PlannerTime getAllDayTimeAtPos(Offset bandLocalPos) {
+    final localX =
+        bandLocalPos.dx - controller.offset.dx - config.hourColumnWidth;
+    final day =
+        (localX / config.blockWidth).floor().clamp(0, config.labels.length - 1);
+    return PlannerTime(day: day, allDay: true);
   }
 
   /// The snap interval (in minutes) in effect right now: the zoom-aware override

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -82,6 +82,18 @@ class _PlannerState extends State<Planner> {
   // exploration hit-areas and the AT focus highlight correct as the user pans).
   final GlobalKey _eventsCanvasKey = GlobalKey();
 
+  // The all-day band's RenderCustomPaint, poked on a day-axis pan to rebuild its
+  // chip semantics the same way as the event canvas (#72/#56): the band's chip
+  // rects track the horizontal scroll, and the `repaint` listenable only
+  // triggers markNeedsPaint, never markNeedsSemanticsUpdate. Null until (and
+  // unless) the band is mounted, so the poke is a no-op when there's no band.
+  final GlobalKey _allDayCanvasKey = GlobalKey();
+
+  // The local position of the most recent double-tap-down on the all-day band,
+  // captured so [_onAllDayDoubleTap] (which carries no position itself) knows
+  // which chip / empty column the double-tap landed on.
+  Offset _allDayDoubleTapPos = Offset.zero;
+
   /// Whether [kind] is a precise pointer (a mouse) that gets the Outlook-style
   /// immediate drag-move/resize. Touch keeps one-finger drag as pan; its
   /// move/resize affordance is the long-press callback (the companion #66).
@@ -91,19 +103,23 @@ class _PlannerState extends State<Planner> {
   void initState() {
     super.initState();
     _data = Manager(config: widget.config, entries: widget.entries);
-    // Rebuild the event semantics whenever the view changes (#56). The
+    // Rebuild the canvas semantics whenever the view changes (#56). The
     // controller is preserved across rebuilds (Manager.update keeps it), so this
     // listener stays valid for the life of the State.
-    _data.controller.triggerUpdate.addListener(_rebuildEventSemantics);
+    _data.controller.triggerUpdate.addListener(_rebuildCanvasSemantics);
   }
 
-  /// Rebuilds the events-canvas accessibility semantics so each event node's
-  /// rect tracks the current scroll/zoom (#56). Fired on every controller
-  /// update: RenderCustomPaint only repaints (not re-semantics) on the `repaint`
-  /// listenable, so without this poke a scrolled event keeps its stale node rect.
-  /// A no-op until the canvas is mounted (`currentContext` is null before then).
-  void _rebuildEventSemantics() {
+  /// Rebuilds the events-canvas and all-day-band accessibility semantics so each
+  /// node's rect tracks the current scroll/zoom (#56/#72). Fired on every
+  /// controller update: RenderCustomPaint only repaints (not re-semantics) on
+  /// the `repaint` listenable, so without this poke a scrolled event/chip keeps
+  /// its stale node rect. A no-op for a canvas that isn't mounted
+  /// (`currentContext` is null — e.g. the band when it's disabled or empty).
+  void _rebuildCanvasSemantics() {
     _eventsCanvasKey.currentContext
+        ?.findRenderObject()
+        ?.markNeedsSemanticsUpdate();
+    _allDayCanvasKey.currentContext
         ?.findRenderObject()
         ?.markNeedsSemanticsUpdate();
   }
@@ -119,7 +135,7 @@ class _PlannerState extends State<Planner> {
 
   @override
   void dispose() {
-    _data.controller.triggerUpdate.removeListener(_rebuildEventSemantics);
+    _data.controller.triggerUpdate.removeListener(_rebuildCanvasSemantics);
     _cursor.dispose();
     super.dispose();
   }
@@ -128,50 +144,73 @@ class _PlannerState extends State<Planner> {
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
       _data.controller.setSize(constraints.biggest);
-      return Column(
+      // The context menu overlay is lifted to a planner-wide Stack so it can
+      // sit over either the time grid or the all-day band (#72): the band is a
+      // thin strip above the grid in the Column, so a menu opened from it must
+      // be free to overflow downward over the grid — impossible while the menu
+      // lived inside the grid's own Stack (the grid paints over earlier Column
+      // children). menuPos is therefore planner-local; both surfaces convert
+      // their local hit position into this space.
+      return Stack(
         children: [
-          paintDates(),
-          // The all-day band (#48) sits between the date row and the time grid.
-          // It self-sizes to its lanes and is omitted entirely (no widget, no
-          // reserved space) when there are no all-day events.
-          if (_data.allDayBandHeight > 0) paintAllDayBand(),
-          Expanded(
-            child: Row(
-              children: [
-                paintHours(),
-                Expanded(
-                  child: Stack(
-                    children: [
-                      PositionedTapDetector2(
-                        controller: _tapController,
-                        onDoubleTap: (position) {
-                          if (position.relative == null) {
-                            return;
-                          }
-                          var event = _data.getEventAtPos(position.relative!);
-                          if (event != null &&
-                              _data.config.onEntryEdit != null) {
-                            _data.config.onEntryEdit!(event.entry);
-                          } else if (event == null &&
-                              _data.config.onEntryCreate != null) {
-                            var time = _data.getTimeAtPos(position.relative!);
-                            _data.config.onEntryCreate!(time);
-                          }
-                        },
-                        child: paintEvents(),
+          Column(
+            children: [
+              paintDates(),
+              // The all-day band (#48) sits between the date row and the time
+              // grid. It self-sizes to its lanes and is omitted entirely (no
+              // widget, no reserved space) when the band is disabled
+              // (showAllDayBand) or there are no all-day events.
+              if (_data.allDayBandHeight > 0) paintAllDayBand(),
+              Expanded(
+                child: Row(
+                  children: [
+                    paintHours(),
+                    Expanded(
+                      child: Stack(
+                        children: [
+                          PositionedTapDetector2(
+                            controller: _tapController,
+                            onDoubleTap: (position) {
+                              if (position.relative == null) {
+                                return;
+                              }
+                              var event =
+                                  _data.getEventAtPos(position.relative!);
+                              if (event != null &&
+                                  _data.config.onEntryEdit != null) {
+                                _data.config.onEntryEdit!(event.entry);
+                              } else if (event == null &&
+                                  _data.config.onEntryCreate != null) {
+                                var time =
+                                    _data.getTimeAtPos(position.relative!);
+                                _data.config.onEntryCreate!(time);
+                              }
+                            },
+                            child: paintEvents(),
+                          ),
+                          paintZoomButtons(context),
+                        ],
                       ),
-                      paintZoomButtons(context),
-                      ...paintMenu(),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
-          )
+              )
+            ],
+          ),
+          ...paintMenu(),
         ],
       );
     });
   }
+
+  /// The events canvas's top-left in planner-local coordinates: right of the
+  /// hour gutter and below the date row plus any all-day band. Used to map an
+  /// events-canvas-local hit position into the planner-local space the lifted
+  /// context menu is positioned in (#72).
+  Offset get _eventsCanvasOrigin => Offset(
+        _data.config.hourColumnWidth,
+        _data.config.dateRowHeight + _data.allDayBandHeight,
+      );
 
   List<Widget> paintMenu() {
     List<Widget> result = [];
@@ -226,18 +265,31 @@ class _PlannerState extends State<Planner> {
   /// events flagged [PlannerTime.allDay]. Like the date row directly above it,
   /// it pans the day axis on a horizontal drag (so it isn't a dead zone) and
   /// tracks the horizontal scroll, but it does not zoom or scroll with the time
-  /// axis. Only mounted when there is at least one all-day event.
+  /// axis. Only mounted when the band is enabled and there is at least one
+  /// all-day event.
+  ///
+  /// Its chips are interactive at parity with timed events (#72): double-tap a
+  /// chip to edit (or empty space to create), right-click for the edit/delete
+  /// (or create) context menu, and long-press a chip for [onEntryLongPress].
+  /// These coexist with the day-axis horizontal drag in one GestureDetector —
+  /// a moving press pans, a still tap/press resolves to the tap gestures.
   Widget paintAllDayBand() {
     return GestureDetector(
       onHorizontalDragStart: (detail) =>
           _data.controller.startHorizontalDrag(detail.globalPosition.dx),
       onHorizontalDragUpdate: (detail) =>
           _data.controller.updateHorizontalDrag(detail.globalPosition.dx),
+      // Double-tap carries no position, so capture it on the down event.
+      onDoubleTapDown: (detail) => _allDayDoubleTapPos = detail.localPosition,
+      onDoubleTap: _onAllDayDoubleTap,
+      onSecondaryTapDown: (detail) => _showAllDayMenu(detail.localPosition),
+      onLongPressStart: (detail) => _onAllDayLongPress(detail.localPosition),
       child: ClipRect(
         child: Container(
           height: _data.allDayBandHeight,
           color: _data.config.allDayBandBackground,
           child: CustomPaint(
+            key: _allDayCanvasKey,
             painter: AllDayBand(
               manager: _data,
               repaint: _data.controller.triggerUpdate,
@@ -247,6 +299,48 @@ class _PlannerState extends State<Planner> {
         ),
       ),
     );
+  }
+
+  /// Double-tap on the all-day band (#72): edit the chip under the press, or —
+  /// mirroring the grid's double-tap — create an all-day event on empty band
+  /// space (the position was captured by `onDoubleTapDown`).
+  void _onAllDayDoubleTap() {
+    final chip = _data.getAllDayEventAtPos(_allDayDoubleTapPos);
+    if (chip != null) {
+      _data.config.onEntryEdit?.call(chip.entry);
+    } else if (_data.config.onEntryCreate != null) {
+      _data
+          .config.onEntryCreate!(_data.getAllDayTimeAtPos(_allDayDoubleTapPos));
+    }
+  }
+
+  /// Right-click on the all-day band (#72): open the edit/delete menu for the
+  /// chip under [bandLocalPos], or the create menu on empty band space. The
+  /// band sits at planner-local `(0, dateRowHeight)`, so the band-local press
+  /// maps to planner-local by shifting down past the date row for the lifted
+  /// menu overlay.
+  void _showAllDayMenu(Offset bandLocalPos) {
+    final plannerPos = bandLocalPos + Offset(0, _data.config.dateRowHeight);
+    final chip = _data.getAllDayEventAtPos(bandLocalPos);
+    if (chip != null) {
+      _data.controller.showEventMenu(plannerPos, chip.entry, hideMenu);
+    } else {
+      _data.controller.showPlannerMenu(
+          plannerPos, _data.getAllDayTimeAtPos(bandLocalPos), hideMenu);
+    }
+    setState(() {});
+  }
+
+  /// Long-press on an all-day chip fires [PlannerConfig.onEntryLongPress] (#72),
+  /// the touch path to act on a chip — at parity with a long-press on a timed
+  /// event ([_onLongPress]). A press on empty band space, or with no callback
+  /// wired, is a no-op.
+  void _onAllDayLongPress(Offset bandLocalPos) {
+    final onLongPress = _data.config.onEntryLongPress;
+    if (onLongPress == null) return;
+    final chip = _data.getAllDayEventAtPos(bandLocalPos);
+    if (chip == null) return;
+    onLongPress(chip.entry);
   }
 
   Widget paintZoomButtons(BuildContext context) {
@@ -530,12 +624,16 @@ class _PlannerState extends State<Planner> {
   }
 
   void showMenu(TapDownDetails details) {
-    var event = _data.getEventAtPos(details.localPosition);
+    // Hit-testing uses the events-canvas-local position; the menu is positioned
+    // in planner-local space (the lifted overlay), so shift by the canvas origin.
+    final local = details.localPosition;
+    final plannerPos = local + _eventsCanvasOrigin;
+    var event = _data.getEventAtPos(local);
     if (event != null) {
-      _data.controller.showEventMenu(details.localPosition, event, hideMenu);
+      _data.controller.showEventMenu(plannerPos, event.entry, hideMenu);
     } else {
-      var time = _data.getTimeAtPos(details.localPosition);
-      _data.controller.showPlannerMenu(details.localPosition, time, hideMenu);
+      var time = _data.getTimeAtPos(local);
+      _data.controller.showPlannerMenu(plannerPos, time, hideMenu);
     }
 
     setState(() {});

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -65,17 +65,28 @@ class PlannerConfig {
   double dateRowHeight;
   double hourColumnWidth;
 
+  /// Whether the all-day band (#48) is shown at all. Opt-in: defaults to
+  /// `false`, so by default no band is rendered and [PlannerTime.allDay] entries
+  /// don't appear anywhere (they have no hour position, so they're simply not
+  /// drawn). Set it to `true` to enable the band — it then appears above the
+  /// time grid whenever there is at least one all-day event, and the chips
+  /// become interactive and accessible (#72). With the band disabled,
+  /// [allDayBandLaneHeight] / [allDayBandBackground] have no effect.
+  bool showAllDayBand;
+
   /// Height, in logical pixels, of one stacked lane in the all-day band (#48).
   /// All-day events ([PlannerTime.allDay]) render as chips above the time grid;
   /// concurrent ones (sharing a column) stack into separate lanes, and the band
   /// auto-sizes to the number of lanes used. The band is omitted entirely (zero
-  /// height) when there are no all-day events, so this has no effect then.
+  /// height) when [showAllDayBand] is `false` or there are no all-day events, so
+  /// this has no effect then.
   double allDayBandLaneHeight;
 
   /// Background fill of the all-day band (#48). Defaults to a dark grey close to
   /// the [plannerBackground] so the band reads as the top of the column area;
   /// override it to match a light theme or to set it off from the grid. Ignored
-  /// when there are no all-day events (the band isn't shown).
+  /// when [showAllDayBand] is `false` or there are no all-day events (the band
+  /// isn't shown).
   Color allDayBandBackground;
 
   TextStyle hourLabelStyle;
@@ -193,6 +204,7 @@ class PlannerConfig {
     this.zoomButtonColor,
     this.zoomButtonIconColor = Colors.white,
     this.scrollStep = 20,
+    this.showAllDayBand = false,
     this.allDayBandLaneHeight = 24,
     this.allDayBandBackground = const Color.fromARGB(255, 60, 60, 60),
     this.plannerBackground = const Color.fromARGB(255, 50, 50, 50),

--- a/test/all_day_band_test.dart
+++ b/test/all_day_band_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/internal/all_day_band.dart';
 import 'package:planner/internal/all_day_event.dart';
@@ -22,9 +23,11 @@ void main() {
   Manager managerWith(
     List<PlannerEntry> entries, {
     List<String> labels = const ['A', 'B', 'C'],
+    bool showAllDayBand = true,
   }) =>
       Manager(
-        config: PlannerConfig(labels: labels, minHour: 0),
+        config: PlannerConfig(
+            labels: labels, minHour: 0, showAllDayBand: showAllDayBand),
         entries: entries,
       );
 
@@ -215,6 +218,74 @@ void main() {
     });
   });
 
+  group('showAllDayBand opt-in gate (#72)', () {
+    test('off by default: all-day entries render nowhere, band is 0-height',
+        () {
+      final manager = managerWith([
+        allDayAt('holiday', day: 0),
+        timedAt('meeting', day: 0, hour: 9),
+      ], showAllDayBand: false);
+
+      // The all-day entry is neither collected for the band nor placed on the
+      // hour grid (it has no hour position), so it simply doesn't render.
+      expect(manager.allDayEvents, isEmpty);
+      expect(manager.allDayLaneCount, 0);
+      expect(manager.allDayBandHeight, 0);
+      expect(manager.events.map((e) => e.entry.id), ['meeting']);
+    });
+
+    test('enabled: the same all-day entry is collected and sizes the band', () {
+      final manager = managerWith([allDayAt('holiday', day: 0)]);
+      expect(manager.allDayEvents.map((e) => e.entry.id), ['holiday']);
+      expect(manager.allDayBandHeight, bandHeightFor(1));
+    });
+  });
+
+  group('chip hit-testing (#72)', () {
+    // Single chip at day 1: screenRect is x 252..448, y 4..24 (the chip-geometry
+    // group pins this), in the band canvas's own coordinate space.
+    test('a point inside a chip resolves to that chip', () {
+      final manager = managerWith([allDayAt('a', day: 1)]);
+      final chip = manager.getAllDayEventAtPos(const Offset(300, 12));
+      expect(chip?.entry.id, 'a');
+    });
+
+    test('a point in empty band space resolves to no chip', () {
+      final manager = managerWith([allDayAt('a', day: 1)]);
+      // Column 0 (x 50..250) carries no chip.
+      expect(manager.getAllDayEventAtPos(const Offset(100, 12)), isNull);
+    });
+
+    test('getAllDayTimeAtPos maps the column under the point, flagged allDay',
+        () {
+      final manager = managerWith([allDayAt('a', day: 1)]);
+      // x 100 is in column 0 (past the 50px gutter); x 300 is in column 1.
+      final t0 = manager.getAllDayTimeAtPos(const Offset(100, 12));
+      expect(t0.day, 0);
+      expect(t0.allDay, isTrue);
+      expect(manager.getAllDayTimeAtPos(const Offset(300, 12)).day, 1);
+    });
+
+    test('getAllDayTimeAtPos clamps a point left of the grid to column 0', () {
+      final manager = managerWith([allDayAt('a', day: 1)]);
+      expect(manager.getAllDayTimeAtPos(const Offset(0, 12)).day, 0);
+    });
+  });
+
+  group('chip semantics label (#72)', () {
+    test('a single-column chip reads title, column label, and "all day"', () {
+      final chip = managerWith([allDayAt('Holiday', day: 1)],
+          labels: const ['Mon', 'Tue', 'Wed']).allDayEvents.single;
+      expect(chip.semanticsLabel, 'Holiday, Tue, all day');
+    });
+
+    test('a multi-day chip reads its first..last column labels', () {
+      final chip = managerWith([allDayAt('Conf', day: 0, endDay: 2)],
+          labels: const ['Mon', 'Tue', 'Wed']).allDayEvents.single;
+      expect(chip.semanticsLabel, 'Conf, Mon to Wed, all day');
+    });
+  });
+
   group('widget rendering', () {
     Finder allDayCanvas() => find.byWidgetPredicate(
           (w) => w is CustomPaint && w.painter is AllDayBand,
@@ -223,12 +294,19 @@ void main() {
           (w) => w is CustomPaint && w.painter is EventsPainter,
         );
 
-    Future<void> pump(WidgetTester tester, List<PlannerEntry> entries) async {
+    Future<void> pump(
+      WidgetTester tester,
+      List<PlannerEntry> entries, {
+      bool showAllDayBand = true,
+    }) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: Planner(
             config: PlannerConfig(
-                labels: const ['c1', 'c2', 'c3'], minHour: 0, maxHour: 23),
+                labels: const ['c1', 'c2', 'c3'],
+                minHour: 0,
+                maxHour: 23,
+                showAllDayBand: showAllDayBand),
             entries: entries,
           ),
         ),
@@ -269,5 +347,85 @@ void main() {
       expect(bandTop, 50);
       expect(gridTop, greaterThanOrEqualTo(bandTop + bandHeightFor(1)));
     });
+
+    testWidgets('no band is mounted when disabled, even with all-day entries',
+        (tester) async {
+      await pump(tester, [allDayAt('a', day: 1)], showAllDayBand: false);
+      // The opt-in gate is off, so the band never appears and the grid is flush
+      // under the date row.
+      expect(allDayCanvas(), findsNothing);
+      expect(tester.getRect(eventsCanvas()).top, 50);
+    });
   });
+
+  group('chip accessibility (#72)', () {
+    testWidgets(
+        'the band exposes each chip and its edit/delete actions to a11y',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+      final edited = <PlannerEntry>[];
+      final deleted = <PlannerEntry>[];
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Planner(
+            config: PlannerConfig(
+              labels: const ['Mon', 'Tue', 'Wed'],
+              minHour: 0,
+              maxHour: 23,
+              showAllDayBand: true,
+              onEntryEdit: edited.add,
+              onEntryDelete: deleted.add,
+            ),
+            entries: [allDayAt('Holiday', day: 1)],
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final owner =
+          tester.renderObject(find.byType(Planner)).owner!.semanticsOwner!;
+      final node = _findByLabelPrefix(owner, 'Holiday');
+      final data = node.getSemanticsData();
+
+      // The chip is announced with its title, column and "all day", and reads as
+      // an actionable button — but, having no time axis, exposes no nudge.
+      expect(data.label, 'Holiday, Tue, all day');
+      expect(data.flagsCollection.isButton, isTrue);
+      expect(data.hasAction(SemanticsAction.increase), isFalse);
+      expect(data.hasAction(SemanticsAction.decrease), isFalse);
+
+      // Activate -> edit; dismiss -> delete (mirrors the timed-event canvas).
+      owner.performAction(node.id, SemanticsAction.tap);
+      await tester.pump();
+      expect(edited.single.id, 'Holiday');
+
+      owner.performAction(node.id, SemanticsAction.dismiss);
+      await tester.pump();
+      expect(deleted.single.id, 'Holiday');
+
+      handle.dispose();
+    });
+  });
+}
+
+/// Returns the first semantics node under [owner] whose label starts with
+/// [prefix]. CustomPaint semantics are raw `SemanticsNode`s, so a widget finder
+/// can't reach them — the tree is walked directly.
+SemanticsNode _findByLabelPrefix(SemanticsOwner owner, String prefix) {
+  SemanticsNode? found;
+  void visit(SemanticsNode node) {
+    if (found == null && node.getSemanticsData().label.startsWith(prefix)) {
+      found = node;
+    }
+    node.visitChildren((child) {
+      visit(child);
+      return found == null;
+    });
+  }
+
+  visit(owner.rootSemanticsNode!);
+  expect(found, isNotNull,
+      reason: 'no semantics node labelled "$prefix…" was found');
+  return found!;
 }


### PR DESCRIPTION
## Summary

Brings all-day chips (#48) to parity with timed events — hit-testing, the context menu, long-press, and screen-reader semantics — and adds an opt-in gate so the band is only shown when the host asks for it.

The all-day band shipped render-only in #48 (mirroring how spanning events shipped read-only in #47): chips painted but inert — not hit-tested, no `Semantics` node, no create. This closes that gap.

## Linked issue
Closes #72

## Changes

**Opt-in gate** ([planner_config.dart](lib/planner_config.dart), [manager.dart](lib/internal/manager.dart))
- New `PlannerConfig.showAllDayBand` (default **false**). With it off, no band is shown and `PlannerTime.allDay` entries render nowhere (they have no hour position to fall back to). Set it `true` to enable the band.

**Interaction parity** ([planner_class.dart](lib/planner_class.dart), [manager.dart](lib/internal/manager.dart))
- `Manager.getAllDayEventAtPos` / `getAllDayTimeAtPos` hit-test the band in its own coordinate space.
- Double-tap a chip → `onEntryEdit`; double-tap empty band space → `onEntryCreate` with an all-day `PlannerTime`; right-click → edit/delete (chip) or create (empty) context menu; long-press a chip → `onEntryLongPress`.
- These share one `GestureDetector` with the existing day-axis horizontal drag (a moving press pans; a still tap/press resolves to the tap gestures).

**Accessibility** ([all_day_band.dart](lib/internal/all_day_band.dart), [all_day_event.dart](lib/internal/all_day_event.dart))
- `AllDayBand` emits a `CustomPainterSemantics` node per chip, mapped onto first-class actions (RenderCustomPaint drops `customSemanticsActions`): `activate (onTap)` → edit, `dismiss (onDismiss)` → delete. No increase/decrease — an all-day chip has no time axis to nudge.
- `AllDayEvent.semanticsLabel` reads "title, column(s), all day" (multi-day reads first..last labels).
- The band's node rects rebuild on a day-axis pan, the same poke the event canvas uses (#56).

**Context-menu lift** ([controller.dart](lib/internal/controller.dart), [context_menu.dart](lib/internal/context_menu.dart), [planner_class.dart](lib/planner_class.dart))
- The single context-menu overlay is lifted from the grid's `Stack` to a planner-wide `Stack`, so a menu opened from the thin band can overflow downward over the grid (impossible before — the grid paints over earlier `Column` children). `menuPos` is now planner-local; both surfaces convert their local hit position into it.
- Controller menu state switches from `Event?` to `PlannerEntry?` so one menu serves both timed events and all-day chips. (Also wires the create menu's close callback, previously only set for the entry menu.)

## Out of scope
Drag/resize of all-day chips (moving between columns / converting to/from timed) — as called out in the issue.

## Test plan
- [x] `flutter analyze` clean (package + example)
- [x] unit/widget tests pass — `flutter test`: **189** pass; 28 in [test/all_day_band_test.dart](test/all_day_band_test.dart), incl. chip hit-test, `semanticsLabel`, the a11y node + edit/delete routing, and the opt-in gate (band off ⇒ nothing renders). #48's existing tests updated to set `showAllDayBand: true`.
- [x] integration/e2e tests pass — `flutter test integration_test/app_test.dart -d windows`: **39** pass. 7 new all-day scenarios drive the real composed band (double-tap edit/create, right-click menu edit/create, long-press, a11y, band-off). The pre-existing timed context-menu and double-tap scenarios were re-verified through the lifted menu. User-visible change, so end-to-end coverage is included.
- [x] `dart format --output=none --set-exit-if-changed .` clean