### PR TITLE
feat: PlannerController for external zoom control (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Added a public `PlannerController` for driving and observing the planner's zoom
+  from outside the widget — e.g. a host's own zoom toolbar. Construct one, pass it
+  to `Planner(controller: …)`, and call `zoomIn([factor])`, `zoomOut([factor])` or
+  `zoomTo(target)` (clamped to `minZoom`/`maxZoom`); read back `zoom`, `minZoom`,
+  `maxZoom`, `dayScroll`, `timeScroll` and `isAttached`. It is a `ChangeNotifier`,
+  so a toolbar can listen and rebuild (e.g. disable `+` at `maxZoom`). It attaches
+  to the planner's internal zoom/scroll state — the single source of truth, no
+  duplicated state — so the controller, pinch, `Ctrl`+wheel and the built-in
+  buttons all move the same zoom. Pair it with `showZoomControls: false` to replace
+  the on-canvas buttons. Optional and fully backward compatible: omit it and
+  nothing changes.
 - Added optional, **non-core** calendar helpers in `package:planner/calendar.dart`
   (a separate import — *not* part of the main `planner.dart` barrel) so building an
   ordinary date-based week calendar on top of the date-agnostic widget is a few

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -52,6 +52,7 @@ Public API (exported from [`lib/planner.dart`](lib/planner.dart)):
 | File | Role |
 |------|------|
 | [`planner_class.dart`](lib/planner_class.dart) | `Planner` widget; builds the layout, wires gestures, hosts the painters. |
+| [`planner_controller.dart`](lib/planner_controller.dart) | `PlannerController` — optional public handle that attaches to the internal `Controller` to drive/observe zoom (and read scroll) from outside the widget (#76). |
 | [`planner_config.dart`](lib/planner_config.dart) | `PlannerConfig` — all sizing, colors, text styles, and callbacks. |
 | [`planner_entry.dart`](lib/planner_entry.dart) | `PlannerEntry` — a single event (id, time, title, content, color, styles). |
 | [`planner_time.dart`](lib/planner_time.dart) | `PlannerTime` — the day/hour/minute/duration value (⚠️ **not** re-exported). |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ hours, and let users pan, zoom, and drag events to move or resize them.
 - 2D panning (drag the empty canvas) plus single-axis pan via the date row / hour
   gutter, and mouse-wheel scroll with `Shift` / `Ctrl` modifiers.
 - Zoom the time axis with pinch, `Ctrl`+wheel, or the built-in +/- buttons; finer
-  grid lines fade in as you zoom.
+  grid lines fade in as you zoom. Drive and observe zoom from your own chrome with
+  a `PlannerController` (see [Driving zoom from a host toolbar](#driving-zoom-from-a-host-toolbar)).
 - Desktop drag-to-edit: press an event to move it or drag its top/bottom edge to
   resize, with hover cursors as cues. Touch keeps one-finger drag for panning and
   exposes a long-press hook (`onEntryLongPress`) for host-defined event actions.
@@ -107,8 +108,9 @@ A complete, runnable demo lives in [`example/`](example/lib/main.dart).
 
 | Type | Purpose |
 |------|---------|
-| `Planner` | The widget. Takes a `config` and a list of `entries`. |
+| `Planner` | The widget. Takes a `config`, a list of `entries`, and an optional `controller`. |
 | `PlannerConfig` | Sizing (`blockWidth`, `blockHeight`, `minHour`, `maxHour` — the inclusive last hour, default `23`, …), colors, text styles, an optional `hourLabelFormatter`, the optional column highlight (`highlightedColumn`, `highlightColumnColor`), the zoom controls (`showZoomControls`, `zoomButtonColor`, `zoomButtonIconColor`), the wheel `scrollStep`, and the `onEntry*` callbacks. `labels` is required. |
+| `PlannerController` | Optional handle to drive/observe zoom from outside the widget (e.g. your own toolbar) — see [Driving zoom from a host toolbar](#driving-zoom-from-a-host-toolbar). |
 | `PlannerEntry` | One event: `id`, `time`, `title`, `content`, `color`, and optional text styles. |
 | `PlannerTime` | `day` (index into `labels`), `hour`, `minutes`, and `duration` (in minutes). |
 
@@ -124,6 +126,88 @@ A complete, runnable demo lives in [`example/`](example/lib/main.dart).
 
 > Your callbacks own the data. Update your own list of entries (and call
 > `setState`) in response — the widget reports interactions but does not persist them.
+
+### Driving zoom from a host toolbar
+
+By default zoom lives entirely inside the widget (pinch, `Ctrl`+wheel, the
+built-in +/- buttons). To drive it from your own chrome — a toolbar, a slider,
+keyboard shortcuts — construct a `PlannerController`, hand it to the `Planner`,
+and (usually) hide the on-canvas buttons with `showZoomControls: false`:
+
+```dart
+class ZoomablePlanner extends StatefulWidget {
+  const ZoomablePlanner({super.key});
+  @override
+  State<ZoomablePlanner> createState() => _ZoomablePlannerState();
+}
+
+class _ZoomablePlannerState extends State<ZoomablePlanner> {
+  final _zoom = PlannerController();
+
+  @override
+  void dispose() {
+    _zoom.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // A host toolbar that listens to the controller so it can disable
+        // a button once the zoom hits a bound.
+        AnimatedBuilder(
+          animation: _zoom,
+          builder: (context, _) => Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.remove),
+                onPressed: !_zoom.isAttached || _zoom.zoom <= _zoom.minZoom
+                    ? null
+                    : _zoom.zoomOut,
+              ),
+              IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: !_zoom.isAttached || _zoom.zoom >= _zoom.maxZoom
+                    ? null
+                    : _zoom.zoomIn,
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Planner(
+            controller: _zoom,
+            config: PlannerConfig(
+              labels: const ['Mon', 'Tue', 'Wed'],
+              showZoomControls: false, // the host owns the controls now
+            ),
+            entries: const [],
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+`PlannerController` is a `ChangeNotifier` and deals only with zoom (plus scroll
+read-back):
+
+| Member | Purpose |
+|--------|---------|
+| `zoomIn([factor = 1.1])` / `zoomOut([factor = 0.9])` | Multiply the current zoom; clamped to `minZoom`/`maxZoom`. |
+| `zoomTo(target)` | Set an absolute zoom; clamped to `minZoom`/`maxZoom`. |
+| `zoom`, `minZoom`, `maxZoom` | Read the current zoom and its bounds. |
+| `dayScroll`, `timeScroll` | Read the current day-axis / time-axis scroll offset. |
+| `isAttached` | Whether it's bound to a mounted `Planner`. |
+
+It attaches to the planner's internal zoom/scroll state — the single source of
+truth — so the controller, pinch, `Ctrl`+wheel and the built-in buttons all move
+the *same* zoom; there's no duplicated state to keep in sync. The read getters
+throw while not `isAttached` (before the `Planner` mounts or after it's gone), so
+read them in response to a notification or guard with `isAttached`; the zoom
+methods are no-ops then. Dispose the controller like any other `ChangeNotifier`.
 
 ### Localizing the context menu
 

--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -13,6 +13,7 @@ surface) can miss rendering/geometry bugs.
 | [`pan_zoom_scenarios.dart`](pan_zoom_scenarios.dart) | 2D pan and wheel modifiers (#65): dragging empty canvas pans both axes; Shift+wheel scrolls the day axis; Ctrl+wheel zooms. |
 | [`long_press_scenarios.dart`](long_press_scenarios.dart) | A touch long-press on an event fires `onEntryLongPress` with that entry; a long-press on empty space is a no-op (#66). |
 | [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
+| [`external_zoom_scenarios.dart`](external_zoom_scenarios.dart) | A host toolbar drives the real grid zoom through a public `PlannerController` with the on-canvas buttons hidden, and the controller and grid share one zoom (#76). |
 | [`hour_label_scenarios.dart`](hour_label_scenarios.dart) | The default `maxHour` (23) clamps a below-grid tap to hour 23, not the invalid 24 (#13 / D10). |
 | [`snapping_scenarios.dart`](snapping_scenarios.dart) | Create and drag snap event times to the single configurable `snapMinutes` interval, and agree (#14 / D8). |
 | [`span_scenarios.dart`](span_scenarios.dart) | A column-spanning event (`PlannerTime.endDay`) paints one box across its columns, hit-tests from any column it covers, and is read-only — dragging it doesn't move it (#47). |

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -9,6 +9,7 @@ import 'direct_manipulation_scenarios.dart';
 import 'double_tap_scenarios.dart';
 import 'drag_scenarios.dart';
 import 'event_geometry_scenarios.dart';
+import 'external_zoom_scenarios.dart';
 import 'highlight_column_scenarios.dart';
 import 'hour_label_scenarios.dart';
 import 'long_press_scenarios.dart';
@@ -38,6 +39,7 @@ void main() {
   doubleTapScenarios();
   dragScenarios();
   eventGeometryScenarios();
+  externalZoomScenarios();
   highlightColumnScenarios();
   hourLabelScenarios();
   longPressScenarios();

--- a/example/integration_test/external_zoom_scenarios.dart
+++ b/example/integration_test/external_zoom_scenarios.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for the public [PlannerController] (#76): a host drives the
+/// planner's zoom from its **own** toolbar (the built-in on-canvas buttons hidden
+/// via `showZoomControls: false`), exercising the real attach lifecycle, real
+/// Material buttons, real layout and real gesture/menu flow — the composition a
+/// widget test in isolation can't cover.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void externalZoomScenarios() {
+  const plannerKey = ValueKey('external-zoom-planner');
+  const zoomInKey = ValueKey('host-zoom-in');
+  const zoomOutKey = ValueKey('host-zoom-out');
+
+  // The recommended external-zoom recipe: a host toolbar with its own +/- buttons
+  // wired to a PlannerController, and the planner's on-canvas controls hidden.
+  Widget hostApp(
+    PlannerController controller,
+    ValueChanged<PlannerTime> onCreate,
+  ) =>
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              Row(
+                children: [
+                  IconButton(
+                    key: zoomOutKey,
+                    icon: const Icon(Icons.remove),
+                    onPressed: controller.zoomOut,
+                  ),
+                  IconButton(
+                    key: zoomInKey,
+                    icon: const Icon(Icons.add),
+                    onPressed: controller.zoomIn,
+                  ),
+                ],
+              ),
+              Expanded(
+                child: Planner(
+                  key: plannerKey,
+                  controller: controller,
+                  config: PlannerConfig(
+                    labels: const ['c1', 'c2', 'c3'],
+                    minHour: 0,
+                    maxHour: 23,
+                    showZoomControls: false,
+                    onEntryCreate: onCreate,
+                  ),
+                  entries: const [],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+  testWidgets('a host toolbar drives the real grid zoom (#76)', (tester) async {
+    PlannerTime? created;
+    final controller = PlannerController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(hostApp(controller, (t) => created = t));
+    await tester.pumpAndSettle();
+
+    // showZoomControls:false hands zoom entirely to the host: no on-canvas
+    // buttons, and the external controller is bound to the live planner.
+    expect(find.byIcon(Icons.zoom_in), findsNothing);
+    expect(find.byIcon(Icons.zoom_out), findsNothing);
+    expect(controller.isAttached, isTrue);
+    expect(controller.zoom, 1.0);
+
+    final planner = find.byKey(plannerKey);
+    final at = gridPointFor(tester.getRect(planner), downFromGridTop: 200);
+
+    // At zoom 1 a point 200px below the grid top maps to hour 5 (200 / 40px row).
+    await createViaMenu(tester, planner, at);
+    expect(created, isNotNull);
+    final baseHour = created!.hour;
+    expect(baseHour, 5);
+
+    // Zoom in via the host's *own* button. It must move the live grid, not just
+    // the controller's number.
+    for (var i = 0; i < 6; i++) {
+      await tester.tap(find.byKey(zoomInKey));
+      await tester.pump();
+    }
+    expect(controller.zoom, greaterThan(1.0),
+        reason: 'the host button drove the real grid zoom');
+
+    // Each hour row is now taller, so the same screen point covers fewer hours —
+    // observable proof the grid actually re-zoomed end-to-end.
+    created = null;
+    await createViaMenu(tester, planner, at);
+    final zoomedInHour = created!.hour;
+    expect(zoomedInHour, lessThan(baseHour),
+        reason: 'zoom enlarged the rows, so a fixed pixel maps to fewer hours');
+
+    // Zooming back out via the other host button reverses the mapping.
+    for (var i = 0; i < 6; i++) {
+      await tester.tap(find.byKey(zoomOutKey));
+      await tester.pump();
+    }
+    created = null;
+    await createViaMenu(tester, planner, at);
+    expect(created!.hour, greaterThan(zoomedInHour),
+        reason: 'zoomOut shrank the rows again, mapping back toward hour 5');
+  });
+
+  testWidgets('the external controller and the grid share one zoom (#76)',
+      (tester) async {
+    final controller = PlannerController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(hostApp(controller, (_) {}));
+    await tester.pumpAndSettle();
+
+    // A host listener (e.g. to enable/disable + at maxZoom) fires on a real tap.
+    var notifications = 0;
+    controller.addListener(() => notifications++);
+
+    await tester.tap(find.byKey(zoomInKey));
+    await tester.pump();
+
+    expect(controller.zoom, closeTo(1.1, 1e-9));
+    expect(notifications, greaterThan(0),
+        reason: 'the controller re-emits so a toolbar can react');
+  });
+}

--- a/lib/planner.dart
+++ b/lib/planner.dart
@@ -1,6 +1,7 @@
 library;
 
 export 'planner_class.dart';
+export 'planner_controller.dart';
 export 'planner_entry.dart';
 export 'planner_config.dart';
 export 'planner_time.dart';

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -12,6 +12,7 @@ import 'internal/scroll_detector.dart';
 import 'internal/positioned_tap_detector_2.dart';
 import 'internal/date_row.dart';
 import 'internal/manager.dart';
+import 'planner_controller.dart';
 import 'planner_entry.dart';
 import 'planner_config.dart';
 
@@ -27,10 +28,19 @@ class Planner extends StatefulWidget {
   final List<PlannerEntry> entries;
   final PlannerConfig config;
 
+  /// Optional public handle for driving and observing zoom from outside the
+  /// widget (#76) — e.g. a host's own zoom toolbar. When supplied it attaches to
+  /// the planner's internal zoom/scroll controller for the life of this widget
+  /// (and across a controller swap); when `null`, zoom is driven only by the
+  /// built-in controls, pinch and Ctrl+wheel, exactly as before. Pair it with
+  /// `config.showZoomControls: false` to replace the on-canvas buttons.
+  final PlannerController? controller;
+
   const Planner({
     super.key,
     required this.config,
     required this.entries,
+    this.controller,
   });
 
   @override
@@ -107,6 +117,11 @@ class _PlannerState extends State<Planner> {
     // controller is preserved across rebuilds (Manager.update keeps it), so this
     // listener stays valid for the life of the State.
     _data.controller.triggerUpdate.addListener(_rebuildCanvasSemantics);
+    // Bind an external zoom controller (#76) to the same internal controller, so
+    // a host toolbar can drive/observe zoom. _data.controller is stable for the
+    // life of the State (Manager.update keeps it), so this single attach holds;
+    // only a controller *swap* needs re-attaching (didUpdateWidget).
+    widget.controller?.attach(_data.controller);
   }
 
   /// Rebuilds the events-canvas and all-day-band accessibility semantics so each
@@ -131,10 +146,21 @@ class _PlannerState extends State<Planner> {
         !identical(oldWidget.entries, widget.entries)) {
       _data.update(config: widget.config, entries: widget.entries);
     }
+    // Re-bind on an external zoom controller swap (#76): detach the old, attach
+    // the new to the same (stable) internal controller, so no listener leaks and
+    // the new controller drives the live planner. A no-op when the same instance
+    // (or null) is passed across rebuilds.
+    if (!identical(oldWidget.controller, widget.controller)) {
+      oldWidget.controller?.detach();
+      widget.controller?.attach(_data.controller);
+    }
   }
 
   @override
   void dispose() {
+    // Unbind the external zoom controller (#76) before the internal controller
+    // goes away, so its re-emit listener doesn't outlive this planner.
+    widget.controller?.detach();
     _data.controller.triggerUpdate.removeListener(_rebuildCanvasSemantics);
     _cursor.dispose();
     super.dispose();

--- a/lib/planner_controller.dart
+++ b/lib/planner_controller.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/foundation.dart';
+
+import 'internal/controller.dart';
+
+/// A public handle a host constructs and hands to a `Planner` to drive and
+/// observe its zoom from outside the widget (#76) — for example a custom zoom
+/// toolbar that lives in the host's own chrome rather than the planner's
+/// on-canvas buttons.
+///
+/// It is intentionally **not** a general-purpose controller: it only deals with
+/// zoom and exposes scroll read-back. Internally it attaches to the planner's
+/// private zoom/scroll [Controller], which stays the single source of truth — no
+/// state is duplicated here, and clamping to `minZoom`/`maxZoom` stays in the
+/// [Controller]. Pass one to `Planner(controller: ...)` and typically set
+/// `showZoomControls: false` so the built-in buttons make way for your own.
+///
+/// As a [ChangeNotifier] it re-emits a notification on every view change (zoom
+/// **and** scroll), so a host toolbar can rebuild to, say, disable its `+`
+/// button once [zoom] reaches [maxZoom]. Notifications only fire while the
+/// controller is attached to a mounted planner; read [zoom]/[minZoom]/[maxZoom]/
+/// [dayScroll]/[timeScroll] only while [isAttached] (the read getters throw
+/// otherwise, since there is no planner to read from).
+///
+/// Lifecycle (attach/detach) is handled by `Planner`; a host only constructs the
+/// controller, optionally listens to it, calls the zoom methods, and disposes it
+/// like any other [ChangeNotifier].
+class PlannerController extends ChangeNotifier {
+  /// The attached planner's internal zoom/scroll controller, or `null` while
+  /// this controller isn't bound to a mounted planner. Set by [attach]/[detach].
+  Controller? _inner;
+
+  /// Whether this controller is currently bound to a mounted `Planner`. Zoom
+  /// methods are no-ops and the read getters throw while this is `false`, so a
+  /// host that reads zoom/scroll outside a listener notification should guard on
+  /// it (a freshly constructed controller, or one whose planner has been
+  /// unmounted, is not attached).
+  bool get isAttached => _inner != null;
+
+  /// The current zoom factor of the attached planner, in `[minZoom, maxZoom]`.
+  /// Throws a [StateError] when not [isAttached].
+  double get zoom => _requireInner().zoom;
+
+  /// The minimum zoom the attached planner clamps to (its
+  /// `PlannerConfig.minZoom`). Throws a [StateError] when not [isAttached].
+  double get minZoom => _requireInner().config.minZoom;
+
+  /// The maximum zoom the attached planner clamps to (its
+  /// `PlannerConfig.maxZoom`). Throws a [StateError] when not [isAttached].
+  double get maxZoom => _requireInner().config.maxZoom;
+
+  /// The day-axis (horizontal) scroll offset of the attached planner, in logical
+  /// pixels (`<= 0`; `0` is the leftmost column). Read-only — this controller
+  /// drives zoom, not scroll. Throws a [StateError] when not [isAttached].
+  double get dayScroll => _requireInner().x;
+
+  /// The time-axis (vertical) scroll offset of the attached planner, in logical
+  /// pixels (`<= 0`; `0` is the top of the grid). Read-only. Throws a
+  /// [StateError] when not [isAttached].
+  double get timeScroll => _requireInner().y;
+
+  /// Zooms in by [factor] (default `1.1`), multiplying the current zoom and
+  /// clamping to [maxZoom] in the [Controller]. A no-op when not [isAttached].
+  void zoomIn([double factor = 1.1]) => _multiplyZoom(factor);
+
+  /// Zooms out by [factor] (default `0.9`), multiplying the current zoom and
+  /// clamping to [minZoom] in the [Controller]. A no-op when not [isAttached].
+  void zoomOut([double factor = 0.9]) => _multiplyZoom(factor);
+
+  /// Sets the zoom to an absolute [target], clamped to `[minZoom, maxZoom]` by
+  /// the [Controller]. A no-op when not [isAttached].
+  ///
+  /// The [Controller] only zooms multiplicatively (relative to the zoom captured
+  /// by `startZoom`), so this asks it to scale from the current zoom to [target];
+  /// the clamp still applies. A current zoom of `0` (only reachable with a
+  /// `minZoom <= 0`) has no defined scale to [target], so it is left untouched.
+  void zoomTo(double target) {
+    final inner = _inner;
+    if (inner == null) return;
+    final current = inner.zoom;
+    if (current <= 0) return;
+    inner.startZoom();
+    inner.updateZoom(target / current);
+  }
+
+  void _multiplyZoom(double factor) {
+    final inner = _inner;
+    if (inner == null) return;
+    inner.startZoom();
+    inner.updateZoom(factor);
+  }
+
+  Controller _requireInner() {
+    final inner = _inner;
+    if (inner == null) {
+      throw StateError(
+        'PlannerController is not attached to a Planner. Read zoom/scroll only '
+        'while attached — guard with `isAttached`, or read inside a listener '
+        'notification (which only fires while attached).',
+      );
+    }
+    return inner;
+  }
+
+  /// Binds this controller to a planner's internal zoom/scroll [Controller].
+  /// Called by `Planner` from its `initState`/`didUpdateWidget` — **not** part of
+  /// the consumer API. Re-binding to the same [inner] is a no-op; binding to a
+  /// different one detaches the previous first, so the listener is never doubled.
+  void attach(Controller inner) {
+    if (identical(_inner, inner)) return;
+    _inner?.triggerUpdate.removeListener(notifyListeners);
+    _inner = inner;
+    inner.triggerUpdate.addListener(notifyListeners);
+  }
+
+  /// Unbinds from the current planner, removing the re-emit listener so nothing
+  /// leaks past the planner's lifetime. Called by `Planner` from its `dispose`
+  /// and on a controller swap — **not** part of the consumer API. Safe to call
+  /// when already detached.
+  void detach() {
+    _inner?.triggerUpdate.removeListener(notifyListeners);
+    _inner = null;
+  }
+
+  /// Detaches before disposing so a still-attached controller can't fire
+  /// [notifyListeners] after disposal (its planner normally detaches it first,
+  /// but disposal order isn't guaranteed).
+  @override
+  void dispose() {
+    detach();
+    super.dispose();
+  }
+}

--- a/test/planner_controller_test.dart
+++ b/test/planner_controller_test.dart
@@ -1,0 +1,321 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/controller.dart';
+import 'package:planner/planner.dart';
+
+/// Unit + widget coverage for the public [PlannerController] (#76): the handle a
+/// host constructs and hands to [Planner] to drive and observe zoom from its own
+/// chrome. The "in isolation" group binds the controller straight to an internal
+/// [Controller] to assert attach/detach and notification plumbing precisely; the
+/// "wired into a real Planner" group drives the actual composed widget.
+void main() {
+  PlannerConfig makeConfig({
+    double minZoom = 0.5,
+    double maxZoom = 4.0,
+    bool showZoomControls = true,
+  }) =>
+      PlannerConfig(
+        labels: const ['A', 'B', 'C'],
+        minZoom: minZoom,
+        maxZoom: maxZoom,
+        showZoomControls: showZoomControls,
+      );
+
+  group('PlannerController in isolation (attached to an internal Controller)',
+      () {
+    test('a fresh controller is not attached', () {
+      final pc = PlannerController();
+      expect(pc.isAttached, isFalse);
+    });
+
+    test('read getters throw a StateError while unattached', () {
+      final pc = PlannerController();
+      expect(() => pc.zoom, throwsStateError);
+      expect(() => pc.minZoom, throwsStateError);
+      expect(() => pc.maxZoom, throwsStateError);
+      expect(() => pc.dayScroll, throwsStateError);
+      expect(() => pc.timeScroll, throwsStateError);
+    });
+
+    test('zoom methods are silent no-ops while unattached', () {
+      final pc = PlannerController();
+      // Must not throw even though there's no planner to drive.
+      expect(() => pc.zoomIn(), returnsNormally);
+      expect(() => pc.zoomOut(), returnsNormally);
+      expect(() => pc.zoomTo(2.0), returnsNormally);
+    });
+
+    test('attach exposes the inner zoom / bounds / scroll', () {
+      final inner = Controller(makeConfig(minZoom: 0.25, maxZoom: 8.0));
+      final pc = PlannerController()..attach(inner);
+
+      expect(pc.isAttached, isTrue);
+      expect(pc.zoom, 1.0);
+      expect(pc.minZoom, 0.25);
+      expect(pc.maxZoom, 8.0);
+      expect(pc.dayScroll, 0.0);
+      expect(pc.timeScroll, 0.0);
+
+      // Scroll is read-only here but must reflect the inner controller.
+      inner.x = -120;
+      inner.y = -80;
+      expect(pc.dayScroll, -120);
+      expect(pc.timeScroll, -80);
+    });
+
+    test('zoomIn / zoomOut multiply the inner zoom', () {
+      final inner = Controller(makeConfig());
+      final pc = PlannerController()..attach(inner);
+
+      pc.zoomIn(); // *1.1
+      expect(pc.zoom, closeTo(1.1, 1e-9));
+      expect(inner.zoom, closeTo(1.1, 1e-9), reason: 'drives the one inner');
+
+      pc.zoomOut(); // *0.9
+      expect(pc.zoom, closeTo(1.1 * 0.9, 1e-9));
+
+      pc.zoomIn(2.0); // explicit factor
+      expect(pc.zoom, closeTo(1.1 * 0.9 * 2.0, 1e-9));
+    });
+
+    test('zoomTo sets an absolute zoom and clamps to [minZoom, maxZoom]', () {
+      final inner = Controller(makeConfig()); // 0.5 .. 4.0
+      final pc = PlannerController()..attach(inner);
+
+      pc.zoomTo(2.0);
+      expect(pc.zoom, closeTo(2.0, 1e-9));
+
+      pc.zoomTo(100); // past maxZoom
+      expect(pc.zoom, 4.0);
+
+      pc.zoomTo(0.001); // past minZoom
+      expect(pc.zoom, 0.5);
+    });
+
+    test('zoomTo from a degenerate zoom of 0 is left untouched (no crash)', () {
+      // Only reachable with a minZoom <= 0; there's no defined scale from 0 to a
+      // target, so the guard leaves it where it is rather than producing NaN.
+      final inner = Controller(makeConfig(minZoom: 0, maxZoom: 4));
+      final pc = PlannerController()..attach(inner);
+
+      pc.zoomTo(0); // current 1 -> scale 0 -> clamps to 0
+      expect(pc.zoom, 0);
+
+      pc.zoomTo(2); // current 0 -> guard returns
+      expect(pc.zoom, 0);
+    });
+
+    test('notifies listeners on every inner view change (zoom and scroll)', () {
+      final inner = Controller(makeConfig());
+      final pc = PlannerController()..attach(inner);
+
+      var notifications = 0;
+      pc.addListener(() => notifications++);
+
+      pc.zoomIn();
+      expect(notifications, 1, reason: 'zoom change re-emits');
+
+      inner.x = -50; // a scroll bumps triggerUpdate too
+      expect(notifications, 2, reason: 'scroll change re-emits as well');
+    });
+
+    test('detach removes the listener so nothing leaks past the planner', () {
+      final inner = Controller(makeConfig());
+      final pc = PlannerController()..attach(inner);
+
+      var notifications = 0;
+      pc.addListener(() => notifications++);
+
+      pc.zoomIn();
+      expect(notifications, 1);
+
+      pc.detach();
+      expect(pc.isAttached, isFalse);
+
+      // Further inner changes must not reach the detached controller.
+      inner.startZoom();
+      inner.updateZoom(1.1);
+      inner.x = -30;
+      expect(notifications, 1, reason: 'no notifications after detach');
+    });
+
+    test('re-attaching the same inner does not double the listener', () {
+      final inner = Controller(makeConfig());
+      final pc = PlannerController()
+        ..attach(inner)
+        ..attach(inner); // no-op
+
+      var notifications = 0;
+      pc.addListener(() => notifications++);
+
+      inner.startZoom();
+      inner.updateZoom(1.1);
+      expect(notifications, 1,
+          reason: 'a single listener despite double attach');
+    });
+
+    test('attaching a different inner detaches the previous one', () {
+      final first = Controller(makeConfig());
+      final second = Controller(makeConfig());
+      final pc = PlannerController()..attach(first);
+
+      var notifications = 0;
+      pc.addListener(() => notifications++);
+
+      // Swap to a different inner; the first must now be detached.
+      pc.attach(second);
+
+      first.startZoom();
+      first.updateZoom(1.1);
+      expect(notifications, 0, reason: 'previous inner was detached on swap');
+
+      second.startZoom();
+      second.updateZoom(1.1);
+      expect(notifications, 1, reason: 'the new inner drives notifications');
+    });
+
+    test('dispose detaches a still-attached controller', () {
+      final inner = Controller(makeConfig());
+      final pc = PlannerController()..attach(inner);
+
+      var notifications = 0;
+      pc.addListener(() => notifications++);
+      pc.dispose();
+
+      // A notify after dispose would throw on a ChangeNotifier; detaching in
+      // dispose means the inner's listener is gone, so this is silent.
+      expect(() {
+        inner.startZoom();
+        inner.updateZoom(1.1);
+      }, returnsNormally);
+      expect(notifications, 0);
+    });
+  });
+
+  group('PlannerController wired into a real Planner', () {
+    Widget app(PlannerController? controller, {PlannerConfig? config}) =>
+        MaterialApp(
+          home: Scaffold(
+            body: Planner(
+              config: config ?? makeConfig(),
+              entries: const [],
+              controller: controller,
+            ),
+          ),
+        );
+
+    testWidgets('attaches on mount and exposes the live zoom / bounds',
+        (tester) async {
+      final pc = PlannerController();
+      await tester.pumpWidget(app(pc));
+      await tester.pumpAndSettle();
+
+      expect(pc.isAttached, isTrue);
+      expect(pc.zoom, 1.0);
+      expect(pc.minZoom, 0.5);
+      expect(pc.maxZoom, 4.0);
+    });
+
+    testWidgets('zoomIn / zoomOut / zoomTo change the grid zoom',
+        (tester) async {
+      final pc = PlannerController();
+      await tester.pumpWidget(app(pc));
+      await tester.pumpAndSettle();
+
+      pc.zoomIn();
+      await tester.pump();
+      expect(pc.zoom, closeTo(1.1, 1e-9));
+
+      pc.zoomTo(3.0);
+      await tester.pump();
+      expect(pc.zoom, closeTo(3.0, 1e-9));
+
+      pc.zoomOut();
+      await tester.pump();
+      expect(pc.zoom, closeTo(3.0 * 0.9, 1e-9));
+    });
+
+    testWidgets('a host listener is notified when the zoom changes',
+        (tester) async {
+      final pc = PlannerController();
+      var notifications = 0;
+      pc.addListener(() => notifications++);
+
+      await tester.pumpWidget(app(pc));
+      await tester.pumpAndSettle();
+
+      pc.zoomIn();
+      await tester.pump();
+      expect(notifications, greaterThan(0),
+          reason: 'a toolbar can rebuild to disable + at maxZoom');
+    });
+
+    testWidgets('external controller and on-canvas buttons share one zoom',
+        (tester) async {
+      final pc = PlannerController();
+      await tester.pumpWidget(app(pc));
+      await tester.pumpAndSettle();
+
+      // Tapping the built-in zoom-in button moves the same zoom the external
+      // controller reads — proof there's a single source of truth, not a copy.
+      await tester.tap(find.byIcon(Icons.zoom_in));
+      await tester.pump();
+      expect(pc.zoom, closeTo(1.1, 1e-9));
+    });
+
+    testWidgets('detaches cleanly when the planner is unmounted',
+        (tester) async {
+      final pc = PlannerController();
+      await tester.pumpWidget(app(pc));
+      await tester.pumpAndSettle();
+      expect(pc.isAttached, isTrue);
+
+      // Replace the planner with something else -> Planner.dispose -> detach.
+      await tester
+          .pumpWidget(const MaterialApp(home: Scaffold(body: SizedBox())));
+      await tester.pumpAndSettle();
+
+      expect(pc.isAttached, isFalse);
+      expect(() => pc.zoomIn(), returnsNormally,
+          reason: 'a stray call after unmount is a no-op, not a crash');
+    });
+
+    testWidgets('swapping the controller re-binds without leaking the old one',
+        (tester) async {
+      final a = PlannerController();
+      final b = PlannerController();
+      final config = makeConfig();
+
+      await tester.pumpWidget(app(a, config: config));
+      await tester.pumpAndSettle();
+      expect(a.isAttached, isTrue);
+
+      // Same Planner position, different controller -> didUpdateWidget swap.
+      await tester.pumpWidget(app(b, config: config));
+      await tester.pumpAndSettle();
+
+      expect(a.isAttached, isFalse, reason: 'old controller detached');
+      expect(b.isAttached, isTrue, reason: 'new controller attached');
+
+      // The new controller drives the planner; the old one is inert.
+      b.zoomTo(2.0);
+      await tester.pump();
+      expect(b.zoom, closeTo(2.0, 1e-9));
+      expect(() => a.zoomIn(), returnsNormally);
+    });
+
+    testWidgets('a Planner with no controller behaves as before',
+        (tester) async {
+      // The built-in zoom buttons still work and nothing throws when no
+      // controller is supplied (the opt-in default path).
+      await tester.pumpWidget(app(null));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.zoom_in), findsOneWidget);
+      expect(() async {
+        await tester.tap(find.byIcon(Icons.zoom_in));
+        await tester.pump();
+      }, returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds a public `PlannerController` (a `ChangeNotifier`) that a host constructs and hands to `Planner(controller: …)` to **drive and observe zoom from outside the widget** — e.g. a host's own zoom toolbar. It attaches to the planner's internal zoom/scroll `Controller`, the single source of truth, so the controller, pinch, `Ctrl`+wheel and the built-in buttons all move the *same* zoom (no duplicated state). Step 1 of the deep-customization effort (#75) and independent of the other child issues.

## Linked issue
Closes #76

## Changes
- **`lib/planner_controller.dart` (new):** `PlannerController extends ChangeNotifier`.
  - Methods: `zoomIn([factor = 1.1])`, `zoomOut([factor = 0.9])`, `zoomTo(target)` — implemented via `_inner.startZoom()` + `_inner.updateZoom(...)`; clamping to `minZoom`/`maxZoom` stays in `Controller`. No-ops while unattached.
  - Getters: `zoom`, `minZoom`, `maxZoom`, `dayScroll`, `timeScroll`, `isAttached`. Read getters throw a `StateError` while unattached (guard with `isAttached`, or read in a listener callback).
  - Re-emits `notifyListeners` off the controller's `triggerUpdate`, so a host toolbar can rebuild (e.g. disable `+` at `maxZoom`). `attach`/`detach` manage the single re-emit listener; `dispose()` detaches first so it can't fire post-disposal.
- **`lib/planner.dart`:** export `planner_controller.dart`.
- **`lib/planner_class.dart`:** optional `controller` param on `Planner`; `attach` in `initState`, re-bind on a controller swap in `didUpdateWidget`, `detach` in `dispose`. No change to `internal/controller.dart` was needed — it already exposed `x`/`y`/`zoom`/`config`/`startZoom`/`updateZoom`/`triggerUpdate` publicly.
- **Tests:** `test/planner_controller_test.dart` (new, 19 tests) covering attach/detach/swap/dispose listener plumbing in isolation plus the real-`Planner` composition; `example/integration_test/external_zoom_scenarios.dart` (new) driving a real host toolbar end-to-end, registered in `app_test.dart`.
- **Docs:** README "Driving zoom from a host toolbar" section + core-types/member tables; CHANGELOG entry; PROJECT_OVERVIEW architecture-map row; integration-test README row.

External-zoom recipe: pass a `PlannerController` + set `showZoomControls: false`. Fully backward compatible — omit the controller and nothing changes.

## Test plan
- [x] `flutter analyze` clean (planner + example)
- [x] Unit/widget tests pass — `flutter test`: **208 pass** (19 new in `planner_controller_test.dart`)
- [x] Integration/e2e tests pass — `flutter test integration_test -d windows` (full suite): **41 scenarios pass**, incl. 2 new `#76` scenarios. The host-toolbar scenario asserts a real button tap re-zooms the live grid (a fixed pixel maps to fewer hours as rows grow), not just the controller's number.

## Notes / screenshots
The internal `Controller` type appears in the framework-internal `attach`/`detach` signatures; these are documented as called by `Planner`, and the type isn't part of the umbrella export, so consumers don't reach it. `scheduler/` design-handoff files were intentionally left untracked and are not part of this PR.