### PR TITLE
feat: generic PlannerEntry<T> with typed metadata payload (#77)

### DIFF
--- a/lib/internal/all_day_band.dart
+++ b/lib/internal/all_day_band.dart
@@ -13,8 +13,13 @@ import 'manager.dart';
 /// draws the [AllDayEvent] chips. Like [DateRow] it repaints on the controller's
 /// update listenable (so a day-axis pan re-lays the chips) and otherwise only
 /// when the event data revision changes.
-class AllDayBand extends CustomPainter {
-  final Manager manager;
+// Generic over the entry payload [T] (#77), for the same reason as
+// [EventsPainter]: its semanticsBuilder reads the now-generic entry callbacks
+// (`config.onEntryEdit`/`onEntryDelete`, typed `void Function(PlannerEntry<T>)`),
+// which would trip a runtime covariance check if read through a covariant
+// `Manager<dynamic>`. So it carries `T` and holds a `Manager<T>`.
+class AllDayBand<T> extends CustomPainter {
+  final Manager<T> manager;
 
   // The manager's data revision when this delegate was built; compared in
   // shouldRepaint so the band repaints only when the data changed, not on every
@@ -53,7 +58,7 @@ class AllDayBand extends CustomPainter {
     final canDelete = config.onEntryDelete != null;
 
     return [
-      for (final AllDayEvent chip in manager.allDayEvents)
+      for (final AllDayEvent<T> chip in manager.allDayEvents)
         CustomPainterSemantics(
           key: ValueKey(chip.entry.id),
           rect: chip.screenRect,

--- a/lib/internal/all_day_event.dart
+++ b/lib/internal/all_day_event.dart
@@ -27,9 +27,9 @@ const double allDayChipInset = 2.0;
 /// to/from a timed event is out of scope (#72). Geometry tracks only the
 /// horizontal scroll ([Controller.offset]'s `dx`) — the band is a fixed header
 /// strip, so it neither zooms nor scrolls with the time axis.
-class AllDayEvent {
-  final PlannerEntry entry;
-  final Manager manager;
+class AllDayEvent<T> {
+  final PlannerEntry<T> entry;
+  final Manager<T> manager;
 
   /// Which stacked lane (row) within the band this chip occupies. Lane 0 is the
   /// topmost; [Manager] assigns it by first-fit packing on the column axis.

--- a/lib/internal/context_menu.dart
+++ b/lib/internal/context_menu.dart
@@ -3,16 +3,16 @@ import 'package:flutter/material.dart';
 import 'controller.dart';
 import 'manager.dart';
 
-class ContextMenu extends StatefulWidget {
-  final Manager manager;
+class ContextMenu<T> extends StatefulWidget {
+  final Manager<T> manager;
 
   const ContextMenu({super.key, required this.manager});
 
   @override
-  State<ContextMenu> createState() => _ContextMenuState();
+  State<ContextMenu<T>> createState() => _ContextMenuState<T>();
 }
 
-class _ContextMenuState extends State<ContextMenu> {
+class _ContextMenuState<T> extends State<ContextMenu<T>> {
   @override
   Widget build(BuildContext context) {
     return IntrinsicWidth(

--- a/lib/internal/controller.dart
+++ b/lib/internal/controller.dart
@@ -8,7 +8,7 @@ enum MenuType {
   none,
 }
 
-class Controller {
+class Controller<T> {
   final triggerUpdate = ValueNotifier<int>(0);
 
   double _x = 0;
@@ -60,11 +60,11 @@ class Controller {
   /// The entry the entry-menu (edit/delete) acts on. A [PlannerEntry] rather
   /// than an [Event] so the same menu serves both timed events and all-day chips
   /// (#72) — both carry a [PlannerEntry], which is all edit/delete need.
-  PlannerEntry? menuEntry;
+  PlannerEntry<T>? menuEntry;
   PlannerTime? menuTime;
   Function? _onCloseMenu;
 
-  PlannerConfig config;
+  PlannerConfig<T> config;
 
   Controller(this.config) {
     _calculateOffsets();
@@ -73,7 +73,7 @@ class Controller {
   /// Adopts a new [config] (e.g. when the host `Planner` is rebuilt with
   /// different settings) and recomputes the scroll bounds, while leaving the
   /// current scroll/zoom position untouched.
-  void updateConfig(PlannerConfig config) {
+  void updateConfig(PlannerConfig<T> config) {
     this.config = config;
     _calculateOffsets();
   }
@@ -191,7 +191,7 @@ class Controller {
   /// Opens the entry menu (edit/delete) for [entry] at planner-local [pos]. The
   /// caller (timed grid or all-day band) passes the chip's/event's
   /// [PlannerEntry], so the same menu serves both surfaces (#72).
-  void showEventMenu(Offset pos, PlannerEntry entry, Function onClose) {
+  void showEventMenu(Offset pos, PlannerEntry<T> entry, Function onClose) {
     menuPos = pos;
     menuType = MenuType.entry;
     menuEntry = entry;

--- a/lib/internal/event.dart
+++ b/lib/internal/event.dart
@@ -10,12 +10,12 @@ enum DragType {
   none,
 }
 
-class Event {
+class Event<T> {
   /// The entry this event draws. Reassigned (never mutated) when a drag/resize
   /// or nudge commits, since [PlannerEntry]/[PlannerTime] are immutable (#27):
   /// the new instance is what flows on to [PlannerConfig.onEntryMove].
-  PlannerEntry entry;
-  final Manager manager;
+  PlannerEntry<T> entry;
+  final Manager<T> manager;
 
   /// The event's bounding rectangle in grid space — for a single-column event
   /// this is its drawn rect; for a spanning event it is the bounding box of all
@@ -57,6 +57,9 @@ class Event {
     _createPaints();
     relayout();
   }
+
+  // Note: this class is generic only to carry the entry's typed payload (#77).
+  // Its geometry/painting read only the entry's strings and time, never `data`.
 
   /// Recomputes the geometry and text wrapping after [columnIndex]/[columnCount]
   /// (or, for a spanning event, its [_spanColumns] placement) change. [Manager]

--- a/lib/internal/events_painter.dart
+++ b/lib/internal/events_painter.dart
@@ -5,9 +5,14 @@ import 'event.dart';
 import 'grid.dart';
 import 'manager.dart';
 
-class EventsPainter extends CustomPainter {
+// Generic over the entry payload [T] (#77). It must be — its semanticsBuilder
+// reads the now-generic entry callbacks (`config.onEntryEdit` et al., typed
+// `void Function(PlannerEntry<T>)`). Held through a covariant `Manager`
+// (`Manager<dynamic>`) those reads would trip a runtime covariance check and
+// throw, so the painter carries `T` and holds a `Manager<T>` at its true type.
+class EventsPainter<T> extends CustomPainter {
   final Grid _grid;
-  final Manager manager;
+  final Manager<T> manager;
 
   // The manager's data revision when this delegate was built; compared in
   // shouldRepaint so the canvas repaints (and its semantics rebuild) only when

--- a/lib/internal/manager.dart
+++ b/lib/internal/manager.dart
@@ -5,18 +5,18 @@ import 'all_day_event.dart';
 import 'controller.dart';
 import 'event.dart';
 
-class Manager {
-  PlannerConfig config;
-  List<PlannerEntry> entries;
-  final Controller controller;
-  final List<Event> events = [];
+class Manager<T> {
+  PlannerConfig<T> config;
+  List<PlannerEntry<T>> entries;
+  final Controller<T> controller;
+  final List<Event<T>> events = [];
 
   /// The all-day events (#48), packed into stacked lanes for the all-day band.
   /// Built from entries whose [PlannerTime.allDay] is set; those are kept out of
   /// [events] (the hour-positioned grid) entirely. Empty — so the band is
   /// omitted and [allDayBandHeight] is zero — when none are all-day or the band
   /// is disabled ([PlannerConfig.showAllDayBand] is `false`, the default).
-  final List<AllDayEvent> allDayEvents = [];
+  final List<AllDayEvent<T>> allDayEvents = [];
 
   /// How many stacked lanes the all-day band needs — the height of the busiest
   /// overlap of all-day events. Zero when there are no all-day events.
@@ -35,12 +35,12 @@ class Manager {
   // (#25): an event's rect lies entirely within its own day-column, so no other
   // bucket can contain the point. Rebuilt only when the event set or an event's
   // day can have changed — never per frame or per tap.
-  final Map<int, List<Event>> _eventsByDay = {};
+  final Map<int, List<Event<T>>> _eventsByDay = {};
 
   Manager({
     required this.config,
     required this.entries,
-  }) : controller = Controller(config) {
+  }) : controller = Controller<T>(config) {
     _buildEvents();
   }
 
@@ -49,8 +49,8 @@ class Manager {
   /// the current scroll/zoom position survives the rebuild instead of being
   /// reset — which is what the previous `static` controller state hacked around.
   void update({
-    required PlannerConfig config,
-    required List<PlannerEntry> entries,
+    required PlannerConfig<T> config,
+    required List<PlannerEntry<T>> entries,
   }) {
     this.config = config;
     this.entries = entries;
@@ -60,8 +60,8 @@ class Manager {
 
   void _buildEvents() {
     events.clear();
-    final allDayInputs = <PlannerEntry>[];
-    for (PlannerEntry entry in entries) {
+    final allDayInputs = <PlannerEntry<T>>[];
+    for (PlannerEntry<T> entry in entries) {
       // All-day entries render in the band, not the hour grid, so they're kept
       // out of `events` (and thus out of overlap layout, hit-testing and drag).
       // The band is opt-in (#72): when [PlannerConfig.showAllDayBand] is off,
@@ -70,7 +70,7 @@ class Manager {
       if (entry.time.allDay) {
         if (config.showAllDayBand) allDayInputs.add(entry);
       } else {
-        events.add(Event(entry: entry, manager: this));
+        events.add(Event<T>(entry: entry, manager: this));
       }
     }
     _layoutOverlaps();
@@ -89,7 +89,7 @@ class Manager {
   /// column — must not share a lane. First-fit on the column axis (sorted by
   /// start column, then end) gives the standard side-by-side stacking with the
   /// fewest lanes, mirroring the per-column time packing in [_layoutDayColumn].
-  void _layoutAllDay(List<PlannerEntry> allDayInputs) {
+  void _layoutAllDay(List<PlannerEntry<T>> allDayInputs) {
     allDayEvents.clear();
 
     final sorted = [...allDayInputs]..sort((a, b) {
@@ -112,7 +112,7 @@ class Manager {
       } else {
         laneLastColumn[lane] = end;
       }
-      allDayEvents.add(AllDayEvent(entry: entry, manager: this, lane: lane));
+      allDayEvents.add(AllDayEvent<T>(entry: entry, manager: this, lane: lane));
     }
 
     allDayLaneCount = laneLastColumn.length;
@@ -135,7 +135,7 @@ class Manager {
   /// hit-tests from any of them, not just its start column.
   void _rebuildDayIndex() {
     _eventsByDay.clear();
-    for (final Event event in events) {
+    for (final Event<T> event in events) {
       final time = event.entry.time;
       for (int day = time.day; day <= time.lastDay; day++) {
         _eventsByDay.putIfAbsent(day, () => []).add(event);
@@ -159,7 +159,7 @@ class Manager {
   /// closes).
   void _layoutOverlaps() {
     final split = config.spanOverlap == SpanOverlap.split;
-    final byDay = <int, List<Event>>{};
+    final byDay = <int, List<Event<T>>>{};
     for (final event in events) {
       final time = event.entry.time;
       if (time.spansColumns) {
@@ -184,9 +184,9 @@ class Manager {
     }
   }
 
-  void _layoutDayColumn(int day, List<Event> dayEvents) {
-    int startOf(Event e) => e.entry.time.hour * 60 + e.entry.time.minutes;
-    int endOf(Event e) => startOf(e) + e.entry.time.duration;
+  void _layoutDayColumn(int day, List<Event<T>> dayEvents) {
+    int startOf(Event<T> e) => e.entry.time.hour * 60 + e.entry.time.minutes;
+    int endOf(Event<T> e) => startOf(e) + e.entry.time.duration;
 
     // Sort by start, then by end: first-fit packing assumes ascending starts.
     dayEvents.sort((a, b) {
@@ -199,9 +199,9 @@ class Manager {
     // landed in, and the cluster's latest end. The sub-column is kept in a local
     // map rather than on the Event, since a spanning event is packed once per
     // column it crosses and must not clobber its other columns' placements.
-    final cluster = <Event>[];
+    final cluster = <Event<T>>[];
     final columnEnds = <int>[];
-    final columnOf = <Event, int>{};
+    final columnOf = <Event<T>, int>{};
     int clusterEnd = -1;
 
     void closeCluster() {
@@ -242,7 +242,7 @@ class Manager {
   /// single-column event stores it directly and relays out now; a spanning event
   /// records it per column (relayout is deferred to [_layoutOverlaps] once all
   /// its columns are packed).
-  void _assignColumn(Event event, int day, int index, int count) {
+  void _assignColumn(Event<T> event, int day, int index, int count) {
     if (event.entry.time.spansColumns) {
       event.setSpanColumn(day, index, count);
     } else {
@@ -252,10 +252,10 @@ class Manager {
     }
   }
 
-  Event? _draggedEvent;
+  Event<T>? _draggedEvent;
 
   /// The event currently being dragged, or `null` when no drag is in progress.
-  Event? get draggedEvent => _draggedEvent;
+  Event<T>? get draggedEvent => _draggedEvent;
 
   /// Translates a pointer position in the planner's local coordinates into the
   /// grid's own coordinate space (undoing the current scroll offset and zoom).
@@ -308,23 +308,23 @@ class Manager {
 
   /// Fires [PlannerConfig.onEntryEdit] for [event] — the accessibility "Edit"
   /// action, mirroring the context menu's "Edit Event".
-  void editEvent(Event event) => config.onEntryEdit?.call(event.entry);
+  void editEvent(Event<T> event) => config.onEntryEdit?.call(event.entry);
 
   /// Fires [PlannerConfig.onEntryDelete] for [event] — the accessibility
   /// "Delete" action, mirroring the context menu's "Delete Event".
-  void deleteEvent(Event event) => config.onEntryDelete?.call(event.entry);
+  void deleteEvent(Event<T> event) => config.onEntryDelete?.call(event.entry);
 
   /// Fires [PlannerConfig.onEntryEdit] for an all-day [chip] — the band's
   /// counterpart to [editEvent], reached by double-tap, the context menu, or the
   /// chip's a11y "activate" action (#72). All-day chips have no time axis, so
   /// (unlike timed events) they expose no move/nudge — only edit and delete.
-  void editAllDayEvent(AllDayEvent chip) =>
+  void editAllDayEvent(AllDayEvent<T> chip) =>
       config.onEntryEdit?.call(chip.entry);
 
   /// Fires [PlannerConfig.onEntryDelete] for an all-day [chip] — the band's
   /// counterpart to [deleteEvent], reached by the context menu or the chip's
   /// a11y "dismiss" action (#72).
-  void deleteAllDayEvent(AllDayEvent chip) =>
+  void deleteAllDayEvent(AllDayEvent<T> chip) =>
       config.onEntryDelete?.call(chip.entry);
 
   /// Shifts [event] by [hourDelta] whole hours, clamped to
@@ -333,7 +333,7 @@ class Manager {
   /// the accessibility layer exposes "Move earlier"/"Move later" nudges — the
   /// keyboard-friendly equivalent of a drag-move. A nudge that would leave the
   /// hour unchanged (already at the bound) is a no-op and fires nothing.
-  void nudgeEvent(Event event, int hourDelta) {
+  void nudgeEvent(Event<T> event, int hourDelta) {
     final time = event.entry.time;
     final newHour =
         (time.hour + hourDelta).clamp(config.minHour, config.maxHour);
@@ -358,17 +358,17 @@ class Manager {
     return event.dragTypeForGridPoint(_toGridPos(localPos));
   }
 
-  Event? getEventAtPos(Offset pos) {
+  Event<T>? getEventAtPos(Offset pos) {
     final Offset realPos = _toGridPos(pos);
 
     // Only events in the tapped day-column can contain the point, so scan that
     // one bucket instead of every event (#25). A tap outside the grid maps to
     // an absent bucket and simply finds nothing.
     final int day = (realPos.dx / config.blockWidth).floor();
-    final List<Event>? candidates = _eventsByDay[day];
+    final List<Event<T>>? candidates = _eventsByDay[day];
     if (candidates == null) return null;
 
-    for (final Event event in candidates) {
+    for (final Event<T> event in candidates) {
       if (event.containsGridPoint(realPos)) {
         return event;
       }
@@ -415,8 +415,8 @@ class Manager {
   /// width, horizontal scroll already applied) — so a chip is hit when its
   /// on-screen rect contains the point. A linear scan: all-day chips are few and
   /// aren't day-bucketed like the timed [events].
-  AllDayEvent? getAllDayEventAtPos(Offset bandLocalPos) {
-    for (final AllDayEvent chip in allDayEvents) {
+  AllDayEvent<T>? getAllDayEventAtPos(Offset bandLocalPos) {
+    for (final AllDayEvent<T> chip in allDayEvents) {
       if (chip.screenRect.contains(bandLocalPos)) return chip;
     }
     return null;

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -24,9 +24,9 @@ import 'planner_config.dart';
 /// layout combined a horizontal-drag recognizer with scale and a long-press).
 enum _GestureMode { idle, pan, zoom, moveResize }
 
-class Planner extends StatefulWidget {
-  final List<PlannerEntry> entries;
-  final PlannerConfig config;
+class Planner<T> extends StatefulWidget {
+  final List<PlannerEntry<T>> entries;
+  final PlannerConfig<T> config;
 
   /// Optional public handle for driving and observing zoom from outside the
   /// widget (#76) — e.g. a host's own zoom toolbar. When supplied it attaches to
@@ -44,15 +44,15 @@ class Planner extends StatefulWidget {
   });
 
   @override
-  State<Planner> createState() => _PlannerState();
+  State<Planner<T>> createState() => _PlannerState<T>();
 }
 
-class _PlannerState extends State<Planner> {
+class _PlannerState<T> extends State<Planner<T>> {
   // Owned by the State so it survives parent rebuilds: building it in the widget
   // constructor recreated the Manager (every Event, every TextPainter, the whole
   // Grid) on every parent build and forced the Controller's scroll/zoom to be
   // static to survive that churn.
-  late Manager _data;
+  late Manager<T> _data;
 
   // Drives the position-aware double-tap detector from the single events
   // GestureDetector below. Nesting a second tap detector (the old layout) let
@@ -140,7 +140,7 @@ class _PlannerState extends State<Planner> {
   }
 
   @override
-  void didUpdateWidget(covariant Planner oldWidget) {
+  void didUpdateWidget(covariant Planner<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget.config, widget.config) ||
         !identical(oldWidget.entries, widget.entries)) {

--- a/lib/planner_config.dart
+++ b/lib/planner_config.dart
@@ -21,7 +21,7 @@ enum SpanOverlap {
   split,
 }
 
-class PlannerConfig {
+class PlannerConfig<T> {
   List<String> labels;
 
   int minHour;
@@ -158,9 +158,9 @@ class PlannerConfig {
   double scrollStep;
 
   Function(PlannerTime time)? onEntryCreate;
-  Function(PlannerEntry)? onEntryEdit;
-  Function(PlannerEntry)? onEntryDelete;
-  Function(PlannerEntry)? onEntryMove;
+  void Function(PlannerEntry<T> entry)? onEntryEdit;
+  void Function(PlannerEntry<T> entry)? onEntryDelete;
+  void Function(PlannerEntry<T> entry)? onEntryMove;
 
   /// Fired when the user long-presses an event, with the pressed [PlannerEntry].
   /// This is the primary way to act on an event by **touch**: touch has no
@@ -174,7 +174,7 @@ class PlannerConfig {
   ///
   /// When `null` (the default) a long-press is a no-op. A long-press on empty
   /// space is always a no-op — create stays on double-tap / right-click.
-  Function(PlannerEntry)? onEntryLongPress;
+  void Function(PlannerEntry<T> entry)? onEntryLongPress;
 
   PlannerConfig({
     required this.labels,

--- a/lib/planner_entry.dart
+++ b/lib/planner_entry.dart
@@ -3,14 +3,23 @@ import 'package:flutter/material.dart';
 import 'planner_time.dart';
 
 /// A single event drawn on the planner: its [id], its [time] (day column /
-/// start / duration), display [title]/[content], fill [color] and text styles.
+/// start / duration), display [title]/[content], fill [color] and text styles,
+/// plus an optional typed [data] payload (#77) for carrying app domain metadata.
+///
+/// Generic over the [data] payload type [T] (#77): an untyped `PlannerEntry(...)`
+/// infers `T == dynamic` and behaves exactly as before, while
+/// `PlannerEntry<ActivityMeta>(...)` makes [data] a typed `ActivityMeta?`. The
+/// type threads through `PlannerConfig<T>`, `Planner<T>` and the entry callbacks,
+/// so a host reads `entry.data` already typed — no side-map keyed by [id] and no
+/// cast. It is the foundation for the custom event/chip builders (#75/#78): the
+/// package itself never reads [data], it only carries it through.
 ///
 /// Immutable (#27): every field is `final`, so a drag/resize or accessibility
 /// nudge produces a *new* instance via [copyWith] (carrying a new [PlannerTime])
 /// reported through the host callbacks, instead of mutating the entry in place.
 /// Value [==] means two entries with the same fields compare equal, so hosts
 /// can diff entry lists.
-class PlannerEntry {
+class PlannerEntry<T> {
   final String id;
   final PlannerTime time;
 
@@ -22,19 +31,31 @@ class PlannerEntry {
   final String title;
   final String content;
 
+  /// Optional app domain metadata carried alongside the event (#77), typed [T].
+  /// The package never reads it — it threads it through so custom event/chip
+  /// builders and the host callbacks get the typed value back. `null` when no
+  /// payload is supplied (and always `null` for an untyped `T == dynamic` entry
+  /// that omits it).
+  final T? data;
+
   const PlannerEntry({
     required this.id,
     required this.time,
     required this.title,
     required this.content,
     required this.color,
+    this.data,
     this.titleStyle = const TextStyle(
         fontWeight: FontWeight.bold, fontSize: 12, color: Colors.white),
     this.textStyle = const TextStyle(fontSize: 10, color: Colors.white),
   });
 
   /// Returns a copy with the given fields replaced; omitted fields are kept.
-  PlannerEntry copyWith({
+  ///
+  /// [data] follows the same `data ?? this.data` rule as every other field, so
+  /// in this first cut (#77) it can be set or changed but **not reset to
+  /// `null`**; a sentinel can be added later if clearing the payload is needed.
+  PlannerEntry<T> copyWith({
     String? id,
     PlannerTime? time,
     Color? color,
@@ -42,8 +63,9 @@ class PlannerEntry {
     TextStyle? textStyle,
     String? title,
     String? content,
+    T? data,
   }) =>
-      PlannerEntry(
+      PlannerEntry<T>(
         id: id ?? this.id,
         time: time ?? this.time,
         color: color ?? this.color,
@@ -51,23 +73,25 @@ class PlannerEntry {
         textStyle: textStyle ?? this.textStyle,
         title: title ?? this.title,
         content: content ?? this.content,
+        data: data ?? this.data,
       );
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is PlannerEntry &&
+      other is PlannerEntry<T> &&
           other.id == id &&
           other.time == time &&
           other.color == color &&
           other.titleStyle == titleStyle &&
           other.textStyle == textStyle &&
           other.title == title &&
-          other.content == content;
+          other.content == content &&
+          other.data == data;
 
   @override
   int get hashCode =>
-      Object.hash(id, time, color, titleStyle, textStyle, title, content);
+      Object.hash(id, time, color, titleStyle, textStyle, title, content, data);
 
   @override
   String toString() => 'PlannerEntry(id: $id, time: $time, title: $title)';

--- a/test/generic_entry_test.dart
+++ b/test/generic_entry_test.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+
+// A sample app-domain payload, proving PlannerEntry<T> carries typed metadata
+// (#77). Equatable so an entry's == / hashCode can fold it in.
+class ActivityMeta {
+  final String kind;
+  final int attendees;
+  const ActivityMeta(this.kind, this.attendees);
+
+  @override
+  bool operator ==(Object other) =>
+      other is ActivityMeta &&
+      other.kind == kind &&
+      other.attendees == attendees;
+
+  @override
+  int get hashCode => Object.hash(kind, attendees);
+}
+
+void main() {
+  PlannerEntry<ActivityMeta> typedEntry({
+    String id = 'a1',
+    ActivityMeta? data = const ActivityMeta('meeting', 3),
+  }) =>
+      PlannerEntry<ActivityMeta>(
+        id: id,
+        time: PlannerTime(day: 0, hour: 9),
+        title: 'Stand-up',
+        content: 'Daily sync',
+        color: const Color(0xFF00FF00),
+        data: data,
+      );
+
+  group('PlannerEntry<T> typed payload (#77)', () {
+    test('exposes a typed T? data; null when omitted', () {
+      const meta = ActivityMeta('meeting', 3);
+      final withData = typedEntry(data: meta);
+      // The static type of `data` is ActivityMeta? — assigning it with no cast
+      // is the compile-time proof of acceptance criterion 2.
+      final ActivityMeta? read = withData.data;
+      expect(read, same(meta));
+
+      final withoutData = PlannerEntry<ActivityMeta>(
+        id: 'b',
+        time: PlannerTime(day: 0, hour: 8),
+        title: 't',
+        content: '',
+        color: const Color(0xFF000000),
+      );
+      expect(withoutData.data, isNull);
+    });
+
+    test('copyWith sets/keeps data and returns PlannerEntry<T>', () {
+      const a = ActivityMeta('meeting', 3);
+      const b = ActivityMeta('lunch', 1);
+      final entry = typedEntry(data: a);
+
+      // Omitting data keeps it (data ?? this.data), and the result stays typed.
+      final kept = entry.copyWith(title: 'Renamed');
+      expect(kept, isA<PlannerEntry<ActivityMeta>>());
+      expect(kept.data, same(a));
+      expect(kept.title, 'Renamed');
+
+      // Passing data replaces it.
+      expect(entry.copyWith(data: b).data, same(b));
+
+      // v1 limitation (#77): copyWith can't reset data to null (data ?? this.data).
+      expect(entry.copyWith(data: null).data, same(a));
+    });
+
+    test('== and hashCode fold in data', () {
+      final base = typedEntry(data: const ActivityMeta('meeting', 3));
+      final equalEntry = typedEntry(data: const ActivityMeta('meeting', 3));
+      final diffEntry = typedEntry(data: const ActivityMeta('meeting', 4));
+
+      expect(base, equals(equalEntry));
+      expect(base.hashCode, equalEntry.hashCode);
+      expect(base, isNot(equals(diffEntry)),
+          reason: 'entries differing only in data are not equal');
+    });
+  });
+
+  group('untyped usage stays non-breaking (T == dynamic)', () {
+    test('PlannerEntry(...) infers PlannerEntry<dynamic> with null data', () {
+      final entry = PlannerEntry(
+        id: 'a1',
+        time: PlannerTime(day: 0, hour: 8),
+        title: 'Stand-up',
+        content: '',
+        color: const Color(0xFF00FF00),
+      );
+      expect(entry, isA<PlannerEntry<dynamic>>());
+      expect(entry.data, isNull);
+
+      // Two untyped entries with the same fields still compare equal (both null
+      // data), so existing host-side diffing keeps working unchanged.
+      final twin = PlannerEntry(
+        id: 'a1',
+        time: PlannerTime(day: 0, hour: 8),
+        title: 'Stand-up',
+        content: '',
+        color: const Color(0xFF00FF00),
+      );
+      expect(entry, equals(twin));
+    });
+  });
+
+  group('the typed payload threads through Manager<T> (#77)', () {
+    Manager<ActivityMeta> makeManager(
+      void Function(PlannerEntry<ActivityMeta>)? onMove, {
+      void Function(PlannerEntry<ActivityMeta>)? onEdit,
+    }) =>
+        Manager<ActivityMeta>(
+          config: PlannerConfig<ActivityMeta>(
+            labels: const ['A', 'B'],
+            onEntryMove: onMove,
+            onEntryEdit: onEdit,
+          ),
+          entries: [typedEntry(data: const ActivityMeta('meeting', 3))],
+        );
+
+    test('Event.entry keeps the typed data', () {
+      final manager = makeManager(null);
+      final ActivityMeta? data = manager.events.first.entry.data; // typed
+      expect(data, const ActivityMeta('meeting', 3));
+    });
+
+    test('editEvent reports a PlannerEntry<ActivityMeta> with typed data', () {
+      PlannerEntry<ActivityMeta>? edited;
+      final manager = makeManager(null, onEdit: (e) => edited = e);
+      manager.editEvent(manager.events.first);
+      expect(edited, isNotNull);
+      final ActivityMeta? data = edited!.data; // typed, no cast
+      expect(data, const ActivityMeta('meeting', 3));
+    });
+
+    test('a drag-move carries the typed data onto the new entry', () {
+      PlannerEntry<ActivityMeta>? moved;
+      final manager = makeManager((e) => moved = e);
+      // Default 200x40 grid: the hour-9 event occupies grid rect (0,360)-(200,400);
+      // body-drag at its centre (100,380), down one block == +1 hour.
+      manager.startDrag(const Offset(100, 380));
+      manager.updateDrag(const Offset(100, 420));
+      manager.endDrag();
+      expect(moved, isNotNull);
+      expect(moved!.time.hour, 10,
+          reason: 'a one-block drag advances one hour');
+      expect(moved!.data, const ActivityMeta('meeting', 3),
+          reason: 'copyWith preserves the payload across a move');
+    });
+  });
+
+  // End-to-end through the *real* composed widget: a typed Planner<ActivityMeta>
+  // hands the host a typed PlannerEntry<ActivityMeta> (with typed .data) when an
+  // event is double-tapped — proof the generic threads all the way through the
+  // widget, not just the model.
+  testWidgets('Planner<ActivityMeta> delivers typed data to onEntryEdit',
+      (tester) async {
+    const key = ValueKey('planner');
+    const meta = ActivityMeta('meeting', 3);
+    ActivityMeta? receivedData;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner<ActivityMeta>(
+          key: key,
+          config: PlannerConfig<ActivityMeta>(
+            labels: const ['c1', 'c2', 'c3'],
+            minHour: 0,
+            maxHour: 23,
+            // entry is PlannerEntry<ActivityMeta>; entry.data is ActivityMeta?
+            // with no cast — the consumer-facing payoff of #77.
+            onEntryEdit: (entry) => receivedData = entry.data,
+          ),
+          entries: [
+            PlannerEntry<ActivityMeta>(
+              id: 'evt',
+              time: PlannerTime(day: 0, hour: 9),
+              title: 'Meeting',
+              content: '',
+              color: const Color(0xFF2244AA),
+              data: meta,
+            ),
+          ],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // The hour-9 event's centre is planner-local (150, 430) on the default grid
+    // (hour column 50 + date row 50 + grid centre 100,380). Two taps inside the
+    // 250ms double-tap window fire onEntryEdit.
+    final at = tester.getRect(find.byKey(key)).topLeft + const Offset(150, 430);
+    await tester.tapAt(at);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(at);
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(receivedData, same(meta),
+        reason: 'the typed payload reaches the host through the real widget');
+  });
+}


### PR DESCRIPTION
## Summary
Make the planner entry generic — `PlannerEntry<T>` with a typed `final T? data` payload — so consumer apps can hang app domain metadata (activity type, place, attendee count, status, …) on each entry without a side-map or a cast. This is step 2 of #75 and the foundation for the custom event/chip builders (#78/#80). Additive and non-breaking: untyped usage infers `T = dynamic` and compiles unchanged.

## Linked issue
Closes #77

## Changes
- **`PlannerEntry<T>`** — adds `final T? data`; threaded through the constructor, `copyWith`, `==` and `hashCode`. `copyWith(data:)` uses `data ?? this.data` in v1 (cannot reset to null; sentinel deferred).
- **`PlannerConfig<T>`** — entry callbacks become `void Function(PlannerEntry<T>)?` (`onEntryEdit`/`onEntryDelete`/`onEntryMove`/`onEntryLongPress`). `onEntryCreate` is unchanged (it takes `PlannerTime`).
- **`Planner<T>` / `_PlannerState<T>`**, and internals **`Manager<T>`, `Event<T>`, `AllDayEvent<T>`, `Controller<T>`, `ContextMenu<T>`**.
- **`EventsPainter<T>` / `AllDayBand<T>` — made generic too**, a correction to the issue's plan (which listed them as untouched). Their `semanticsBuilder` *reads the now-generic entry callbacks*; reading a `void Function(PlannerEntry<T>)` field through a covariant `Manager<dynamic>` trips a runtime contravariance check and throws (surfacing in `flushSemantics`, so analyze stays green). Holding `Manager<T>` reads them at their true type. The pure geometry/label painters (`DateRow`, `HourColumn`, `Grid`) correctly stay on the raw covariant `Manager`.
- **Tests:** new `test/generic_entry_test.dart`.

## Test plan
- [x] `flutter analyze` clean — package **and** `example/`
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] unit/widget tests pass (`flutter test`) — **216 pass**, incl. 8 new: typed `data` / `copyWith` / `==` / `hashCode`, untyped `T = dynamic` non-breaking, threading through `Manager<T>` (edit + drag-move), and an end-to-end `Planner<ActivityMeta>` widget test proving the host receives typed `.data` with no cast
- [x] integration/e2e tests pass (`flutter test integration_test -d windows` from `example/`) — **41 pass**. Although the change is type-only and not user-visible, the suite was run in full because it touches the package's core types; it confirms the example app builds and behaves identically against the generic API (the untyped `T = dynamic` path end-to-end).

## Notes / screenshots
A typed `Planner<ActivityMeta>` semantics/double-tap widget test was essential here: the contravariance throw above is invisible to `analyze` and to unit tests on `<dynamic>` — only exercising a typed `Planner<T>` through the real composed widget surfaces it.