### PR TITLE
feat: entryBuilder — custom widgets for timed events (hybrid overlay) (#78)

### DIFF
--- a/example/integration_test/README.md
+++ b/example/integration_test/README.md
@@ -14,6 +14,7 @@ surface) can miss rendering/geometry bugs.
 | [`long_press_scenarios.dart`](long_press_scenarios.dart) | A touch long-press on an event fires `onEntryLongPress` with that entry; a long-press on empty space is a no-op (#66). |
 | [`event_geometry_scenarios.dart`](event_geometry_scenarios.dart) | An event's hit-area derives from `config.blockHeight` with proportional minutes (#10 / D3 + D4). |
 | [`external_zoom_scenarios.dart`](external_zoom_scenarios.dart) | A host toolbar drives the real grid zoom through a public `PlannerController` with the on-canvas buttons hidden, and the controller and grid share one zoom (#76). |
+| [`entry_builder_scenarios.dart`](entry_builder_scenarios.dart) | A host `entryBuilder` renders fully custom widgets over the grid at each event's on-screen rect; a real double-tap / mouse drag on a widget falls through the `IgnorePointer` overlay to `onEntryEdit` / `onEntryMove`, and the widget sheds detail by pixel height as the grid zooms (#78). |
 | [`hour_label_scenarios.dart`](hour_label_scenarios.dart) | The default `maxHour` (23) clamps a below-grid tap to hour 23, not the invalid 24 (#13 / D10). |
 | [`snapping_scenarios.dart`](snapping_scenarios.dart) | Create and drag snap event times to the single configurable `snapMinutes` interval, and agree (#14 / D8). |
 | [`span_scenarios.dart`](span_scenarios.dart) | A column-spanning event (`PlannerTime.endDay`) paints one box across its columns, hit-tests from any column it covers, and is read-only — dragging it doesn't move it (#47). |

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -8,6 +8,7 @@ import 'context_menu_scenarios.dart';
 import 'direct_manipulation_scenarios.dart';
 import 'double_tap_scenarios.dart';
 import 'drag_scenarios.dart';
+import 'entry_builder_scenarios.dart';
 import 'event_geometry_scenarios.dart';
 import 'external_zoom_scenarios.dart';
 import 'highlight_column_scenarios.dart';
@@ -38,6 +39,7 @@ void main() {
   directManipulationScenarios();
   doubleTapScenarios();
   dragScenarios();
+  entryBuilderScenarios();
   eventGeometryScenarios();
   externalZoomScenarios();
   highlightColumnScenarios();

--- a/example/integration_test/entry_builder_scenarios.dart
+++ b/example/integration_test/entry_builder_scenarios.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+import 'planner_harness.dart';
+
+/// End-to-end guard for the `entryBuilder` hybrid overlay (#78): a host renders
+/// fully custom widgets for timed events, layered over the canvas at each event's
+/// live on-screen rect. This drives the *real* app (real layout, real fonts, real
+/// gestures over the competing pan/zoom/tap recognizers) — the layer where the
+/// widget harness (Ahem font, fixed surface) can miss real composition/geometry:
+///   * the custom widget is positioned at the event's on-screen rect,
+///   * a real double-tap and a real mouse drag on the widget still fall through
+///     the `IgnorePointer` overlay to the canvas and fire `onEntryEdit` /
+///     `onEntryMove`, and
+///   * the widget sheds detail by pixel height as the real grid zooms — the
+///     headline use case the overlay exists for.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void entryBuilderScenarios() {
+  // Above this on-screen height the card shows its extra detail; below it the
+  // detail is shed. The hour-4/60-min event is 40px tall at zoom 1 (< threshold)
+  // and clears it once zoomed in.
+  const detailThreshold = 56.0;
+
+  // The host's custom widget for one event: a coloured card whose avatar-style
+  // detail only renders when the card is tall enough (responsive shedding, #78).
+  Widget eventCard(
+      BuildContext context, PlannerEntry entry, PlannerEntryLayout layout) {
+    return ClipRect(
+      child: Container(
+        key: ValueKey('card-${entry.id}'),
+        color: entry.color,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              entry.title,
+              key: ValueKey('title-${entry.id}'),
+              style: const TextStyle(fontSize: 9, color: Colors.white),
+            ),
+            if (layout.size.height >= detailThreshold)
+              Icon(Icons.people,
+                  key: ValueKey('details-${entry.id}'),
+                  size: 8,
+                  color: Colors.white),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget hostApp({
+    void Function(PlannerEntry)? onEdit,
+    void Function(PlannerEntry)? onMove,
+  }) =>
+      MaterialApp(
+        home: Scaffold(
+          body: _BuilderHost(
+            onEdit: onEdit,
+            onMove: onMove,
+            builder: eventCard,
+          ),
+        ),
+      );
+
+  testWidgets('a custom widget paints over the grid at the event rect (#78)',
+      (tester) async {
+    await tester.pumpWidget(hostApp());
+    await tester.pumpAndSettle();
+
+    final plannerRect = tester.getRect(find.byType(Planner));
+    final card = find.byKey(const ValueKey('card-evt'));
+    expect(card, findsOneWidget,
+        reason: 'the builder renders a widget for the on-screen event');
+
+    // The event sits at day 0 / hour 4 -> grid rect (0,160)-(200,200) with the
+    // default 200x40 blocks; offset by the hour column (50) and date row (50) it
+    // is planner-local (50,210)-(250,250).
+    final cardRect = tester.getRect(card);
+    expect(
+        cardRect.left - plannerRect.left, moreOrLessEquals(50, epsilon: 0.5));
+    expect(cardRect.top - plannerRect.top, moreOrLessEquals(210, epsilon: 0.5));
+    expect(cardRect.width, moreOrLessEquals(200, epsilon: 0.5));
+    expect(cardRect.height, moreOrLessEquals(40, epsilon: 0.5));
+  });
+
+  testWidgets('a double-tap on the custom widget falls through and edits (#78)',
+      (tester) async {
+    final edited = <PlannerEntry>[];
+    await tester.pumpWidget(hostApp(onEdit: edited.add));
+    await tester.pumpAndSettle();
+
+    final cardRect = tester.getRect(find.byKey(const ValueKey('card-evt')));
+
+    // Two real taps within the double-tap window, on the custom widget: the
+    // IgnorePointer overlay must let them reach the canvas's tap recognizer.
+    await tester.tapAt(cardRect.center);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(cardRect.center);
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(edited, hasLength(1),
+        reason: 'the tap fell through the overlay to onEntryEdit');
+    expect(edited.single.id, 'evt');
+  });
+
+  testWidgets('a mouse drag on the custom widget moves the event (#78)',
+      (tester) async {
+    final moved = <PlannerEntry>[];
+    await tester.pumpWidget(hostApp(onMove: moved.add));
+    await tester.pumpAndSettle();
+
+    final cardRect = tester.getRect(find.byKey(const ValueKey('card-evt')));
+
+    // Drag the widget down one block (40px == 1 hour): hour 4 -> hour 5. The
+    // drag must fall through the overlay to the move/resize recognizer.
+    await mouseDrag(tester, cardRect.center, const Offset(0, 40));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull,
+        reason: 'onEntryMove must not fire during paint');
+    expect(moved, hasLength(1), reason: 'the drag committed exactly one move');
+    expect(moved.single.time.hour, 5,
+        reason: 'a one-block drag advances the event one hour');
+  });
+
+  testWidgets(
+      'the custom widget sheds detail by pixel height as it zooms (#78)',
+      (tester) async {
+    await tester.pumpWidget(hostApp());
+    await tester.pumpAndSettle();
+
+    final details = find.byKey(const ValueKey('details-evt'));
+    // At zoom 1 the card is 40px tall — below the detail threshold, so the
+    // avatar-style detail is shed while the card itself still renders.
+    expect(find.byKey(const ValueKey('card-evt')), findsOneWidget);
+    expect(details, findsNothing,
+        reason: 'a 40px card is below the detail threshold');
+
+    // Zoom in with the on-canvas + button until the card clears the threshold
+    // (40 * 1.1^n >= 56 -> n >= 4). The overlay rebuilds on the same zoom tick as
+    // the canvas, so the builder re-runs with the taller size and shows the detail.
+    for (var i = 0; i < 6; i++) {
+      await tester.tap(find.byIcon(Icons.zoom_in));
+      await tester.pump();
+    }
+
+    expect(details, findsOneWidget,
+        reason: 'the taller card now renders its detail (responsive shedding)');
+  });
+}
+
+/// A minimal real host for one [Planner] driven by an `entryBuilder`. Its
+/// `onEntryMove` rebuilds via [setState] (the everyday host pattern), so the move
+/// fall-through is exercised against a real rebuilding host.
+class _BuilderHost extends StatefulWidget {
+  const _BuilderHost({this.onEdit, this.onMove, required this.builder});
+
+  final void Function(PlannerEntry)? onEdit;
+  final void Function(PlannerEntry)? onMove;
+  final PlannerEntryBuilder builder;
+
+  @override
+  State<_BuilderHost> createState() => _BuilderHostState();
+}
+
+class _BuilderHostState extends State<_BuilderHost> {
+  final List<PlannerEntry> _entries = [
+    PlannerEntry(
+      id: 'evt',
+      time: PlannerTime(day: 0, hour: 4),
+      title: 'Standup',
+      content: '',
+      color: const Color(0xFF2244AA),
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Planner(
+      config: PlannerConfig(
+        labels: const ['c1', 'c2', 'c3'],
+        minHour: 0,
+        maxHour: 23,
+        onEntryEdit: widget.onEdit,
+        onEntryMove: widget.onMove == null
+            ? null
+            : (e) => setState(() => widget.onMove!(e)),
+      ),
+      entries: _entries,
+      entryBuilder: widget.builder,
+    );
+  }
+}

--- a/lib/internal/event.dart
+++ b/lib/internal/event.dart
@@ -3,13 +3,6 @@ import 'package:flutter/material.dart';
 import '../planner.dart';
 import 'manager.dart';
 
-enum DragType {
-  body,
-  topHandle,
-  bottomHandle,
-  none,
-}
-
 class Event<T> {
   /// The entry this event draws. Reassigned (never mutated) when a drag/resize
   /// or nudge commits, since [PlannerEntry]/[PlannerTime] are immutable (#27):
@@ -203,6 +196,11 @@ class Event<T> {
   /// [paint] to draw it and by the accessibility layer to place the event's
   /// semantics node (#21).
   Rect get screenRect => _toScreen(_getCurrentRect());
+
+  /// The drag/resize this event is currently undergoing, or [DragType.none] when
+  /// idle. Exposed (#78) so the widget overlay can hand the live drag state to a
+  /// custom [PlannerEntryBuilder] (via [PlannerEntryLayout.dragType]).
+  DragType get dragType => _dragType;
 
   /// A screen-reader description of this event — its title, day-column label,
   /// time span and duration — so the otherwise-opaque `CustomPaint` canvas

--- a/lib/internal/events_painter.dart
+++ b/lib/internal/events_painter.dart
@@ -19,18 +19,31 @@ class EventsPainter<T> extends CustomPainter {
   // the event data changed, not on every unrelated parent rebuild (#25 / D6).
   final int _revision;
 
-  EventsPainter({required this.manager, required Listenable repaint})
-      : _grid = Grid(manager: manager),
+  // Whether to paint the event bodies on the canvas (#78). When a host supplies
+  // an `entryBuilder`, real widgets are layered over the canvas to render each
+  // event, so the canvas skips its own body paint to avoid drawing each event
+  // twice — but it still draws the grid and still exposes the per-event
+  // accessibility semantics (those stay canvas-owned; the overlay is
+  // ExcludeSemantics). Defaults to `true` — the canvas paints bodies itself.
+  final bool drawEventBodies;
+
+  EventsPainter({
+    required this.manager,
+    required Listenable repaint,
+    this.drawEventBodies = true,
+  })  : _grid = Grid(manager: manager),
         _revision = manager.revision,
         super(repaint: repaint);
 
-  // Pure rendering only: draw the grid, then each event using its own drag
-  // state. Drag detection and the onEntryMove callback live in the widget layer
-  // (gesture handlers -> Manager.start/update/endDrag), never here — a painter
-  // must not mutate state or fire callbacks while painting.
+  // Pure rendering only: draw the grid, then (unless a widget overlay is taking
+  // over the bodies, #78) each event using its own drag state. Drag detection
+  // and the onEntryMove callback live in the widget layer (gesture handlers ->
+  // Manager.start/update/endDrag), never here — a painter must not mutate state
+  // or fire callbacks while painting.
   @override
   void paint(Canvas canvas, Size size) {
     _grid.draw(canvas);
+    if (!drawEventBodies) return;
     for (Event event in manager.events) {
       event.paint(canvas);
     }
@@ -106,5 +119,6 @@ class EventsPainter<T> extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant EventsPainter oldDelegate) =>
-      _revision != oldDelegate._revision;
+      _revision != oldDelegate._revision ||
+      drawEventBodies != oldDelegate.drawEventBodies;
 }

--- a/lib/planner.dart
+++ b/lib/planner.dart
@@ -1,5 +1,6 @@
 library;
 
+export 'planner_builders.dart';
 export 'planner_class.dart';
 export 'planner_controller.dart';
 export 'planner_entry.dart';

--- a/lib/planner_builders.dart
+++ b/lib/planner_builders.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/widgets.dart';
+
+import 'planner_entry.dart';
+
+/// What a single in-progress events-canvas drag/resize is doing. A press within
+/// 8px of an event's top edge resizes from the top ([topHandle]), within 8px of
+/// the bottom resizes from the bottom ([bottomHandle]), anywhere else moves the
+/// whole event ([body]); [none] is the idle state (no drag in progress).
+///
+/// Public (#78) so a custom [PlannerEntryBuilder] can react to the live drag —
+/// e.g. emphasise the widget while it's being moved. It is carried on
+/// [PlannerEntryLayout.dragType] (and the package's own hover-cursor hit test
+/// reads it too).
+enum DragType {
+  body,
+  topHandle,
+  bottomHandle,
+  none,
+}
+
+/// Builds a fully custom widget for a single timed event (#78). Supplied to the
+/// `Planner` as `entryBuilder`; when non-null the planner layers a widget
+/// overlay over the canvas and calls this for every (on-screen) event, sizing
+/// and positioning the returned widget at the event's current on-screen rect so
+/// it tracks scroll, zoom and drag in lockstep with the grid.
+///
+/// The overlay is purely visual — it is wrapped in `IgnorePointer` /
+/// `ExcludeSemantics`, so every gesture (tap, double-tap, drag, resize,
+/// long-press, right-click) and all accessibility actions fall through to the
+/// package's existing recognizers and fire the usual `onEntry*` callbacks. The
+/// builder therefore decides *appearance* only; interaction stays package-owned.
+///
+/// [entry] is the typed entry being drawn (read `entry.data` for the host's
+/// metadata payload, #77); [layout] carries the on-screen [PlannerEntryLayout]
+/// facts (size, overlap column, drag state) the builder needs to shed detail or
+/// reflect the drag.
+typedef PlannerEntryBuilder<T> = Widget Function(
+  BuildContext context,
+  PlannerEntry<T> entry,
+  PlannerEntryLayout layout,
+);
+
+/// The on-screen layout facts handed to a [PlannerEntryBuilder] for one event
+/// (#78). Everything here is derived from the package's geometry for the current
+/// frame, so the builder can lay out responsively without recomputing it.
+class PlannerEntryLayout {
+  /// The widget's on-screen size — the event's `screenRect` size, i.e. its
+  /// (possibly overlap-narrowed) width and `durationInHours * blockHeight *
+  /// zoom` height. Detail-shedding builders key their thresholds on
+  /// `size.height` (e.g. show avatars only above 92px).
+  final Size size;
+
+  /// Which sub-column this event occupies within its day-column, and how many
+  /// sub-columns the day-column was split into for concurrent events (#20). A
+  /// non-overlapping event is `columnIndex: 0, columnCount: 1`; overlapping
+  /// events render side-by-side via these and the [size] width.
+  final int columnIndex;
+  final int columnCount;
+
+  /// Whether this event is the one currently being dragged or resized — a
+  /// convenience for `dragType != DragType.none`.
+  final bool isDragged;
+
+  /// The live drag this event is undergoing ([DragType.none] when idle), so a
+  /// builder can reflect a move vs. a top/bottom resize.
+  final DragType dragType;
+
+  /// Whether this widget is an all-day chip rather than a timed event. Always
+  /// `false` for the timed-event overlay (#78); reserved for the all-day chip
+  /// builder (#80) that will reuse this type.
+  final bool allDay;
+
+  const PlannerEntryLayout({
+    required this.size,
+    required this.columnIndex,
+    required this.columnCount,
+    required this.isDragged,
+    required this.dragType,
+    required this.allDay,
+  });
+}

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -12,6 +12,7 @@ import 'internal/scroll_detector.dart';
 import 'internal/positioned_tap_detector_2.dart';
 import 'internal/date_row.dart';
 import 'internal/manager.dart';
+import 'planner_builders.dart';
 import 'planner_controller.dart';
 import 'planner_entry.dart';
 import 'planner_config.dart';
@@ -36,11 +37,25 @@ class Planner<T> extends StatefulWidget {
   /// `config.showZoomControls: false` to replace the on-canvas buttons.
   final PlannerController? controller;
 
+  /// Optional builder for fully custom timed-event widgets (#78). When non-null
+  /// the planner layers a widget overlay over the events canvas and calls this
+  /// for every on-screen event, sizing/positioning the returned widget at the
+  /// event's current on-screen rect so it tracks scroll, zoom and drag in
+  /// lockstep with the grid; the canvas then skips painting the default event
+  /// bodies (the grid lines and accessibility semantics stay intact).
+  ///
+  /// The overlay is visual-only — wrapped in `IgnorePointer`/`ExcludeSemantics`
+  /// — so every gesture and accessibility action still falls through to the
+  /// built-in recognizers and fires the usual `config.onEntry*` callbacks. When
+  /// `null` (the default) events render exactly as before, painted on the canvas.
+  final PlannerEntryBuilder<T>? entryBuilder;
+
   const Planner({
     super.key,
     required this.config,
     required this.entries,
     this.controller,
+    this.entryBuilder,
   });
 
   @override
@@ -214,6 +229,12 @@ class _PlannerState<T> extends State<Planner<T>> {
                             },
                             child: paintEvents(),
                           ),
+                          // Custom-widget overlay for timed events (#78), above
+                          // the canvas (so widgets draw over the grid) and below
+                          // the zoom buttons (which stay on top and tappable).
+                          // Only present when a builder is supplied; otherwise
+                          // events stay canvas-painted exactly as before.
+                          paintEntryOverlay(),
                           paintZoomButtons(context),
                         ],
                       ),
@@ -368,6 +389,72 @@ class _PlannerState<T> extends State<Planner<T>> {
     if (chip == null) return;
     onLongPress(chip.entry);
   }
+
+  /// The custom-widget overlay for timed events (#78). When the host supplies
+  /// an [Planner.entryBuilder] this layers, over the events canvas, one
+  /// host-built widget per on-screen event — positioned and sized at the event's
+  /// live `screenRect` so it tracks scroll, zoom and drag in lockstep with the
+  /// canvas (it rebuilds on the same `triggerUpdate` the canvas repaints on).
+  ///
+  /// The overlay is purely visual: [IgnorePointer] lets every gesture fall
+  /// through to the canvas's recognizers (tap/double-tap/drag/resize/long-press/
+  /// right-click all still fire the usual callbacks), and [ExcludeSemantics]
+  /// keeps the canvas's per-event accessibility nodes the single source of truth.
+  /// Off-screen events are culled from the overlay (visuals only — the canvas
+  /// keeps a semantics node for every event, on-screen or not). When no builder
+  /// is supplied this is an empty box, so the canvas paints events as before.
+  Widget paintEntryOverlay() {
+    final builder = widget.entryBuilder;
+    if (builder == null) return const SizedBox.shrink();
+
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: ExcludeSemantics(
+          child: ClipRect(
+            // The overlay fills the same box as the events canvas (both are
+            // non-positioned children of the inner Stack), so its constraints
+            // are the canvas viewport — used to cull off-screen events whose
+            // screenRect lies outside it.
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final viewport = Offset.zero & constraints.biggest;
+                return ValueListenableBuilder<int>(
+                  valueListenable: _data.controller.triggerUpdate,
+                  builder: (context, _, __) {
+                    return Stack(
+                      children: [
+                        for (final event in _data.events)
+                          if (event.screenRect.overlaps(viewport))
+                            Positioned.fromRect(
+                              rect: event.screenRect,
+                              child: builder(
+                                  context, event.entry, _layoutFor(event)),
+                            ),
+                      ],
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// The on-screen [PlannerEntryLayout] for [event], handed to the host's
+  /// [Planner.entryBuilder] (#78). Its `size` is the live `screenRect` size
+  /// (overlap-narrowed width x `durationInHours * blockHeight * zoom` height),
+  /// and it carries the overlap sub-column and live drag state so the builder can
+  /// shed detail and reflect a move/resize.
+  PlannerEntryLayout _layoutFor(Event<T> event) => PlannerEntryLayout(
+        size: event.screenRect.size,
+        columnIndex: event.columnIndex,
+        columnCount: event.columnCount,
+        isDragged: event.dragType != DragType.none,
+        dragType: event.dragType,
+        allDay: false,
+      );
 
   Widget paintZoomButtons(BuildContext context) {
     // Hosts that drive zoom themselves (pinch, own chrome) can hide the built-in
@@ -602,6 +689,10 @@ class _PlannerState<T> extends State<Planner<T>> {
                     painter: EventsPainter(
                       manager: _data,
                       repaint: _data.controller.triggerUpdate,
+                      // A custom-widget overlay (#78) renders the event bodies
+                      // instead, so the canvas skips its own body paint to avoid
+                      // double-drawing (grid + semantics still come from here).
+                      drawEventBodies: widget.entryBuilder == null,
                     ),
                     child: Container(),
                   )),

--- a/test/entry_builder_test.dart
+++ b/test/entry_builder_test.dart
@@ -1,0 +1,358 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/events_painter.dart';
+import 'package:planner/internal/manager.dart';
+import 'package:planner/planner.dart';
+
+// Covers the entryBuilder hybrid overlay (#78): a host-supplied widget per timed
+// event, layered over the canvas at the event's live screenRect, while the
+// canvas keeps the grid + accessibility semantics and stops painting the default
+// event bodies. The overlay is IgnorePointer/ExcludeSemantics, so all gestures
+// and a11y actions still fall through to the existing recognizers.
+void main() {
+  PlannerConfig makeConfig({
+    void Function(PlannerEntry)? onEdit,
+    void Function(PlannerEntry)? onMove,
+  }) =>
+      PlannerConfig(
+        labels: const ['c1', 'c2', 'c3'],
+        minHour: 0,
+        maxHour: 23,
+        onEntryEdit: onEdit,
+        onEntryMove: onMove,
+      );
+
+  PlannerEntry entryAt(String id,
+          {int day = 0, int hour = 9, int duration = 60}) =>
+      PlannerEntry(
+        id: id,
+        time: PlannerTime(day: day, hour: hour, duration: duration),
+        title: id,
+        content: '',
+        color: const Color(0xFF2244AA),
+      );
+
+  // The default-grid event used by the existing widget tests: day 0 / hour 9,
+  // duration 60. Its grid rect is (0,360)-(200,400); past the hour column (50)
+  // and date row (50) its on-screen rect is planner-local (50,410)-(250,450),
+  // centre (150,430).
+  PlannerEntry eventAtHour9() => entryAt('evt');
+
+  // A builder that records the layout it was handed per entry id and renders a
+  // keyed, sized box so tests can locate it and read its on-screen rect.
+  ({PlannerEntryBuilder builder, Map<String, PlannerEntryLayout> layouts})
+      recordingBuilder() {
+    final layouts = <String, PlannerEntryLayout>{};
+    Widget build(BuildContext c, PlannerEntry e, PlannerEntryLayout l) {
+      layouts[e.id] = l;
+      return Container(
+        key: ValueKey('w-${e.id}'),
+        color: const Color(0x8800FF00),
+      );
+    }
+
+    return (builder: build, layouts: layouts);
+  }
+
+  Future<void> pumpBuilderPlanner(
+    WidgetTester tester, {
+    required List<PlannerEntry> entries,
+    PlannerEntryBuilder? builder,
+    void Function(PlannerEntry)? onEdit,
+    void Function(PlannerEntry)? onMove,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: makeConfig(onEdit: onEdit, onMove: onMove),
+          entries: entries,
+          entryBuilder: builder,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  // Two quick taps within the double-tap window (mirrors planner_widget_test):
+  // PositionedTapDetector2 only resolves a double-tap once the second tap lands
+  // in time; the trailing pump past the window flushes the timeout timer.
+  Future<void> doubleTapAt(WidgetTester tester, Offset at) async {
+    await tester.tapAt(at);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(at);
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  // Press with a mouse and drag immediately (the Outlook-style desktop move):
+  // the pointer-down position anchors the drag so the committed move == delta.
+  Future<void> mouseDrag(WidgetTester tester, Offset from, Offset delta) async {
+    final gesture =
+        await tester.startGesture(from, kind: PointerDeviceKind.mouse);
+    await tester.pump();
+    await gesture.moveBy(delta);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+  }
+
+  group('overlay positioning, sizing and culling (real composed Planner)', () {
+    testWidgets('renders the custom widget at the event on-screen rect',
+        (tester) async {
+      final rec = recordingBuilder();
+      await pumpBuilderPlanner(tester,
+          entries: [eventAtHour9()], builder: rec.builder);
+
+      final rect = tester.getRect(find.byKey(const ValueKey('w-evt')));
+      // (0,360)-(200,400) in grid space, shifted by the hour column (50) and
+      // date row (50): planner-local (50,410), 200x40.
+      expect(rect.left, moreOrLessEquals(50));
+      expect(rect.top, moreOrLessEquals(410));
+      expect(rect.width, moreOrLessEquals(200));
+      expect(rect.height, moreOrLessEquals(40));
+    });
+
+    testWidgets('the widget tracks the canvas through a zoom', (tester) async {
+      final rec = recordingBuilder();
+      await pumpBuilderPlanner(tester,
+          entries: [eventAtHour9()], builder: rec.builder);
+
+      // Zoom in with the built-in control (default 1.1x per tap). The y axis is
+      // the only one that zooms, so the height grows by the zoom factor and the
+      // top moves down proportionally while the width is unchanged.
+      final before = tester.getRect(find.byKey(const ValueKey('w-evt')));
+      await tester.tap(find.byIcon(Icons.zoom_in));
+      await tester.pump();
+      final after = tester.getRect(find.byKey(const ValueKey('w-evt')));
+
+      expect(after.height, greaterThan(before.height),
+          reason: 'a zoom-in must grow the widget in lockstep with the canvas');
+      expect(after.width, moreOrLessEquals(before.width),
+          reason: 'only the time axis zooms, so the width is unchanged');
+    });
+
+    testWidgets(
+        'size.height is duration x blockHeight x zoom; overlaps sit side-by-side',
+        (tester) async {
+      final rec = recordingBuilder();
+      // Two events at the same time overlap -> the day-column splits into two
+      // sub-columns and each renders at half width.
+      await pumpBuilderPlanner(tester,
+          entries: [entryAt('e1'), entryAt('e2')], builder: rec.builder);
+
+      // duration 60 / 60 * blockHeight 40 * zoom 1 == 40.
+      expect(rec.layouts['e1']!.size.height, moreOrLessEquals(40));
+      expect(rec.layouts['e1']!.columnCount, 2);
+      expect(rec.layouts['e2']!.columnCount, 2);
+      expect(rec.layouts['e1']!.size.width, moreOrLessEquals(100));
+
+      final r1 = tester.getRect(find.byKey(const ValueKey('w-e1')));
+      final r2 = tester.getRect(find.byKey(const ValueKey('w-e2')));
+      // Side-by-side, no horizontal overlap: e1 in the left sub-column (x 50),
+      // e2 in the right (x 150).
+      expect(r1.left, moreOrLessEquals(50));
+      expect(r2.left, moreOrLessEquals(150));
+      expect(r1.right, lessThanOrEqualTo(r2.left + 0.5));
+    });
+
+    testWidgets('off-screen events are culled from the overlay',
+        (tester) async {
+      final rec = recordingBuilder();
+      // hour 1 is well within the viewport; hour 23 (grid top 920) is far below
+      // the ~550px-tall events canvas, so its widget must not be built.
+      await pumpBuilderPlanner(tester,
+          entries: [entryAt('on', hour: 1), entryAt('off', hour: 23)],
+          builder: rec.builder);
+
+      expect(find.byKey(const ValueKey('w-on')), findsOneWidget);
+      expect(find.byKey(const ValueKey('w-off')), findsNothing,
+          reason: 'an event outside the canvas viewport is culled (visuals)');
+    });
+
+    testWidgets('no overlay widgets when entryBuilder is null (defaults)',
+        (tester) async {
+      await pumpBuilderPlanner(tester, entries: [eventAtHour9()]);
+
+      expect(find.byKey(const ValueKey('w-evt')), findsNothing,
+          reason: 'with no builder, events stay canvas-painted as before');
+    });
+  });
+
+  group('gesture fall-through (overlay is IgnorePointer)', () {
+    testWidgets('double-tapping the custom widget still fires onEntryEdit',
+        (tester) async {
+      final rec = recordingBuilder();
+      final edited = <PlannerEntry>[];
+      await pumpBuilderPlanner(tester,
+          entries: [eventAtHour9()], builder: rec.builder, onEdit: edited.add);
+
+      // The custom widget sits at planner-local (50,410)-(250,450); tap its
+      // centre (150,430). The tap must pass through the overlay to the canvas.
+      await doubleTapAt(tester, const Offset(150, 430));
+
+      expect(edited, hasLength(1),
+          reason: 'the IgnorePointer overlay lets the tap reach the canvas');
+      expect(edited.single.id, 'evt');
+    });
+
+    testWidgets('dragging the custom widget still fires onEntryMove',
+        (tester) async {
+      final rec = recordingBuilder();
+      final moved = <PlannerEntry>[];
+      await pumpBuilderPlanner(tester,
+          entries: [eventAtHour9()], builder: rec.builder, onMove: moved.add);
+
+      // Press the widget centre and drag down one block (40px == 1 hour).
+      await mouseDrag(tester, const Offset(150, 430), const Offset(0, 40));
+
+      expect(moved, hasLength(1),
+          reason:
+              'the drag falls through the overlay to the canvas recognizer');
+      expect(moved.single.time.hour, 10,
+          reason: 'a one-block drag advances the event one hour');
+    });
+  });
+
+  // The canvas keeps exposing each event to assistive technology even with a
+  // builder set (the overlay is ExcludeSemantics), so a screen reader still sees
+  // a labelled node per event. Drives the real composed Planner with semantics on.
+  testWidgets('semantics stay on the canvas when a builder is supplied',
+      (tester) async {
+    final handle = tester.ensureSemantics();
+    final rec = recordingBuilder();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: PlannerConfig(
+            labels: const ['Mon', 'Tue', 'Wed'],
+            minHour: 0,
+            maxHour: 23,
+            onEntryEdit: (_) {},
+          ),
+          entries: [
+            PlannerEntry(
+              id: 'evt',
+              time: PlannerTime(day: 0, hour: 9),
+              title: 'Meeting',
+              content: '',
+              color: const Color(0xFF2244AA),
+            ),
+          ],
+          entryBuilder: rec.builder,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // The custom widget is shown...
+    expect(find.byKey(const ValueKey('w-evt')), findsOneWidget);
+
+    // ...and the canvas's per-event semantics node is still present and labelled.
+    final owner =
+        tester.renderObject(find.byType(Planner)).owner!.semanticsOwner!;
+    final node = _findSemanticsByLabelPrefix(owner, 'Meeting');
+    expect(
+        node.getSemanticsData().label, 'Meeting, Mon, 09:00 to 10:00, 1 hour');
+
+    handle.dispose();
+  });
+
+  // The no-double-draw invariant at the painter level (#78): with drawEventBodies
+  // off the canvas paints the grid but none of the event bodies, so each event is
+  // drawn exactly once (by the overlay widget), not twice. Counts canvas.drawRect
+  // calls: with no highlighted column the grid draws zero rects, so every counted
+  // rect is an event body (fill + stroke).
+  group('EventsPainter.drawEventBodies (no double-draw)', () {
+    int rectsPainted({required bool drawBodies, required bool withEvent}) {
+      final manager = Manager(
+        config: makeConfig(),
+        entries: withEvent ? [eventAtHour9()] : const [],
+      );
+      final painter = EventsPainter(
+        manager: manager,
+        repaint: manager.controller.triggerUpdate,
+        drawEventBodies: drawBodies,
+      );
+      final canvas = _CountingCanvas();
+      painter.paint(canvas, const Size(800, 600));
+      return canvas.rects;
+    }
+
+    test('defaults to true', () {
+      final manager = Manager(config: makeConfig(), entries: const []);
+      final painter = EventsPainter(
+          manager: manager, repaint: manager.controller.triggerUpdate);
+      expect(painter.drawEventBodies, isTrue);
+    });
+
+    test('skips event bodies but keeps the grid when false', () {
+      final gridOnly = rectsPainted(drawBodies: true, withEvent: false);
+      final withBodies = rectsPainted(drawBodies: true, withEvent: true);
+      final withoutBodies = rectsPainted(drawBodies: false, withEvent: true);
+
+      // Painting the body adds exactly the fill + stroke rects of the one event.
+      expect(withBodies - gridOnly, 2,
+          reason: 'an event body is a fill rect plus a stroke rect');
+      // With bodies off, only the grid is drawn — the event body is skipped, so
+      // the event is never drawn twice (the overlay widget draws it instead).
+      expect(withoutBodies, gridOnly,
+          reason: 'no event body is painted when drawEventBodies is false');
+    });
+
+    test('shouldRepaint reacts to a drawEventBodies toggle (same data)', () {
+      final manager = Manager(config: makeConfig(), entries: [eventAtHour9()]);
+      final repaint = manager.controller.triggerUpdate;
+      final withBodies = EventsPainter(
+          manager: manager, repaint: repaint, drawEventBodies: true);
+
+      // Toggling the builder on/off must repaint even though the data revision
+      // is unchanged, or the canvas would keep its now-doubled bodies.
+      expect(
+          EventsPainter(
+                  manager: manager, repaint: repaint, drawEventBodies: false)
+              .shouldRepaint(withBodies),
+          isTrue);
+      expect(
+          EventsPainter(
+                  manager: manager, repaint: repaint, drawEventBodies: true)
+              .shouldRepaint(withBodies),
+          isFalse);
+    });
+  });
+}
+
+/// A [Canvas] that counts only [drawRect] calls and ignores everything else, so
+/// a painter's event-body rects can be counted without a real surface.
+class _CountingCanvas implements ui.Canvas {
+  int rects = 0;
+
+  @override
+  void drawRect(ui.Rect rect, ui.Paint paint) => rects++;
+
+  @override
+  void noSuchMethod(Invocation invocation) {}
+}
+
+/// Walks the live semantics tree under [owner] and returns the first node whose
+/// label starts with [prefix]. CustomPaint semantics are raw `SemanticsNode`s,
+/// so a widget finder can't reach them.
+SemanticsNode _findSemanticsByLabelPrefix(SemanticsOwner owner, String prefix) {
+  SemanticsNode? found;
+  void visit(SemanticsNode node) {
+    if (found == null && node.getSemanticsData().label.startsWith(prefix)) {
+      found = node;
+    }
+    node.visitChildren((child) {
+      visit(child);
+      return found == null;
+    });
+  }
+
+  visit(owner.rootSemanticsNode!);
+  expect(found, isNotNull,
+      reason: 'no semantics node labelled "$prefix…" was found');
+  return found!;
+}

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:planner/internal/event.dart';
 import 'package:planner/internal/manager.dart';
 import 'package:planner/planner.dart';
 


### PR DESCRIPTION
## Summary
Adds an opt-in `entryBuilder` so a host can render **fully custom widgets** for timed events. Keeps the grid lines + hour gutter as `CustomPaint` and, when a builder is supplied, layers a widget overlay over the events canvas at each event's live `screenRect` — tracking scroll, zoom and drag in lockstep. The overlay is `IgnorePointer` + `ExcludeSemantics`, so it is **visual-only**: every gesture (tap, double-tap, drag, resize, long-press, right-click) and all accessibility actions fall through to the existing recognizers and fire the usual `onEntry*` callbacks.

## Linked issue
Closes #78

## Changes
- **New public `lib/planner_builders.dart`** (exported from `planner.dart`):
  - `enum DragType` — **moved out of `internal/event.dart` and made public**.
  - `typedef PlannerEntryBuilder<T> = Widget Function(BuildContext, PlannerEntry<T>, PlannerEntryLayout)`.
  - `class PlannerEntryLayout { size; columnIndex; columnCount; isDragged; dragType; allDay; }`.
- **`Planner.entryBuilder`** (optional): when non-null, `paintEntryOverlay()` adds an `IgnorePointer(ExcludeSemantics(ClipRect(ValueListenableBuilder(triggerUpdate, Stack(Positioned.fromRect…)))))` above the canvas / below the zoom buttons, and **culls off-screen events** (visuals only).
- **`EventsPainter.drawEventBodies`** (default `true`): skips event-body paint when a builder is present, but **keeps grid lines and the per-event accessibility semantics**; `shouldRepaint` reacts to a toggle.
- **`Event.dragType`** getter, surfaced to the builder via `PlannerEntryLayout`.
- Removed a now-unused `internal/event.dart` import in `test/manager_test.dart`.

## Test plan
- [x] `flutter analyze` clean (lib + test + example)
- [x] Unit/widget tests pass (`flutter test`) — **227 pass**, incl. new `test/entry_builder_test.dart` (11): positioning, zoom-tracking, `size.height = duration×blockHeight×zoom` + side-by-side overlap, off-screen culling, defaults-when-null, double-tap & mouse-drag fall-through, semantics-intact, and the no-double-draw invariant (counts `drawRect` calls).
- [x] Integration/e2e tests pass (`flutter test integration_test -d windows`) — **45 scenarios pass**, incl. 4 new in `example/integration_test/entry_builder_scenarios.dart`: custom widget over the grid at the event rect, real double-tap & mouse-drag fall-through to `onEntryEdit`/`onEntryMove`, and **responsive detail-shedding by pixel height** as the real grid zooms.

## Notes / screenshots
- Establishes the overlay infrastructure that the all-day-chip work (#80) will reuse; `PlannerEntryLayout.allDay` is reserved for it (always `false` here).
- A stale "review findings" table in `PROJECT_OVERVIEW.md` still references `DragType`'s old location alongside other non-existent files; left untouched as out of scope (it has its own update path).
