### PR TITLE
feat: dayHeaderBuilder — fully custom day/column header widgets (#79)

### DIFF
--- a/lib/planner_builders.dart
+++ b/lib/planner_builders.dart
@@ -79,3 +79,31 @@ class PlannerEntryLayout {
     required this.allDay,
   });
 }
+
+/// Builds a fully custom widget for a single day/column header (#79). Supplied
+/// to the `Planner` as `dayHeaderBuilder`; when non-null the planner replaces
+/// the painted `DateRow` text with a row of host-built header widgets — one per
+/// column label — each sized to the column's `blockWidth` and the date row's
+/// height, and offset by the live horizontal scroll so the headers stay aligned
+/// with the day-columns below as the user pans (it rebuilds on the same
+/// `triggerUpdate` the row repaints on).
+///
+/// The header row is wrapped in `IgnorePointer`, so a horizontal drag across it
+/// still pans the day axis through the package's own gesture detector — the
+/// builder decides *appearance* only. Header widgets keep their natural
+/// semantics, so a `Text` header is read by assistive technology (unlike the
+/// painted default, which exposes none).
+///
+/// [columnIndex] is the column's index into `config.labels`; [label] is that
+/// label string (the same text the painted `DateRow` would show); [isHighlighted]
+/// is `columnIndex == config.highlightedColumn`, for emphasising e.g. "today".
+///
+/// No `DateTime` enters the signature (ADR-0001 keeps the core date-agnostic): a
+/// consumer using `lib/calendar.dart` closes over their `CalendarWindow` and
+/// calls `window.dateAt(columnIndex)` inside the builder to recover the date.
+typedef PlannerDayHeaderBuilder = Widget Function(
+  BuildContext context,
+  int columnIndex,
+  String label,
+  bool isHighlighted,
+);

--- a/lib/planner_class.dart
+++ b/lib/planner_class.dart
@@ -50,12 +50,26 @@ class Planner<T> extends StatefulWidget {
   /// `null` (the default) events render exactly as before, painted on the canvas.
   final PlannerEntryBuilder<T>? entryBuilder;
 
+  /// Optional builder for fully custom day/column header widgets (#79). When
+  /// non-null the planner replaces the painted `DateRow` text with a row of
+  /// host-built header widgets — one per `config.labels` entry — each sized to
+  /// the column's `blockWidth` and the date row's height, and offset by the live
+  /// horizontal scroll so the headers track the day-columns below as the user
+  /// pans (rebuilt on the same `triggerUpdate` the row repaints on).
+  ///
+  /// The header row is wrapped in `IgnorePointer`, so a horizontal drag across
+  /// it still pans the day axis through the same gesture detector as the painted
+  /// row — the builder decides appearance only. When `null` (the default) the
+  /// painted `DateRow` is shown exactly as before.
+  final PlannerDayHeaderBuilder? dayHeaderBuilder;
+
   const Planner({
     super.key,
     required this.config,
     required this.entries,
     this.controller,
     this.entryBuilder,
+    this.dayHeaderBuilder,
   });
 
   @override
@@ -296,14 +310,72 @@ class _PlannerState<T> extends State<Planner<T>> {
         child: Container(
           height: _data.config.dateRowHeight,
           color: _data.config.dateBackground,
-          child: CustomPaint(
-            painter: DateRow(
-              manager: _data,
-              repaint: _data.controller.triggerUpdate,
-            ),
-            child: Container(),
-          ),
+          // With a dayHeaderBuilder (#79) the painted row is replaced by a row
+          // of host-built header widgets; otherwise the default DateRow paints.
+          // Either way the surrounding GestureDetector keeps the day-axis pan,
+          // and the ClipRect trims headers scrolled past the gutter/edge.
+          child: widget.dayHeaderBuilder == null
+              ? CustomPaint(
+                  painter: DateRow(
+                    manager: _data,
+                    repaint: _data.controller.triggerUpdate,
+                  ),
+                  child: Container(),
+                )
+              : paintDayHeaders(),
         ),
+      ),
+    );
+  }
+
+  /// The custom day/column header row (#79). When the host supplies a
+  /// [Planner.dayHeaderBuilder] this builds one header widget per `config.labels`
+  /// entry, laid out as a [Row] of `blockWidth`-wide cells offset by the live
+  /// horizontal scroll (`hourColumnWidth + controller.x`) so each header sits
+  /// above its day-column and tracks a pan/scroll — it rebuilds on the same
+  /// `triggerUpdate` the painted [DateRow] repaints on.
+  ///
+  /// The row is wrapped in [IgnorePointer] so a horizontal drag across it falls
+  /// through to the surrounding day-axis pan [GestureDetector] (visual-only
+  /// builder); header widgets keep their natural semantics. An [OverflowBox]
+  /// gives the row unbounded width so the full-width column strip can extend past
+  /// the viewport without an overflow error (the enclosing [ClipRect] trims it),
+  /// while the date-row height passes through so each cell fills it via stretch.
+  Widget paintDayHeaders() {
+    final builder = widget.dayHeaderBuilder!;
+    return IgnorePointer(
+      child: ValueListenableBuilder<int>(
+        valueListenable: _data.controller.triggerUpdate,
+        builder: (context, _, __) {
+          final labels = _data.config.labels;
+          final blockWidth = _data.config.blockWidth.toDouble();
+          return Transform.translate(
+            offset: Offset(
+              _data.config.hourColumnWidth + _data.controller.x,
+              0,
+            ),
+            child: OverflowBox(
+              alignment: Alignment.centerLeft,
+              minWidth: 0,
+              maxWidth: double.infinity,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  for (int i = 0; i < labels.length; i++)
+                    SizedBox(
+                      width: blockWidth,
+                      child: builder(
+                        context,
+                        i,
+                        labels[i],
+                        i == _data.config.highlightedColumn,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/test/day_header_builder_test.dart
+++ b/test/day_header_builder_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/internal/date_row.dart';
+
+import 'package:planner/calendar.dart';
+import 'package:planner/planner.dart';
+
+// Covers the dayHeaderBuilder (#79): a host-supplied widget per day/column
+// header, laid out as a row of blockWidth-wide cells offset by the live
+// horizontal scroll so each header sits above its column and tracks a pan. The
+// row is IgnorePointer, so a horizontal drag across it still pans the day axis
+// through the same GestureDetector the painted DateRow uses. When no builder is
+// supplied the painted DateRow stays the default.
+void main() {
+  PlannerConfig makeConfig({
+    List<String> labels = const ['c1', 'c2', 'c3'],
+    int? highlightedColumn,
+  }) =>
+      PlannerConfig(
+        labels: labels,
+        minHour: 0,
+        maxHour: 23,
+        highlightedColumn: highlightedColumn,
+      );
+
+  // A builder that records, per column index, the label and isHighlighted it was
+  // handed (last write wins across rebuilds) and renders a keyed, full-cell box
+  // so tests can locate it and read its on-screen rect.
+  ({
+    PlannerDayHeaderBuilder builder,
+    Map<int, String> labels,
+    Map<int, bool> highlighted,
+  }) recordingHeaders() {
+    final labels = <int, String>{};
+    final highlighted = <int, bool>{};
+    Widget build(BuildContext c, int i, String label, bool isHighlighted) {
+      labels[i] = label;
+      highlighted[i] = isHighlighted;
+      return Container(key: ValueKey('h-$i'), color: const Color(0x8800FF00));
+    }
+
+    return (builder: build, labels: labels, highlighted: highlighted);
+  }
+
+  Future<void> pumpHeaderPlanner(
+    WidgetTester tester, {
+    required PlannerConfig config,
+    PlannerDayHeaderBuilder? builder,
+    PlannerController? controller,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config: config,
+          entries: const [],
+          controller: controller,
+          dayHeaderBuilder: builder,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  Finder dateRowCanvas() => find.byWidgetPredicate(
+        (w) => w is CustomPaint && w.painter is DateRow,
+      );
+
+  group('custom day headers (real composed Planner)', () {
+    testWidgets('renders one header per label at its column position and width',
+        (tester) async {
+      final rec = recordingHeaders();
+      await pumpHeaderPlanner(tester,
+          config: makeConfig(), builder: rec.builder);
+
+      // One header widget per config.labels entry, and the painted DateRow is
+      // replaced (no longer in the tree).
+      expect(find.byKey(const ValueKey('h-0')), findsOneWidget);
+      expect(find.byKey(const ValueKey('h-1')), findsOneWidget);
+      expect(find.byKey(const ValueKey('h-2')), findsOneWidget);
+      expect(dateRowCanvas(), findsNothing,
+          reason: 'a builder replaces the painted DateRow');
+
+      // Default geometry: hourColumnWidth 50, blockWidth 200, dateRowHeight 50.
+      // Header i sits at planner-local x = 50 + i*200, full column width, and
+      // fills the date row height (top 0, height 50) via the cross-axis stretch.
+      final r0 = tester.getRect(find.byKey(const ValueKey('h-0')));
+      final r1 = tester.getRect(find.byKey(const ValueKey('h-1')));
+      final r2 = tester.getRect(find.byKey(const ValueKey('h-2')));
+      expect(r0.left, moreOrLessEquals(50));
+      expect(r0.top, moreOrLessEquals(0));
+      expect(r0.width, moreOrLessEquals(200));
+      expect(r0.height, moreOrLessEquals(50));
+      expect(r1.left, moreOrLessEquals(250));
+      expect(r2.left, moreOrLessEquals(450));
+
+      // The label handed to the builder is the same text the painted DateRow
+      // would show, in column order.
+      expect(rec.labels, {0: 'c1', 1: 'c2', 2: 'c3'});
+    });
+
+    testWidgets('painted DateRow stays the default when no builder is supplied',
+        (tester) async {
+      await pumpHeaderPlanner(tester, config: makeConfig());
+
+      expect(dateRowCanvas(), findsOneWidget,
+          reason: 'with no builder, headers stay painted by DateRow');
+      expect(find.byKey(const ValueKey('h-0')), findsNothing);
+    });
+
+    testWidgets('isHighlighted is true only for the highlightedColumn',
+        (tester) async {
+      final rec = recordingHeaders();
+      await pumpHeaderPlanner(tester,
+          config: makeConfig(highlightedColumn: 1), builder: rec.builder);
+
+      expect(rec.highlighted, {0: false, 1: true, 2: false});
+    });
+
+    testWidgets('no header is highlighted when highlightedColumn is null',
+        (tester) async {
+      final rec = recordingHeaders();
+      await pumpHeaderPlanner(tester,
+          config: makeConfig(), builder: rec.builder);
+
+      expect(rec.highlighted.values, everyElement(isFalse));
+    });
+
+    testWidgets('dragging the header pans the day axis and repositions headers',
+        (tester) async {
+      // Ten columns (2000px) wider than the 800px test viewport, so there is
+      // day-axis scroll room to pan into.
+      final controller = PlannerController();
+      addTearDown(controller.dispose);
+      final rec = recordingHeaders();
+      await pumpHeaderPlanner(
+        tester,
+        config: makeConfig(
+          labels: const [
+            'd0',
+            'd1',
+            'd2',
+            'd3',
+            'd4',
+            'd5',
+            'd6',
+            'd7',
+            'd8',
+            'd9'
+          ],
+        ),
+        builder: rec.builder,
+        controller: controller,
+      );
+
+      final before = tester.getRect(find.byKey(const ValueKey('h-0')));
+      expect(controller.dayScroll, moreOrLessEquals(0));
+
+      // Drag horizontally at the header's location. The header overlay is
+      // IgnorePointer, so the pointer falls through to the day-axis pan
+      // GestureDetector behind it (dragFrom dispatches at the raw coordinate).
+      await tester.dragFrom(before.center, const Offset(-100, 0));
+      await tester.pump();
+
+      // The day axis panned by the drag delta...
+      expect(controller.dayScroll, moreOrLessEquals(-100),
+          reason: 'the drag fell through the header to the day-axis pan');
+      // ...and the headers tracked it: header 0 moved left by the same amount.
+      final after = tester.getRect(find.byKey(const ValueKey('h-0')));
+      expect(after.left, moreOrLessEquals(before.left - 100),
+          reason: 'headers reposition with controller.x on a pan');
+      expect(after.top, moreOrLessEquals(before.top),
+          reason: 'a day-axis pan does not move headers vertically');
+    });
+  });
+
+  // The ADR-0001 pattern end-to-end (#79): no DateTime enters the builder
+  // signature, so a calendar consumer closes over its CalendarWindow and calls
+  // window.dateAt(columnIndex) inside the builder to recover each column's date.
+  // Drives the real composed Planner to prove the bridge from column index to a
+  // rendered, dated header.
+  testWidgets('a header builder recovers the date via CalendarWindow.dateAt',
+      (tester) async {
+    // A Monday-first week; column 2 is Wednesday 2026-06-10.
+    final window = CalendarWindow.week(anchor: DateTime(2026, 6, 10));
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Planner(
+          config:
+              PlannerConfig(labels: window.labels(), minHour: 0, maxHour: 23),
+          entries: const [],
+          dayHeaderBuilder: (context, columnIndex, label, isHighlighted) {
+            final date = window.dateAt(columnIndex);
+            return Center(
+              child: Text(
+                '${date.month}/${date.day}',
+                key: ValueKey('cal-$columnIndex'),
+              ),
+            );
+          },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Column 2's header shows Wednesday's date, recovered from the window the
+    // builder closed over — not from anything the package passed in.
+    final wednesday = window.dateAt(2);
+    final header = tester.widget<Text>(find.byKey(const ValueKey('cal-2')));
+    expect(header.data, '${wednesday.month}/${wednesday.day}');
+  });
+}


### PR DESCRIPTION
## Summary
Adds an optional `dayHeaderBuilder` to `Planner` (step 4 of the #75 deep-customization epic). When supplied, the painted `DateRow` text is replaced by a row of host-built header widgets — one per column — so consumers can render branded, multi-part headers (day-of-week, day number, full date in different fonts/colours) that can't be a single painted string. Opt-in and fully backward compatible: omit it and the painted `DateRow` is unchanged.

## Linked issue
Closes #79

## Changes
- **`lib/planner_builders.dart`** — new `PlannerDayHeaderBuilder` typedef: `(BuildContext, int columnIndex, String label, bool isHighlighted) → Widget` (exported via the `planner.dart` barrel). No `DateTime` in the signature (ADR-0001) — a calendar consumer closes over its `CalendarWindow` and calls `window.dateAt(columnIndex)` inside the builder.
- **`lib/planner_class.dart`** — added the optional `dayHeaderBuilder` param to the `Planner` constructor; `paintDates()` now swaps the `CustomPaint(DateRow)` for a new `paintDayHeaders()` when the builder is set. That overlay is an `IgnorePointer` `Row` of `blockWidth`-wide `SizedBox` cells (in an `OverflowBox` so the full column strip can extend past the viewport without an overflow error — the existing `ClipRect` trims it), offset by `hourColumnWidth + controller.x` and rebuilt on `triggerUpdate`. The surrounding horizontal-drag `GestureDetector` is kept, so a drag across the headers still pans the day axis. `isHighlighted` is `columnIndex == config.highlightedColumn`.
- **`test/day_header_builder_test.dart`** — new test file covering every acceptance criterion.

## Test plan
- [x] `flutter analyze` clean
- [x] unit/widget tests pass (`flutter test`) — **233 pass** (227 prior + 6 new)
- [x] e2e / real-app coverage: this is a Flutter **package** (no `integration_test/` app harness — the sibling #77/#78 work follows the same pattern), so the closest equivalent is driving the **real composed `Planner`** in a `MaterialApp` (real layout, real gesture arena). The new tests do exactly that, including a calendar-composed test that recovers each column's date via `CalendarWindow.dateAt` inside the builder — the ADR-0001 consumer path, end to end. New tests cover: one header per label at the correct column position/width; painted `DateRow` remains the default when the builder is null; `isHighlighted` true only for `highlightedColumn` (and none when null); dragging the header pans the day axis (`PlannerController.dayScroll`) and the headers reposition with it.

## Notes / screenshots
Independent of #78; reuses the same `triggerUpdate` overlay-sync approach. CHANGELOG left untouched to match the #75 epic, which consolidates example + docs into #81.