### PR TITLE
docs: example + docs showcasing the customization hooks (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- Added fully custom **widget builders**, so a host can own the visuals while the
+  package stays the time-grid engine (geometry, scroll, zoom, hit-testing,
+  overlap, accessibility). All opt-in and non-breaking — defaults are unchanged:
+  - `Planner.dayHeaderBuilder` — a custom widget per day/column header (#79). The
+    signature carries no `DateTime` (the core stays date-agnostic, ADR 0001);
+    close over a `CalendarWindow` to recover the date. Headers track day-axis
+    pan, and a drag across them still pans.
+  - `Planner.entryBuilder` — a custom widget per timed event, layered over the
+    canvas at the event's live on-screen rect so it tracks scroll/zoom/drag (#78).
+    `PlannerEntryLayout.size` lets a widget **shed detail by pixel height**.
+  - `Planner.allDayEntryBuilder` — the same for all-day chips, with
+    `PlannerEntryLayout.allDay == true` (#80).
+  - The overlays are visual-only (`IgnorePointer` / `ExcludeSemantics`), so every
+    gesture and accessibility action still falls through to the canvas and fires
+    the usual `onEntry*` callbacks.
+- Made `PlannerEntry` generic: `PlannerEntry<T>` adds an optional typed `data`
+  payload for your own per-event metadata (#77). `T` threads through `Planner<T>`,
+  `PlannerConfig<T>` and the `onEntry*` callbacks, so a builder reads `entry.data`
+  already typed — no cast, no side-map keyed by `id`. An untyped `PlannerEntry(...)`
+  infers `T == dynamic` and is unchanged, so this is backward compatible.
 - Added a public `PlannerController` for driving and observing the planner's zoom
   from outside the widget — e.g. a host's own zoom toolbar. Construct one, pass it
   to `Planner(controller: …)`, and call `zoomIn([factor])`, `zoomOut([factor])` or

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -8,7 +8,7 @@
 - **Version:** 0.0.4
 - **Repo:** https://github.com/pebble-world/planner
 - **Status:** internal-only (`publish_to: none`); goal is pub.dev + cross-project reuse.
-- **Last reviewed:** 2026-06-06
+- **Last reviewed:** 2026-06-07
 
 ---
 
@@ -53,8 +53,9 @@ Public API (exported from [`lib/planner.dart`](lib/planner.dart)):
 |------|------|
 | [`planner_class.dart`](lib/planner_class.dart) | `Planner` widget; builds the layout, wires gestures, hosts the painters. |
 | [`planner_controller.dart`](lib/planner_controller.dart) | `PlannerController` — optional public handle that attaches to the internal `Controller` to drive/observe zoom (and read scroll) from outside the widget (#76). |
-| [`planner_config.dart`](lib/planner_config.dart) | `PlannerConfig` — all sizing, colors, text styles, and callbacks. |
-| [`planner_entry.dart`](lib/planner_entry.dart) | `PlannerEntry` — a single event (id, time, title, content, color, styles). |
+| [`planner_builders.dart`](lib/planner_builders.dart) | The custom-widget builder surface (#78/#79/#80): `PlannerEntryBuilder<T>` + `PlannerEntryLayout` (timed events & all-day chips), `PlannerDayHeaderBuilder`, and the public `DragType` enum. |
+| [`planner_config.dart`](lib/planner_config.dart) | `PlannerConfig<T>` — all sizing, colors, text styles, and callbacks. |
+| [`planner_entry.dart`](lib/planner_entry.dart) | `PlannerEntry<T>` — a single event (id, time, title, content, color, styles) plus an optional typed `data` payload (#77). |
 | [`planner_time.dart`](lib/planner_time.dart) | `PlannerTime` — the day/hour/minute/duration value (⚠️ **not** re-exported). |
 
 Internals ([`lib/internal/`](lib/internal/)):
@@ -190,6 +191,12 @@ Severity: 🔴 blocker/bug · 🟠 important · 🟡 polish.
   `date ↔ index` consumer helpers (#49 — `CalendarWindow` in the non-core
   `lib/calendar.dart`).
 - **D11** overlap/column layout. Accessibility (`Semantics`), localization of menu strings.
+- ✅ **Deep customization (#75):** the package is the time-grid engine while a host
+  owns the visuals — ✅ external zoom (`PlannerController`, #76), ✅ typed
+  `PlannerEntry<T>.data` (#77), ✅ `entryBuilder` (#78), ✅ `dayHeaderBuilder` (#79),
+  ✅ `allDayEntryBuilder` (#80), ✅ example + docs showcasing all four (#81). Hybrid
+  render model: canvas keeps grid/gutter, builders layer `IgnorePointer` widget
+  overlays positioned by the existing geometry — all opt-in, defaults unchanged.
 
 ### P3 — Polish & tooling
 - **B2** bump `flutter_lints`; **E1/E2** CI + stricter analysis; **D6/D7** repaint &

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ hours, and let users pan, zoom, and drag events to move or resize them.
 - Create / edit / delete via double-tap or a right-click context menu.
 - Per-event accessibility semantics (edit / delete / move) for screen readers.
 - Customizable colors and text styles for the grid, labels, events, and menu.
+- **Fully custom widgets** via opt-in builders: branded day/column headers
+  (`dayHeaderBuilder`), real-widget events that shed detail by pixel height
+  (`entryBuilder`), and custom all-day chips (`allDayEntryBuilder`) — each reads
+  a typed `PlannerEntry<T>.data` payload. See
+  [Fully custom widgets (builders)](#fully-custom-widgets-builders).
 
 See [Interactions](#interactions) below for the full mouse and touch gesture map.
 
@@ -111,8 +116,10 @@ A complete, runnable demo lives in [`example/`](example/lib/main.dart).
 | `Planner` | The widget. Takes a `config`, a list of `entries`, and an optional `controller`. |
 | `PlannerConfig` | Sizing (`blockWidth`, `blockHeight`, `minHour`, `maxHour` — the inclusive last hour, default `23`, …), colors, text styles, an optional `hourLabelFormatter`, the optional column highlight (`highlightedColumn`, `highlightColumnColor`), the zoom controls (`showZoomControls`, `zoomButtonColor`, `zoomButtonIconColor`), the wheel `scrollStep`, and the `onEntry*` callbacks. `labels` is required. |
 | `PlannerController` | Optional handle to drive/observe zoom from outside the widget (e.g. your own toolbar) — see [Driving zoom from a host toolbar](#driving-zoom-from-a-host-toolbar). |
-| `PlannerEntry` | One event: `id`, `time`, `title`, `content`, `color`, and optional text styles. |
+| `PlannerEntry<T>` | One event: `id`, `time`, `title`, `content`, `color`, optional text styles, and an optional typed `data` payload (`T?`) for your own metadata — see [Fully custom widgets (builders)](#fully-custom-widgets-builders). |
 | `PlannerTime` | `day` (index into `labels`), `hour`, `minutes`, and `duration` (in minutes). |
+| `PlannerEntryBuilder<T>` / `PlannerEntryLayout` | Build a custom widget for a timed event or all-day chip; `PlannerEntryLayout` carries the on-screen `size` (for detail-shedding), overlap column, and drag state. |
+| `PlannerDayHeaderBuilder` | Build a custom widget for a day/column header. |
 
 ### Callbacks
 
@@ -208,6 +215,131 @@ the *same* zoom; there's no duplicated state to keep in sync. The read getters
 throw while not `isAttached` (before the `Planner` mounts or after it's gone), so
 read them in response to a notification or guard with `isAttached`; the zoom
 methods are no-ops then. Dispose the controller like any other `ChangeNotifier`.
+
+### Fully custom widgets (builders)
+
+By default the planner paints everything on a canvas. Three opt-in **builders**
+let you replace any of those surfaces with real Flutter widgets — branded
+headers, rich event cards, custom chips — while the package stays the engine
+(geometry, scroll, zoom, hit-testing, overlap, accessibility). Each builder is
+**visual-only**: the widget overlay is wrapped in `IgnorePointer` /
+`ExcludeSemantics`, so every gesture and accessibility action still falls through
+to the canvas and fires the usual `onEntry*` callbacks. Everything is opt-in —
+pass `null` (the default) and the painted look is unchanged.
+
+#### Typed metadata: `PlannerEntry<T>.data`
+
+To render a rich widget you usually need your app's own data on each event —
+type, place, attendees, status. Make the entry generic and hang it on `data`:
+
+```dart
+class ActivityMeta {
+  const ActivityMeta({required this.type, this.place = '', this.attendees = const []});
+  final String type;
+  final String place;
+  final List<String> attendees;
+}
+
+final entry = PlannerEntry<ActivityMeta>(
+  id: '1',
+  time: PlannerTime(day: 0, hour: 9, duration: 60),
+  title: 'Stand-up',
+  content: '',
+  color: Colors.teal,
+  data: const ActivityMeta(type: 'meeting', place: 'Room A', attendees: ['AM', 'BK']),
+);
+```
+
+`T` threads through `Planner<T>`, `PlannerConfig<T>` and the `onEntry*`
+callbacks, so the builder (and your callbacks) read `entry.data` already typed —
+no cast, no side-map keyed by `id`. An untyped `PlannerEntry(...)` infers
+`T == dynamic` and behaves exactly as before, so this is non-breaking.
+
+#### `entryBuilder` — custom timed-event widgets
+
+When set, the planner layers one widget per on-screen event over the canvas,
+positioned and sized at the event's live on-screen rect so it tracks scroll,
+zoom and drag in lockstep with the grid. The `PlannerEntryLayout` carries the
+on-screen facts — crucially `size.height`, so a card can **shed detail by pixel
+height** as the user zooms:
+
+```dart
+Planner<ActivityMeta>(
+  config: PlannerConfig<ActivityMeta>(labels: const ['Mon', 'Tue', 'Wed']),
+  entries: entries,
+  entryBuilder: (context, entry, layout) {
+    final meta = entry.data;
+    return Card(
+      color: entry.color,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(entry.title),
+          // Only show the place when the event is tall enough on screen.
+          if (layout.size.height >= 52 && meta != null) Text(meta.place),
+          // …and the avatar stack only when it's taller still.
+          if (layout.size.height >= 92 && meta != null)
+            Row(children: [for (final a in meta.attendees) CircleAvatar(child: Text(a))]),
+        ],
+      ),
+    );
+  },
+)
+```
+
+Tapping, double-tapping, dragging or right-clicking the custom widget still
+fires `onEntryEdit` / `onEntryMove` / `onEntryLongPress` (the overlay is
+`IgnorePointer`). Overlapping events are placed side-by-side automatically via
+`layout.columnIndex` / `layout.columnCount`, and `layout.dragType` reflects a
+live move/resize.
+
+#### `dayHeaderBuilder` — custom day/column headers
+
+Supplies one widget per column header — e.g. a multi-part branded header with the
+weekday, day number and a "today" tint. The signature carries **no `DateTime`**
+(the core stays date-agnostic — ADR 0001); a consumer using the
+[calendar helpers](#building-a-date-based-week-calendar) closes over their
+`CalendarWindow` to recover the date:
+
+```dart
+final window = CalendarWindow.week(anchor: DateTime.now());
+
+Planner(
+  config: PlannerConfig(labels: window.labels()),
+  entries: entries,
+  dayHeaderBuilder: (context, columnIndex, label, isHighlighted) {
+    final date = window.dateAt(columnIndex); // map index → real date
+    return Container(
+      color: isHighlighted ? Colors.blue : null, // `isHighlighted` == highlightedColumn
+      child: Column(children: [Text('${date.day}'), Text(label)]),
+    );
+  },
+)
+```
+
+Headers reposition on a day-axis pan and a horizontal drag across them still pans
+the day axis.
+
+#### `allDayEntryBuilder` — custom all-day chips
+
+The all-day twin of `entryBuilder` — same `PlannerEntryBuilder<T>` signature, applied
+to the all-day band (needs `showAllDayBand: true`). The `PlannerEntryLayout` carries
+`allDay: true`, so one builder can serve both surfaces and branch on it:
+
+```dart
+Planner<ActivityMeta>(
+  config: PlannerConfig<ActivityMeta>(labels: const ['Mon', 'Tue'], showAllDayBand: true),
+  entries: entries, // some with PlannerTime(..., allDay: true)
+  allDayEntryBuilder: (context, entry, layout) => Container(
+    decoration: BoxDecoration(color: entry.color, borderRadius: BorderRadius.circular(10)),
+    child: Text(entry.title),
+  ),
+)
+```
+
+A complete demo wiring **all four** hooks together (host zoom toolbar, branded
+headers, detail-shedding event cards, and all-day chips) lives in
+[`example/lib/main.dart`](example/lib/main.dart).
 
 ### Localizing the context menu
 

--- a/example/integration_test/app_smoke_scenarios.dart
+++ b/example/integration_test/app_smoke_scenarios.dart
@@ -2,6 +2,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
 
+import 'package:example/data.dart';
 import 'package:example/main.dart' as app;
 
 /// Drives the *real* example app end-to-end (real entrypoint, real fonts, real
@@ -17,7 +18,7 @@ void appSmokeScenarios() {
     app.main();
     await tester.pumpAndSettle();
 
-    expect(find.byType(Planner), findsOneWidget);
+    expect(find.byType(Planner<ActivityMeta>), findsOneWidget);
     expect(find.text('Planner Demo'), findsOneWidget);
   });
 
@@ -28,10 +29,12 @@ void appSmokeScenarios() {
 
     // An empty spot in column 0: +100px right (into the grid) and +120px down
     // from the grid top maps to hour 3, which the sample data leaves free
-    // (entries sit at 08:00 and 13:30). This exercises the real secondary-tap
-    // gesture path the widget harness can't always reach.
-    final rect = tester.getRect(find.byType(Planner));
-    final at = rect.topLeft + const Offset(50 + 100, 50 + 120);
+    // (column-0 entries sit at 01:00, 08:00 and 13:30). The grid top is the date
+    // row (50) plus the now-enabled all-day band (one lane: 24 + 2*2 = 28). This
+    // exercises the real secondary-tap gesture path the widget harness can't
+    // always reach.
+    final rect = tester.getRect(find.byType(Planner<ActivityMeta>));
+    final at = rect.topLeft + const Offset(50 + 100, 50 + 28 + 120);
 
     final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
     await tester.pump();

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -11,6 +11,7 @@ import 'double_tap_scenarios.dart';
 import 'drag_scenarios.dart';
 import 'entry_builder_scenarios.dart';
 import 'event_geometry_scenarios.dart';
+import 'example_hooks_scenarios.dart';
 import 'external_zoom_scenarios.dart';
 import 'highlight_column_scenarios.dart';
 import 'hour_label_scenarios.dart';
@@ -43,6 +44,7 @@ void main() {
   dragScenarios();
   entryBuilderScenarios();
   eventGeometryScenarios();
+  exampleHooksScenarios();
   externalZoomScenarios();
   highlightColumnScenarios();
   hourLabelScenarios();

--- a/example/integration_test/context_menu_scenarios.dart
+++ b/example/integration_test/context_menu_scenarios.dart
@@ -2,6 +2,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
 
+import 'package:example/data.dart';
 import 'package:example/main.dart' as app;
 
 /// Drives the *real* example app end-to-end to cover the **entry** context menu
@@ -18,12 +19,13 @@ void contextMenuScenarios() {
     app.main();
     await tester.pumpAndSettle();
 
-    // The sample data's "Entry 1" sits at day 0 / 08:00 for 60 min
-    // (DataEntry.createSampleData). With the default 200x40 grid that is grid
-    // rect (0,320)-(200,360); skipping the hour column (50) and date row (50),
-    // the box centre lands at planner-local (50 + 100, 50 + 340).
-    final rect = tester.getRect(find.byType(Planner));
-    final at = rect.topLeft + const Offset(50 + 100, 50 + 340);
+    // The sample data's 'Stand-up' entry sits at day 0 / 08:00 for 60 min
+    // (sampleEntries). With the default 200x40 grid that is grid rect
+    // (0,320)-(200,360); skipping the hour column (50), the date row (50) and the
+    // all-day band (one lane: 24 + 2*2 = 28), the box centre lands at
+    // planner-local (50 + 100, 50 + 28 + 340).
+    final rect = tester.getRect(find.byType(Planner<ActivityMeta>));
+    final at = rect.topLeft + const Offset(50 + 100, 50 + 28 + 340);
 
     final gesture = await tester.startGesture(at, buttons: kSecondaryButton);
     await tester.pump();

--- a/example/integration_test/example_hooks_scenarios.dart
+++ b/example/integration_test/example_hooks_scenarios.dart
@@ -1,0 +1,75 @@
+import 'package:example/data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planner/planner.dart';
+
+import 'package:example/main.dart' as app;
+
+/// End-to-end verification that the *example app* wires all four customization
+/// hooks together (#81) — the integration check the docs/example issue exists
+/// for. It drives the **real** entrypoint (`app.main()`), so it exercises the
+/// hooks in real composition: a `dayHeaderBuilder` row above an all-day band of
+/// `allDayEntryBuilder` chips above the `entryBuilder` overlay, with zoom driven
+/// from the host's own `PlannerController` toolbar (the built-in controls
+/// hidden). Event titles/labels are real widgets here (the builders render real
+/// `Text`), so they're assertable — unlike the painted defaults.
+///
+/// Registered from [app_test.dart]; not a standalone entry point (desktop can
+/// only launch one app per `flutter test` invocation).
+void exampleHooksScenarios() {
+  testWidgets('the example wires all four customization hooks together (#81)',
+      (tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    // The typed Planner<ActivityMeta> proves the generic payload (#77) is in use.
+    expect(find.byType(Planner<ActivityMeta>), findsOneWidget);
+
+    // entryBuilder (#78): a custom "Pop Block" widget for an on-screen event.
+    expect(find.byKey(const ValueKey('pop-block-0')), findsOneWidget);
+
+    // dayHeaderBuilder (#79): a custom multi-part header for column 0.
+    expect(find.byKey(const ValueKey('day-header-0')), findsOneWidget);
+
+    // allDayEntryBuilder (#80): a custom chip in the all-day band (the day-2
+    // event sits in view without scrolling).
+    expect(find.byKey(const ValueKey('all-day-chip-ad-0')), findsOneWidget);
+
+    // PlannerController (#76): the host owns zoom. `showZoomControls:false` hides
+    // the on-canvas buttons, so the single remaining zoom_in icon is the host's.
+    expect(find.byKey(const ValueKey('demo-zoom-in')), findsOneWidget);
+    expect(find.byIcon(Icons.zoom_in), findsOneWidget,
+        reason: 'the built-in on-canvas zoom button is hidden');
+  });
+
+  testWidgets(
+      'the host toolbar zooms the grid and the Pop Block sheds detail by '
+      'height (#81)', (tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    // The 01:00 column-0 event ('Coffee & planning') stays near the top as the
+    // grid zooms, so it visibly grows from a bare title to the full card.
+    final card = find.byKey(const ValueKey('pop-block-2'));
+    final avatars = find.byKey(const ValueKey('pop-avatars-2'));
+    expect(card, findsOneWidget);
+
+    // At zoom 1 the 60-min card is 40px tall — below the 92px avatar tier.
+    final baseHeight = tester.getSize(card).height;
+    expect(baseHeight, moreOrLessEquals(40, epsilon: 0.5));
+    expect(avatars, findsNothing,
+        reason: 'a 40px card is below the avatar-stack threshold');
+
+    // Zoom in from the host's *own* toolbar button. 40 * 1.1^10 ≈ 104 ≥ 92, and
+    // the button stays enabled (zoom < maxZoom 4.0) the whole way.
+    for (var i = 0; i < 10; i++) {
+      await tester.tap(find.byKey(const ValueKey('demo-zoom-in')));
+      await tester.pump();
+    }
+
+    expect(tester.getSize(card).height, greaterThan(baseHeight),
+        reason: 'the host button drove the real grid zoom (#76)');
+    expect(avatars, findsOneWidget,
+        reason: 'the taller card now reveals its avatar stack (#78 shedding)');
+  });
+}

--- a/example/lib/data.dart
+++ b/example/lib/data.dart
@@ -1,52 +1,131 @@
-enum DataType {
-  A,
-  B,
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+/// The kind of activity an event represents. This is the *example app's own*
+/// domain enum — the planner package knows nothing about it. It rides along on
+/// each entry's typed [PlannerEntry.data] payload (#77) and the custom widgets
+/// (the "Pop Block" `entryBuilder` and the all-day chip) read it back already
+/// typed, with no cast and no side-map keyed by id.
+enum ActivityType { focus, meeting, social }
+
+extension ActivityTypeVisuals on ActivityType {
+  /// The accent colour the custom widgets use for this type (the Pop Block's
+  /// left bar, the all-day pill fill).
+  Color get color => switch (this) {
+        ActivityType.focus => const Color(0xFF3A7BD5),
+        ActivityType.meeting => const Color(0xFF12A594),
+        ActivityType.social => const Color(0xFFE5484D),
+      };
+
+  String get label => switch (this) {
+        ActivityType.focus => 'Focus',
+        ActivityType.meeting => 'Meeting',
+        ActivityType.social => 'Social',
+      };
 }
 
-class DataEntry {
-  int id;
-  int day;
-  int hour;
-  int minutes;
-  int durationInMinutes;
+/// The example app's per-event metadata, carried on
+/// `PlannerEntry<ActivityMeta>.data` (#77). Everything here is app data the
+/// package never inspects — it only threads it through so the builders get it
+/// back typed.
+class ActivityMeta {
+  const ActivityMeta({
+    required this.type,
+    this.place = '',
+    this.status = '',
+    this.attendees = const [],
+  });
 
-  String title;
-  String content;
+  final ActivityType type;
+  final String place;
+  final String status;
 
-  DataType type;
+  /// Attendee initials, rendered as the avatar stack in the tallest detail tier.
+  final List<String> attendees;
+}
 
-  DataEntry(
-      {required this.id,
-      required this.day,
-      required this.hour,
-      required this.minutes,
-      required this.durationInMinutes,
-      required this.title,
-      required this.content,
-      required this.type});
-
-  static List<DataEntry> createSampleData() {
-    List<DataEntry> entries = [
-      DataEntry(
-          id: 0,
-          day: 0,
-          hour: 8,
-          minutes: 0,
-          durationInMinutes: 60,
-          title: "Entry 1",
-          content: "some content to show in this entry",
-          type: DataType.A),
-      DataEntry(
-          id: 1,
-          day: 0,
-          hour: 13,
-          minutes: 30,
-          durationInMinutes: 90,
-          title: "Entry 2 is a bit longer and does not fit inside its box",
-          content:
-              "This is the content of entry 2. It takes up a bit more space.",
-          type: DataType.B),
+/// The demo's sample entries, typed `PlannerEntry<ActivityMeta>`.
+///
+/// Positions are plain **column indices** (`day: 0` is the first label), not
+/// real dates, so the demo is deterministic no matter what date the headers
+/// show. The `dayHeaderBuilder` maps a column index back to its `DateTime` via a
+/// `CalendarWindow` for display only.
+List<PlannerEntry<ActivityMeta>> sampleEntries() => [
+      // A 60-min event in column 0 at 08:00. Small at zoom 1 (40px), so its Pop
+      // Block shows only the title until you zoom in.
+      PlannerEntry<ActivityMeta>(
+        id: '0',
+        time: PlannerTime(day: 0, hour: 8, duration: 60),
+        title: 'Stand-up',
+        content: 'Daily team sync',
+        color: ActivityType.meeting.color,
+        data: const ActivityMeta(
+          type: ActivityType.meeting,
+          place: 'Room A',
+          status: 'Confirmed',
+          attendees: ['AM', 'BK', 'CD'],
+        ),
+      ),
+      // A second column-0 event early in the day (01:00). It stays near the top
+      // as you zoom, so it's the one that visibly grows from a bare title to the
+      // full card (place → status → time → avatar stack) by pixel height.
+      PlannerEntry<ActivityMeta>(
+        id: '2',
+        time: PlannerTime(day: 0, hour: 1, duration: 60),
+        title: 'Coffee & planning',
+        content: 'Kick off the day',
+        color: ActivityType.social.color,
+        data: const ActivityMeta(
+          type: ActivityType.social,
+          place: 'The Atrium',
+          status: 'Tentative',
+          attendees: ['YS', 'PV', 'LM', 'RJ'],
+        ),
+      ),
+      // A taller 90-min event later in column 0.
+      PlannerEntry<ActivityMeta>(
+        id: '1',
+        time: PlannerTime(day: 0, hour: 13, minutes: 30, duration: 90),
+        title: 'Design review',
+        content: 'Walk through the new flow',
+        color: ActivityType.focus.color,
+        data: const ActivityMeta(
+          type: ActivityType.focus,
+          place: 'Studio',
+          status: 'Confirmed',
+          attendees: ['AM', 'CD'],
+        ),
+      ),
+      // Something in a second column, for visual variety.
+      PlannerEntry<ActivityMeta>(
+        id: '3',
+        time: PlannerTime(day: 1, hour: 9, duration: 120),
+        title: 'Workshop',
+        content: 'Hands-on session',
+        color: ActivityType.meeting.color,
+        data: const ActivityMeta(
+          type: ActivityType.meeting,
+          place: 'Room B',
+          status: 'Confirmed',
+          attendees: ['AM', 'BK', 'CD', 'PV', 'RJ'],
+        ),
+      ),
+      // Two all-day events, in distinct columns so the band stays a single lane.
+      // They render through the `allDayEntryBuilder` as custom pills.
+      PlannerEntry<ActivityMeta>(
+        id: 'ad-0',
+        time: PlannerTime(day: 2, allDay: true),
+        title: 'Company offsite',
+        content: '',
+        color: ActivityType.social.color,
+        data: const ActivityMeta(type: ActivityType.social),
+      ),
+      PlannerEntry<ActivityMeta>(
+        id: 'ad-1',
+        time: PlannerTime(day: 4, allDay: true),
+        title: 'Release day',
+        content: '',
+        color: ActivityType.meeting.color,
+        data: const ActivityMeta(type: ActivityType.meeting),
+      ),
     ];
-    return entries;
-  }
-}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:example/data.dart';
 import 'package:flutter/material.dart';
+import 'package:planner/calendar.dart';
 import 'package:planner/planner.dart';
 
 void main() {
@@ -7,9 +8,8 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -23,16 +23,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, required this.title}) : super(key: key);
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
+  const MyHomePage({super.key, required this.title});
 
   final String title;
 
@@ -41,85 +32,418 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  var dataEntries = DataEntry.createSampleData();
+  // Drives zoom from the host's own toolbar (#76). The built-in on-canvas
+  // buttons are hidden via `showZoomControls: false` below, so this is the only
+  // way to zoom besides pinch / Ctrl+wheel.
+  final PlannerController _controller = PlannerController();
+
+  // The week shown, snapped to its Monday. The `dayHeaderBuilder` closes over
+  // this to turn a column index into its real date — the package itself stays
+  // date-agnostic (ADR 0001), so no `DateTime` enters its API.
+  final CalendarWindow _window = CalendarWindow.week(anchor: DateTime.now());
+
+  // The entries are immutable (#27); a move replaces the matching one in place.
+  List<PlannerEntry<ActivityMeta>> _entries = sampleEntries();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    // create planner entries from the data set
-    List<PlannerEntry> entries = [];
-    for (final element in dataEntries) {
-      entries.add(PlannerEntry(
-          id: element.id.toString(),
-          time: PlannerTime(
-              day: element.day,
-              hour: element.hour,
-              minutes: element.minutes,
-              duration: element.durationInMinutes),
-          title: element.hour.toString() +
-              ':' +
-              element.minutes.toString() +
-              ' ' +
-              element.title,
-          content: element.content,
-          color: element.type == DataType.A ? Colors.green : Colors.blue));
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+        // The host's own zoom toolbar (#76). It listens to the controller so the
+        // buttons disable once zoom hits a bound; the controller's read getters
+        // throw before the planner has attached, so guard on `isAttached`.
+        actions: [
+          AnimatedBuilder(
+            animation: _controller,
+            builder: (context, _) {
+              final atMin = _controller.isAttached &&
+                  _controller.zoom <= _controller.minZoom;
+              final atMax = _controller.isAttached &&
+                  _controller.zoom >= _controller.maxZoom;
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    key: const ValueKey('demo-zoom-out'),
+                    tooltip: 'Zoom out',
+                    icon: const Icon(Icons.zoom_out),
+                    onPressed: atMin ? null : _controller.zoomOut,
+                  ),
+                  IconButton(
+                    key: const ValueKey('demo-zoom-in'),
+                    tooltip: 'Zoom in',
+                    icon: const Icon(Icons.zoom_in),
+                    onPressed: atMax ? null : _controller.zoomIn,
+                  ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+      body: Planner<ActivityMeta>(
+        controller: _controller,
+        config: PlannerConfig<ActivityMeta>(
+          // Week-style headers, one label per column. The builder below ignores
+          // the painted label and renders its own multi-part header instead.
+          labels: _window.labels(),
+          minHour: 0,
+          maxHour: 23,
+          // Hand zoom to the host toolbar above.
+          showZoomControls: false,
+          // Show the all-day band so the custom chips have somewhere to live.
+          showAllDayBand: true,
+          // Emphasize today's column ("today" style); null off-week.
+          highlightedColumn: _window.todayColumn,
+          onEntryMove: (entry) => setState(() {
+            _entries = [
+              for (final e in _entries) e.id == entry.id ? entry : e,
+            ];
+          }),
+          onEntryEdit: (entry) => debugPrint('edit: ${entry.title}'),
+          onEntryCreate: (time) => debugPrint(
+              'create at day ${time.day} ${time.hour}:${time.minutes}'),
+          onEntryDelete: (entry) => debugPrint('delete: ${entry.title}'),
+          // Presentation-only: the host decides what a long-press does (#66).
+          onEntryLongPress: (entry) => debugPrint('long-press: ${entry.title}'),
+        ),
+        entries: _entries,
+        // #79 — a branded, multi-part header per column. It reads the real date
+        // from the closed-over CalendarWindow; `isHighlighted` flags today.
+        dayHeaderBuilder: (context, columnIndex, label, isHighlighted) =>
+            _DayHeader(
+          key: ValueKey('day-header-$columnIndex'),
+          date: _window.dateAt(columnIndex),
+          highlighted: isHighlighted,
+        ),
+        // #78 — fully custom timed-event widgets, reading the typed `entry.data`
+        // and shedding detail by on-screen pixel height.
+        entryBuilder: _buildPopBlock,
+        // #80 — fully custom all-day chips, same typed payload.
+        allDayEntryBuilder: _buildAllDayChip,
+      ),
+    );
+  }
+
+  /// The "Pop Block" (#78): a fully custom timed-event widget that reads the
+  /// typed [PlannerEntry.data] (#77) and **sheds detail by pixel height** —
+  /// `layout.size.height` is the event's live on-screen height, so as you zoom
+  /// the same event reveals more. Thresholds: place ≥52, status ≥56, time ≥60,
+  /// avatar stack ≥92.
+  Widget _buildPopBlock(
+    BuildContext context,
+    PlannerEntry<ActivityMeta> entry,
+    PlannerEntryLayout layout,
+  ) =>
+      _PopBlock(
+        key: ValueKey('pop-block-${entry.id}'),
+        entry: entry,
+        layout: layout,
+      );
+
+  /// A fully custom all-day chip (#80). Reuses the typed payload for its accent
+  /// colour; `layout.allDay` is `true` here, so a single builder wired to both
+  /// hooks could branch on it instead.
+  Widget _buildAllDayChip(
+    BuildContext context,
+    PlannerEntry<ActivityMeta> entry,
+    PlannerEntryLayout layout,
+  ) {
+    final accent = entry.data?.type.color ?? entry.color;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 3),
+      child: Container(
+        key: ValueKey('all-day-chip-${entry.id}'),
+        decoration: BoxDecoration(
+          color: accent,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        alignment: Alignment.centerLeft,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.event, size: 11, color: Colors.white),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                entry.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A branded, multi-part day/column header (#79): the weekday in a small caps
+/// style above a large day number, tinted when it's today. Built from a real
+/// `DateTime` the host recovered from its `CalendarWindow`.
+class _DayHeader extends StatelessWidget {
+  const _DayHeader({super.key, required this.date, required this.highlighted});
+
+  final DateTime date;
+  final bool highlighted;
+
+  static const _weekdays = [
+    'MON',
+    'TUE',
+    'WED',
+    'THU',
+    'FRI',
+    'SAT',
+    'SUN',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = highlighted ? Colors.white : Colors.black87;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 3, vertical: 4),
+      decoration: BoxDecoration(
+        color: highlighted ? const Color(0xFF3A7BD5) : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      // OverflowBox + ClipRect lets the stacked text lay out at its natural
+      // height and be trimmed rather than throw an overflow when a cell is short
+      // (mirrors how the package lays the header row out).
+      child: ClipRect(
+        child: OverflowBox(
+          minHeight: 0,
+          maxHeight: double.infinity,
+          alignment: Alignment.center,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                _weekdays[date.weekday - 1],
+                style: TextStyle(
+                  fontSize: 9,
+                  letterSpacing: 1.5,
+                  fontWeight: FontWeight.w600,
+                  color: highlighted ? Colors.white70 : Colors.black54,
+                ),
+              ),
+              Text(
+                '${date.day}',
+                style: TextStyle(
+                  fontSize: 16,
+                  height: 1.1,
+                  fontWeight: FontWeight.bold,
+                  color: fg,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The Pop Block widget itself: a dark card with a type-coloured left bar and a
+/// hard-offset shadow, revealing more of the entry's metadata as it grows.
+class _PopBlock extends StatelessWidget {
+  const _PopBlock({super.key, required this.entry, required this.layout});
+
+  final PlannerEntry<ActivityMeta> entry;
+  final PlannerEntryLayout layout;
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = entry.data;
+    final h = layout.size.height;
+    final accent = meta?.type.color ?? entry.color;
+
+    final showPlace = h >= 52 && (meta?.place.isNotEmpty ?? false);
+    final showStatus = h >= 56 && (meta?.status.isNotEmpty ?? false);
+    final showTime = h >= 60;
+    final showAvatars = h >= 92 && (meta?.attendees.isNotEmpty ?? false);
+
+    return Padding(
+      padding: const EdgeInsets.all(2),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: const Color(0xFF1F2430),
+          borderRadius: BorderRadius.circular(6),
+          boxShadow: const [
+            BoxShadow(color: Color(0x55000000), offset: Offset(3, 3)),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(6),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // The type-coloured left bar.
+              Container(width: 4, color: accent),
+              Expanded(
+                child: ClipRect(
+                  child: OverflowBox(
+                    minHeight: 0,
+                    maxHeight: double.infinity,
+                    alignment: Alignment.topLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.all(4),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  entry.title,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 11,
+                                  ),
+                                ),
+                              ),
+                              if (showStatus)
+                                _StatusBadge(text: meta!.status, color: accent),
+                            ],
+                          ),
+                          if (showTime)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 2),
+                              child: Row(
+                                children: [
+                                  const Icon(Icons.schedule,
+                                      size: 11, color: Colors.white60),
+                                  const SizedBox(width: 3),
+                                  Text(
+                                    _timeRange(entry.time),
+                                    style: const TextStyle(
+                                      color: Colors.white60,
+                                      fontSize: 9,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          if (showPlace)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 2),
+                              child: Text(
+                                meta!.place,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  color: Colors.white54,
+                                  fontSize: 9,
+                                ),
+                              ),
+                            ),
+                          if (showAvatars)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: _AvatarStack(
+                                key: ValueKey('pop-avatars-${entry.id}'),
+                                initials: meta!.attendees,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// `HH:MM–HH:MM` for the entry's start and computed end time.
+  static String _timeRange(PlannerTime time) {
+    String hhmm(int totalMinutes) {
+      final h = (totalMinutes ~/ 60) % 24;
+      final m = totalMinutes % 60;
+      return '${h.toString().padLeft(2, '0')}:${m.toString().padLeft(2, '0')}';
     }
 
-    return Scaffold(
-        appBar: AppBar(
-          // Here we take the value from the MyHomePage object that was created by
-          // the App.build method, and use it to set our appbar title.
-          title: Text(widget.title),
-        ),
-        body: Planner(
-          config: PlannerConfig(
-              minHour: 0,
-              maxHour: 23,
-              labels: [
-                "day 1",
-                "day 2",
-                "day 3",
-                "day 4",
-                "day 5",
-                "day 6",
-                "day 7",
-                "day 8",
-                "day 9",
-                "day 10"
-              ],
-              // Emphasize a column ("today" style). The widget is date-agnostic,
-              // so a real calendar would map DateTime.now() to this index itself.
-              highlightedColumn: 0,
-              //dateBackground: Colors.red,
-              //hourBackground: Colors.deepOrange,
-              onEntryMove: (entry) {
-                for (int i = 0; i < entries.length; i++) {
-                  if (dataEntries[i].id.toString() == entry.id) {
-                    dataEntries[i].day = entry.time.day;
-                    dataEntries[i].hour = entry.time.hour;
-                    dataEntries[i].minutes = entry.time.minutes;
-                    continue;
-                  }
-                }
-              },
-              onEntryEdit: (entry) {
-                debugPrint('entry: ' + entry.title);
-              },
-              onEntryCreate: (time) {
-                debugPrint(
-                    'day: ${time.day} hour: ${time.hour} minutes: ${time.minutes}');
-              },
-              onEntryDelete: (entry) {
-                debugPrint('deleting entry: ' + entry.title);
-              },
-              // The freed-up touch gesture (#66): the widget is presentation-
-              // only, so the host decides the response. A real app would show a
-              // selection UI / action sheet here.
-              onEntryLongPress: (entry) {
-                debugPrint('long-pressed entry: ' + entry.title);
-              }),
-          entries: entries,
-        )
-        // This trailing comma makes auto-formatting nicer for build methods.
-        );
+    final start = time.hour * 60 + time.minutes;
+    return '${hhmm(start)}–${hhmm(start + time.duration)}';
   }
+}
+
+/// A small status pill shown once the card clears the 56px tier.
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.text, required this.color});
+
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        style:
+            TextStyle(color: color, fontSize: 8, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}
+
+/// The attendee avatar stack, shown only in the tallest (≥92px) tier.
+class _AvatarStack extends StatelessWidget {
+  const _AvatarStack({super.key, required this.initials});
+
+  final List<String> initials;
+
+  @override
+  Widget build(BuildContext context) {
+    const maxShown = 3;
+    final shown = initials.take(maxShown).toList();
+    final extra = initials.length - shown.length;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final i in shown)
+          Padding(
+            padding: const EdgeInsets.only(right: 2),
+            child: _avatar(i, const Color(0xFF3A7BD5)),
+          ),
+        if (extra > 0) _avatar('+$extra', const Color(0xFF55607A)),
+      ],
+    );
+  }
+
+  Widget _avatar(String text, Color color) => Container(
+        width: 16,
+        height: 16,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        child: Text(
+          text,
+          style: const TextStyle(color: Colors.white, fontSize: 7),
+        ),
+      );
 }

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:planner/planner.dart';
 
+import 'package:example/data.dart';
 import 'package:example/main.dart';
 
 void main() {
@@ -16,8 +17,8 @@ void main() {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
 
-    // The demo renders a single Planner inside a 'Planner Demo' scaffold.
-    expect(find.byType(Planner), findsOneWidget);
+    // The demo renders a single typed Planner inside a 'Planner Demo' scaffold.
+    expect(find.byType(Planner<ActivityMeta>), findsOneWidget);
     expect(find.text('Planner Demo'), findsOneWidget);
 
     // Guard against the old counter template creeping back in.

--- a/test/public_api_test.dart
+++ b/test/public_api_test.dart
@@ -40,5 +40,55 @@ void main() {
       expect(config, isA<PlannerConfig>());
       expect(Planner.new, isA<Function>());
     });
+
+    test('PlannerController is reachable (#76)', () {
+      final controller = PlannerController();
+      addTearDown(controller.dispose);
+      // A freshly built controller isn't bound to any Planner yet.
+      expect(controller.isAttached, isFalse);
+      expect(controller, isA<ChangeNotifier>());
+    });
+
+    test('PlannerEntry<T>.data carries a typed payload (#77)', () {
+      final entry = PlannerEntry<int>(
+        id: 'a1',
+        time: PlannerTime(day: 0, hour: 8),
+        title: 'Stand-up',
+        content: '',
+        color: const Color(0xFF00FF00),
+        data: 42,
+      );
+      // `data` is typed `int?`, reachable with no cast.
+      expect(entry.data, 42);
+      expect(entry.copyWith(data: 7).data, 7);
+    });
+
+    test('the builder hook types are reachable (#78/#79/#80)', () {
+      // PlannerEntryLayout + DragType (#78).
+      const layout = PlannerEntryLayout(
+        size: Size(120, 40),
+        columnIndex: 0,
+        columnCount: 1,
+        isDragged: false,
+        dragType: DragType.none,
+        allDay: false,
+      );
+      expect(layout.size.height, 40);
+      expect(layout.allDay, isFalse);
+      expect(DragType.values, contains(DragType.body));
+
+      // The builder typedefs (#78/#80 share PlannerEntryBuilder; #79 has its own).
+      Widget entryBuilder(BuildContext context, PlannerEntry<int> entry,
+              PlannerEntryLayout l) =>
+          const SizedBox.shrink();
+      Widget headerBuilder(BuildContext context, int columnIndex, String label,
+              bool isHighlighted) =>
+          const SizedBox.shrink();
+      expect(entryBuilder, isA<PlannerEntryBuilder<int>>());
+      expect(headerBuilder, isA<PlannerDayHeaderBuilder>());
+
+      // The generic Planner constructor accepts the typed payload.
+      expect(Planner<int>.new, isA<Function>());
+    });
   });
 }


### PR DESCRIPTION
## Summary
Final step of the #75 deep-customization effort: rework the example app into the end-to-end showcase for all four customization hooks, and document them. The example doubles as the integration verification that the hooks work together.

## Linked issue
Closes #81

## Changes
- **`example/lib/main.dart`** — typed `Planner<ActivityMeta>` wiring all four hooks:
  - host AppBar zoom toolbar driving a `PlannerController` with `showZoomControls: false` (disables at bounds) — #76
  - branded, multi-part `dayHeaderBuilder` closing over a `CalendarWindow` for the date — #79
  - a "Pop Block" `entryBuilder` reading the typed `entry.data` and shedding detail by `layout.size.height` at 52/56/60/92 px — #77/#78
  - an `allDayEntryBuilder` chip — #80
  - overflow-safe via the package's own `OverflowBox`+`ClipRect` pattern
- **`example/lib/data.dart`** — replaced the old `DataEntry` with a typed `ActivityMeta` payload + `sampleEntries()` (deterministic column indices; timed + all-day).
- **`example/integration_test/example_hooks_scenarios.dart`** (new) — drives the real app: verifies all four hooks render together, and that the host button zooms the real grid while the Pop Block reveals its avatar tier at ≥92px. Registered in `app_test.dart`.
- **Test fixups** — `app_smoke`/`context_menu`/`widget_test` updated for the typed `Planner<ActivityMeta>` finder and the +28px all-day-band offset.
- **`test/public_api_test.dart`** — asserts the new umbrella exports (`PlannerController`, `PlannerEntry<T>.data`, `PlannerEntryLayout`, `DragType`, `PlannerEntryBuilder<T>`, `PlannerDayHeaderBuilder`).
- **Docs** — README ("Fully custom widgets" section + features/types tables), PROJECT_OVERVIEW (API map + roadmap), CHANGELOG (added the missing #77–#80 entries).

## Test plan
- [x] `flutter analyze` clean — package **and** example
- [x] unit/widget tests pass — `flutter test` (250) + example `flutter test test/` (1)
- [x] integration/e2e tests pass — `flutter test integration_test/app_test.dart -d windows` (51), including the two new #81 scenarios and the modified app-smoke/context-menu real-app scenarios
- [x] `dart format --output=none --set-exit-if-changed .` clean

## Notes / screenshots
The example app is itself the user-visible artifact and is covered end-to-end by the new `example_hooks_scenarios` driving the real entrypoint (real fonts, layout, gestures, zoom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)