### PR TITLE
docs: restructure the example into a gallery of progressive examples (#90)

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,16 +1,70 @@
-# example
+# planner examples
 
-A new Flutter project.
+A gallery of focused examples for the [`planner`](../) package, ordered basic →
+advanced. The app boots into a list ([`lib/main.dart`](lib/main.dart)); tap a row
+to open that example. Each page demonstrates **one** feature on its own; the
+final Showcase wires them all together.
 
-## Getting Started
+## Examples
 
-This project is a starting point for a Flutter application.
+| # | Example | Shows |
+|---|---------|-------|
+| 1 | [Basic](lib/examples/basic_example.dart) | A minimal `Planner` with the default look (painted titles, times, grid, all-day chips) and the `onEntry*` callbacks. The get-it-running starting point. |
+| 2 | [Typed data + entryBuilder](lib/examples/typed_data_example.dart) | A typed `PlannerEntry<ActivityMeta>` payload (#77) read back without a cast in an `entryBuilder` (#78) — a custom card that sheds detail by on-screen height. |
+| 3 | [Custom headers](lib/examples/custom_headers_example.dart) | A `CalendarWindow` (from `package:planner/calendar.dart`) feeding `dayHeaderBuilder` (#79) and a `highlightedColumn` "today" highlight. |
+| 4 | [All-day band](lib/examples/all_day_example.dart) | Opting the all-day band in (`showAllDayBand: true`, #48) and drawing custom chips with `allDayEntryBuilder` (#80). |
+| 5 | [Host zoom toolbar](lib/examples/host_zoom_example.dart) | Driving zoom from your own chrome via a `PlannerController` (#76), with the on-canvas buttons hidden (`showZoomControls: false`). |
+| 6 | [Week calendar](lib/examples/week_calendar_example.dart) | A real week with prev/next navigation built on `calendar.dart`: `CalendarWindow` stepping, `entriesFor`, and `todayColumn`. |
+| 7 | [Showcase](lib/examples/showcase_example.dart) | Every customization hook on one screen (#81): custom headers, an all-day band of custom chips, a custom-card event overlay, and a host zoom toolbar. |
 
-A few resources to get you started if this is your first Flutter project:
+The custom widgets shared across pages live in
+[`lib/widgets/`](lib/widgets/): the detail-shedding
+[`PopBlock`](lib/widgets/pop_block.dart) card, the branded
+[`DayHeader`](lib/widgets/day_header.dart), and the
+[`AllDayChip`](lib/widgets/all_day_chip.dart) pill. The sample data is in
+[`lib/data.dart`](lib/data.dart).
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+## A minimal planner
 
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+The smallest amount of code that gives you a working planner (see the Basic
+example for the runnable version):
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+Planner(
+  config: PlannerConfig(
+    labels: const ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+    onEntryCreate: (time) => debugPrint('create at ${time.day} ${time.hour}h'),
+  ),
+  entries: [
+    PlannerEntry(
+      id: 'standup',
+      time: PlannerTime(day: 0, hour: 9, duration: 45),
+      title: 'Team stand-up',
+      content: 'Daily sync',
+      color: Colors.blue,
+    ),
+  ],
+);
+```
+
+## Running
+
+```sh
+flutter run                 # pick a device when prompted
+flutter run -d windows      # or target one explicitly
+```
+
+## Tests
+
+End-to-end tests drive the real app on a device; see
+[`integration_test/README.md`](integration_test/README.md). The app-level
+scenarios open the Showcase page first (the gallery home has no planner of its
+own).
+
+```sh
+flutter test                                  # widget tests
+flutter test integration_test -d windows      # integration tests (what CI runs)
+```

--- a/example/integration_test/app_smoke_scenarios.dart
+++ b/example/integration_test/app_smoke_scenarios.dart
@@ -5,18 +5,23 @@ import 'package:planner/planner.dart';
 import 'package:example/data.dart';
 import 'package:example/main.dart' as app;
 
+import 'planner_harness.dart';
+
 /// Drives the *real* example app end-to-end (real entrypoint, real fonts, real
-/// layout, real gestures) on the device under test. Event titles and hour/day
-/// labels are painted on the CustomPaint canvas rather than rendered as Text
-/// widgets, so assertions target the things that are real widgets: the app bar
-/// and the context menu.
+/// layout, real gestures) on the device under test. `main.dart` boots a gallery
+/// home (#90), so each scenario opens the Showcase page first via
+/// [openShowcase]. Event titles and hour/day labels are painted on the
+/// CustomPaint canvas rather than rendered as Text widgets, so assertions target
+/// the things that are real widgets: the app bar and the context menu.
 ///
 /// Registered from [app_test.dart]; not a standalone entry point (desktop can
 /// only launch one app per `flutter test` invocation).
 void appSmokeScenarios() {
-  testWidgets('example app boots and renders a Planner', (tester) async {
+  testWidgets('example app boots and the Showcase renders a Planner',
+      (tester) async {
     app.main();
     await tester.pumpAndSettle();
+    await openShowcase(tester);
 
     expect(find.byType(Planner<ActivityMeta>), findsOneWidget);
     expect(find.text('Planner Demo'), findsOneWidget);
@@ -26,6 +31,7 @@ void appSmokeScenarios() {
       (tester) async {
     app.main();
     await tester.pumpAndSettle();
+    await openShowcase(tester);
 
     // An empty spot in column 0: +100px right (into the grid) and +120px down
     // from the grid top maps to hour 3, which the sample data leaves free

--- a/example/integration_test/context_menu_scenarios.dart
+++ b/example/integration_test/context_menu_scenarios.dart
@@ -5,11 +5,14 @@ import 'package:planner/planner.dart';
 import 'package:example/data.dart';
 import 'package:example/main.dart' as app;
 
+import 'planner_harness.dart';
+
 /// Drives the *real* example app end-to-end to cover the **entry** context menu
 /// (right-clicking an existing event), which the create-event smoke
-/// ([app_smoke_scenarios.dart]) does not exercise. The "Edit Event" /
-/// "Delete Event" items are real Text widgets, so the menu itself is assertable
-/// even though event titles are painted on the canvas.
+/// ([app_smoke_scenarios.dart]) does not exercise. `main.dart` boots a gallery
+/// home (#90), so it opens the Showcase page first via [openShowcase]. The
+/// "Edit Event" / "Delete Event" items are real Text widgets, so the menu itself
+/// is assertable even though event titles are painted on the canvas.
 ///
 /// Registered from [app_test.dart]; not a standalone entry point (desktop can
 /// only launch one app per `flutter test` invocation).
@@ -18,6 +21,7 @@ void contextMenuScenarios() {
       (tester) async {
     app.main();
     await tester.pumpAndSettle();
+    await openShowcase(tester);
 
     // The sample data's 'Stand-up' entry sits at day 0 / 08:00 for 60 min
     // (sampleEntries). With the default 200x40 grid that is grid rect

--- a/example/integration_test/example_hooks_scenarios.dart
+++ b/example/integration_test/example_hooks_scenarios.dart
@@ -5,10 +5,13 @@ import 'package:planner/planner.dart';
 
 import 'package:example/main.dart' as app;
 
+import 'planner_harness.dart';
+
 /// End-to-end verification that the *example app* wires all four customization
 /// hooks together (#81) — the integration check the docs/example issue exists
-/// for. It drives the **real** entrypoint (`app.main()`), so it exercises the
-/// hooks in real composition: a `dayHeaderBuilder` row above an all-day band of
+/// for. It drives the **real** entrypoint (`app.main()`) and opens the Showcase
+/// page (#90) via [openShowcase], so it exercises the hooks in real
+/// composition: a `dayHeaderBuilder` row above an all-day band of
 /// `allDayEntryBuilder` chips above the `entryBuilder` overlay, with zoom driven
 /// from the host's own `PlannerController` toolbar (the built-in controls
 /// hidden). Event titles/labels are real widgets here (the builders render real
@@ -21,6 +24,7 @@ void exampleHooksScenarios() {
       (tester) async {
     app.main();
     await tester.pumpAndSettle();
+    await openShowcase(tester);
 
     // The typed Planner<ActivityMeta> proves the generic payload (#77) is in use.
     expect(find.byType(Planner<ActivityMeta>), findsOneWidget);
@@ -47,6 +51,7 @@ void exampleHooksScenarios() {
       'height (#81)', (tester) async {
     app.main();
     await tester.pumpAndSettle();
+    await openShowcase(tester);
 
     // The 01:00 column-0 event ('Coffee & planning') stays near the top as the
     // grid zooms, so it visibly grows from a bare title to the full card.

--- a/example/integration_test/planner_harness.dart
+++ b/example/integration_test/planner_harness.dart
@@ -48,6 +48,21 @@ class PlannerSpec {
   final List<PlannerEntry> entries;
 }
 
+/// Navigates the gallery example app into the Showcase page (#90).
+///
+/// `main.dart` now boots a gallery home (a lazily-built list of example pages),
+/// so the app-level scenarios — which assert against the all-hooks Showcase —
+/// must open it first. Call right after `app.main()` and the initial
+/// `pumpAndSettle()`. The Showcase is the last row, so [scrollUntilVisible]
+/// scrolls it into view (and builds it) if the list is taller than the window,
+/// making this work at any device size.
+Future<void> openShowcase(WidgetTester tester) async {
+  final tile = find.byKey(const ValueKey('gallery-tile-showcase'));
+  await tester.scrollUntilVisible(tile, 120);
+  await tester.tap(tile);
+  await tester.pumpAndSettle();
+}
+
 /// A point inside a planner's event grid: skip the hour column (default 50) and
 /// the date row (default 50), then move +100px right / +[downFromGridTop] down
 /// so it lands cleanly in the grid. With the default `blockHeight` of 40, the

--- a/example/lib/examples/all_day_example.dart
+++ b/example/lib/examples/all_day_example.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+import '../data.dart';
+import '../widgets/all_day_chip.dart';
+
+/// The all-day band (#48) with fully custom chips (#80).
+///
+/// Setting [PlannerConfig.showAllDayBand] to `true` opts the band in: it appears
+/// above the time grid whenever there is at least one [PlannerTime.allDay]
+/// entry, and its chips become interactive and accessible. The
+/// [Planner.allDayEntryBuilder] then replaces the painted chips with the custom
+/// [AllDayChip] pills, reusing the same typed [ActivityMeta] payload (#77) for
+/// their accent colour. Timed events keep the package's default rendering, so
+/// the band is the star.
+class AllDayExample extends StatefulWidget {
+  const AllDayExample({super.key});
+
+  @override
+  State<AllDayExample> createState() => _AllDayExampleState();
+}
+
+class _AllDayExampleState extends State<AllDayExample> {
+  // Immutable entries (#27): a move replaces the matching one in place.
+  List<PlannerEntry<ActivityMeta>> _entries = sampleEntries();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('All-day band')),
+      body: Planner<ActivityMeta>(
+        config: PlannerConfig<ActivityMeta>(
+          labels: const ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+          minHour: 0,
+          maxHour: 23,
+          // Opt the band in (#48); it appears once there's an all-day entry.
+          showAllDayBand: true,
+          onEntryMove: (entry) => setState(() {
+            _entries = [
+              for (final e in _entries) e.id == entry.id ? entry : e,
+            ];
+          }),
+        ),
+        entries: _entries,
+        // Fully custom chips for the band (#80); timed events stay default.
+        allDayEntryBuilder: (context, entry, layout) =>
+            AllDayChip(entry: entry),
+      ),
+    );
+  }
+}

--- a/example/lib/examples/basic_example.dart
+++ b/example/lib/examples/basic_example.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+import '../data.dart';
+
+/// The get-it-running example: a minimal [Planner] with the **default** look.
+///
+/// Plain [PlannerEntry]s (no typed `data`, no custom builders) over a Mon–Fri
+/// set of column labels — the package paints the titles, times, grid and
+/// all-day chips itself, so the only styling is each entry's
+/// [PlannerEntry.color]. The `onEntry*` callbacks are wired so a drag commits a
+/// move (entries are immutable, #27) and the other interactions log.
+///
+/// This is the smallest amount of code that gives you a working planner; every
+/// other gallery page layers one feature on top of it.
+class BasicExample extends StatefulWidget {
+  const BasicExample({super.key});
+
+  @override
+  State<BasicExample> createState() => _BasicExampleState();
+}
+
+class _BasicExampleState extends State<BasicExample> {
+  // Immutable entries (#27): a move replaces the matching one in place.
+  List<PlannerEntry> _entries = basicEntries();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Basic')),
+      body: Planner(
+        config: PlannerConfig(
+          labels: const ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+          minHour: 7,
+          maxHour: 19,
+          // Enable the band so the single all-day entry has somewhere to show,
+          // still with the package's default (painted) chip — no custom builder.
+          showAllDayBand: true,
+          onEntryMove: (entry) => setState(() {
+            _entries = [
+              for (final e in _entries) e.id == entry.id ? entry : e,
+            ];
+          }),
+          onEntryEdit: (entry) => debugPrint('edit: ${entry.title}'),
+          onEntryCreate: (time) => debugPrint(
+              'create at day ${time.day} ${time.hour}:${time.minutes}'),
+          onEntryDelete: (entry) => debugPrint('delete: ${entry.title}'),
+        ),
+        entries: _entries,
+      ),
+    );
+  }
+}

--- a/example/lib/examples/custom_headers_example.dart
+++ b/example/lib/examples/custom_headers_example.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:planner/calendar.dart';
+import 'package:planner/planner.dart';
+
+import '../data.dart';
+import '../widgets/day_header.dart';
+
+/// Custom day/column headers (#79) over a real week.
+///
+/// The package stays date-agnostic — a `day` is just an index into
+/// `config.labels` (ADR 0001) — so this page owns the `date ↔ column` mapping
+/// with a [CalendarWindow] from `package:planner/calendar.dart`. The window
+/// supplies the [PlannerConfig.labels] and the [PlannerConfig.highlightedColumn]
+/// for "today", and the [Planner.dayHeaderBuilder] closes over it to recover
+/// each column's [DateTime] and render the branded [DayHeader]. Events render in
+/// the package's default style — the focus here is the header row.
+class CustomHeadersExample extends StatelessWidget {
+  const CustomHeadersExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // The current week, snapped to its Monday.
+    final window = CalendarWindow.week(anchor: DateTime.now());
+    return Scaffold(
+      appBar: AppBar(title: const Text('Custom headers')),
+      body: Planner<ActivityMeta>(
+        config: PlannerConfig<ActivityMeta>(
+          labels: window.labels(),
+          minHour: 0,
+          maxHour: 23,
+          // The window maps today to its column (null when today is off-week).
+          highlightedColumn: window.todayColumn,
+        ),
+        entries: sampleEntries(),
+        // Recover the real date for the column and render the branded header;
+        // `isHighlighted` flags the today column above.
+        dayHeaderBuilder: (context, columnIndex, label, isHighlighted) =>
+            DayHeader(
+          date: window.dateAt(columnIndex),
+          highlighted: isHighlighted,
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/examples/host_zoom_example.dart
+++ b/example/lib/examples/host_zoom_example.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+import '../data.dart';
+
+/// Host-driven zoom (#76): the planner's own zoom is replaced by the app's
+/// chrome.
+///
+/// A [PlannerController] is constructed by the host, handed to the
+/// `Planner(controller: ...)`, and driven from the app-bar toolbar's +/−
+/// buttons. Pairing it with [PlannerConfig.showZoomControls] `= false` hides the
+/// built-in on-canvas buttons, so the toolbar is the only zoom UI (pinch and
+/// Ctrl+wheel still work). The controller is a [ChangeNotifier], so the toolbar
+/// rebuilds to disable a button once zoom reaches a bound — guard reads on
+/// [PlannerController.isAttached], since the getters throw before the planner
+/// attaches.
+class HostZoomExample extends StatefulWidget {
+  const HostZoomExample({super.key});
+
+  @override
+  State<HostZoomExample> createState() => _HostZoomExampleState();
+}
+
+class _HostZoomExampleState extends State<HostZoomExample> {
+  final PlannerController _controller = PlannerController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Host zoom toolbar'),
+        actions: [
+          AnimatedBuilder(
+            animation: _controller,
+            builder: (context, _) {
+              final atMin = _controller.isAttached &&
+                  _controller.zoom <= _controller.minZoom;
+              final atMax = _controller.isAttached &&
+                  _controller.zoom >= _controller.maxZoom;
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    tooltip: 'Zoom out',
+                    icon: const Icon(Icons.zoom_out),
+                    onPressed: atMin ? null : _controller.zoomOut,
+                  ),
+                  IconButton(
+                    tooltip: 'Zoom in',
+                    icon: const Icon(Icons.zoom_in),
+                    onPressed: atMax ? null : _controller.zoomIn,
+                  ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+      body: Planner(
+        controller: _controller,
+        config: PlannerConfig(
+          labels: const ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+          minHour: 7,
+          maxHour: 19,
+          // Hand zoom entirely to the host toolbar above.
+          showZoomControls: false,
+        ),
+        entries: basicEntries(),
+      ),
+    );
+  }
+}

--- a/example/lib/examples/showcase_example.dart
+++ b/example/lib/examples/showcase_example.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:planner/calendar.dart';
+import 'package:planner/planner.dart';
+
+import '../data.dart';
+import '../widgets/all_day_chip.dart';
+import '../widgets/day_header.dart';
+import '../widgets/pop_block.dart';
+
+/// The full showcase: every customization hook wired together on one screen
+/// (#81). A [dayHeaderBuilder] row above an all-day band of [allDayEntryBuilder]
+/// chips above an [entryBuilder] overlay of detail-shedding [PopBlock]s, with
+/// zoom driven from the host's own [PlannerController] toolbar (the on-canvas
+/// controls hidden via `showZoomControls: false`).
+///
+/// This is the relocated original single-screen demo; the gallery's other pages
+/// break these same hooks out one at a time. Its [ValueKey]s (`pop-block-*`,
+/// `pop-avatars-*`, `day-header-*`, `all-day-chip-*`, `demo-zoom-*`) and the
+/// `Planner Demo` title are pinned by the integration suite.
+class ShowcaseExample extends StatefulWidget {
+  const ShowcaseExample({super.key});
+
+  @override
+  State<ShowcaseExample> createState() => _ShowcaseExampleState();
+}
+
+class _ShowcaseExampleState extends State<ShowcaseExample> {
+  // Drives zoom from the host's own toolbar (#76). The built-in on-canvas
+  // buttons are hidden via `showZoomControls: false` below, so this is the only
+  // way to zoom besides pinch / Ctrl+wheel.
+  final PlannerController _controller = PlannerController();
+
+  // The week shown, snapped to its Monday. The `dayHeaderBuilder` closes over
+  // this to turn a column index into its real date — the package itself stays
+  // date-agnostic (ADR 0001), so no `DateTime` enters its API.
+  final CalendarWindow _window = CalendarWindow.week(anchor: DateTime.now());
+
+  // The entries are immutable (#27); a move replaces the matching one in place.
+  List<PlannerEntry<ActivityMeta>> _entries = sampleEntries();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Planner Demo'),
+        // The host's own zoom toolbar (#76). It listens to the controller so the
+        // buttons disable once zoom hits a bound; the controller's read getters
+        // throw before the planner has attached, so guard on `isAttached`.
+        actions: [
+          AnimatedBuilder(
+            animation: _controller,
+            builder: (context, _) {
+              final atMin = _controller.isAttached &&
+                  _controller.zoom <= _controller.minZoom;
+              final atMax = _controller.isAttached &&
+                  _controller.zoom >= _controller.maxZoom;
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    key: const ValueKey('demo-zoom-out'),
+                    tooltip: 'Zoom out',
+                    icon: const Icon(Icons.zoom_out),
+                    onPressed: atMin ? null : _controller.zoomOut,
+                  ),
+                  IconButton(
+                    key: const ValueKey('demo-zoom-in'),
+                    tooltip: 'Zoom in',
+                    icon: const Icon(Icons.zoom_in),
+                    onPressed: atMax ? null : _controller.zoomIn,
+                  ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+      body: Planner<ActivityMeta>(
+        controller: _controller,
+        config: PlannerConfig<ActivityMeta>(
+          // Week-style headers, one label per column. The builder below ignores
+          // the painted label and renders its own multi-part header instead.
+          labels: _window.labels(),
+          minHour: 0,
+          maxHour: 23,
+          // Hand zoom to the host toolbar above.
+          showZoomControls: false,
+          // Show the all-day band so the custom chips have somewhere to live.
+          showAllDayBand: true,
+          // Emphasize today's column ("today" style); null off-week.
+          highlightedColumn: _window.todayColumn,
+          onEntryMove: (entry) => setState(() {
+            _entries = [
+              for (final e in _entries) e.id == entry.id ? entry : e,
+            ];
+          }),
+          onEntryEdit: (entry) => debugPrint('edit: ${entry.title}'),
+          onEntryCreate: (time) => debugPrint(
+              'create at day ${time.day} ${time.hour}:${time.minutes}'),
+          onEntryDelete: (entry) => debugPrint('delete: ${entry.title}'),
+          // Presentation-only: the host decides what a long-press does (#66).
+          onEntryLongPress: (entry) => debugPrint('long-press: ${entry.title}'),
+        ),
+        entries: _entries,
+        // #79 — a branded, multi-part header per column. It reads the real date
+        // from the closed-over CalendarWindow; `isHighlighted` flags today.
+        dayHeaderBuilder: (context, columnIndex, label, isHighlighted) =>
+            DayHeader(
+          key: ValueKey('day-header-$columnIndex'),
+          date: _window.dateAt(columnIndex),
+          highlighted: isHighlighted,
+        ),
+        // #78 — fully custom timed-event widgets, reading the typed `entry.data`
+        // and shedding detail by on-screen pixel height.
+        entryBuilder: (context, entry, layout) => PopBlock(
+          key: ValueKey('pop-block-${entry.id}'),
+          entry: entry,
+          layout: layout,
+        ),
+        // #80 — fully custom all-day chips, same typed payload.
+        allDayEntryBuilder: (context, entry, layout) => AllDayChip(
+          key: ValueKey('all-day-chip-${entry.id}'),
+          entry: entry,
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/examples/typed_data_example.dart
+++ b/example/lib/examples/typed_data_example.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+import '../data.dart';
+import '../widgets/pop_block.dart';
+
+/// Typed payloads (#77) + a custom timed-event widget (#78).
+///
+/// The entries are `PlannerEntry<ActivityMeta>`, so each carries an app-domain
+/// [ActivityMeta] on `entry.data` that the package threads through untouched.
+/// The [Planner.entryBuilder] reads it back **already typed** — no cast, no
+/// side-map keyed by id — to render the [PopBlock], a card that sheds detail by
+/// its on-screen pixel height. Zoom in (pinch / Ctrl+wheel / the on-canvas
+/// buttons) and watch the small cards reveal place, status, time, then the
+/// attendee avatar stack as they grow.
+class TypedDataExample extends StatefulWidget {
+  const TypedDataExample({super.key});
+
+  @override
+  State<TypedDataExample> createState() => _TypedDataExampleState();
+}
+
+class _TypedDataExampleState extends State<TypedDataExample> {
+  // Immutable entries (#27): a move replaces the matching one in place.
+  List<PlannerEntry<ActivityMeta>> _entries = sampleEntries();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Typed data + entryBuilder')),
+      body: Planner<ActivityMeta>(
+        config: PlannerConfig<ActivityMeta>(
+          labels: const ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+          minHour: 0,
+          maxHour: 23,
+          onEntryMove: (entry) => setState(() {
+            _entries = [
+              for (final e in _entries) e.id == entry.id ? entry : e,
+            ];
+          }),
+          onEntryEdit: (entry) => debugPrint('edit: ${entry.title}'),
+        ),
+        entries: _entries,
+        // The typed payload comes back without a cast (#77/#78).
+        entryBuilder: (context, entry, layout) =>
+            PopBlock(entry: entry, layout: layout),
+      ),
+    );
+  }
+}

--- a/example/lib/examples/week_calendar_example.dart
+++ b/example/lib/examples/week_calendar_example.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:planner/calendar.dart';
+import 'package:planner/planner.dart';
+
+/// A real week calendar built on `package:planner/calendar.dart`.
+///
+/// The package itself never sees a `DateTime` (ADR 0001); a [CalendarWindow]
+/// owns the whole `date ↔ column` bridge. This page holds the current window as
+/// state and steps it with [CalendarWindow.previous] / [CalendarWindow.next] for
+/// prev/next-week navigation. Each build derives the widget inputs from the
+/// window: [CalendarWindow.labels] for the headers, [CalendarWindow.todayColumn]
+/// for the "today" highlight, and [CalendarWindow.entriesFor] to turn the host's
+/// own dated events into `PlannerEntry`s — dropping any outside the visible week.
+class WeekCalendarExample extends StatefulWidget {
+  const WeekCalendarExample({super.key});
+
+  @override
+  State<WeekCalendarExample> createState() => _WeekCalendarExampleState();
+}
+
+class _WeekCalendarExampleState extends State<WeekCalendarExample> {
+  // The visible week, snapped to its Monday; stepped by the prev/next buttons.
+  CalendarWindow _window = CalendarWindow.week(anchor: DateTime.now());
+
+  // The host's own dated events — a plain domain model the package knows
+  // nothing about. `entriesFor` maps the ones inside the current week onto
+  // columns; anchoring to this week's Monday keeps the initial view populated.
+  late final List<_Meeting> _meetings = _sampleMeetings();
+
+  static List<_Meeting> _sampleMeetings() {
+    final monday = CalendarWindow.week(anchor: DateTime.now()).start;
+    DateTime at(int dayOffset, int hour, [int minute = 0]) =>
+        monday.add(Duration(days: dayOffset, hours: hour, minutes: minute));
+    return [
+      _Meeting('Sprint kickoff', at(0, 9), const Duration(minutes: 90),
+          const Color(0xFF3A7BD5)),
+      _Meeting('Design sync', at(1, 11), const Duration(hours: 1),
+          const Color(0xFF12A594)),
+      _Meeting('1:1 with Sam', at(2, 14), const Duration(minutes: 30),
+          const Color(0xFFE5484D)),
+      _Meeting('Workshop', at(3, 10), const Duration(hours: 2),
+          const Color(0xFFD9730D)),
+      _Meeting('Sprint demo', at(4, 16), const Duration(hours: 1),
+          const Color(0xFF8E4EC6)),
+      // Two events one week out, so "next" isn't an empty grid.
+      _Meeting('Planning', at(7, 10), const Duration(hours: 1),
+          const Color(0xFF3A7BD5)),
+      _Meeting('Review', at(9, 13), const Duration(hours: 1),
+          const Color(0xFF12A594)),
+    ];
+  }
+
+  static const _months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', //
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+
+  String _label(DateTime d) => '${_months[d.month - 1]} ${d.day}';
+
+  @override
+  Widget build(BuildContext context) {
+    // Build this week's column entries from the dated model. `entriesFor` drops
+    // events whose start date falls outside the window, so stepping weeks shows
+    // only that week's events.
+    final entries = _window.entriesFor<_Meeting>(
+      _meetings,
+      start: (m) => m.start,
+      duration: (m) => m.duration,
+      build: (m, time) => PlannerEntry(
+        id: m.title,
+        time: time,
+        title: m.title,
+        content: '',
+        color: m.color,
+      ),
+    );
+
+    final first = _window.dates.first;
+    final last = _window.dates.last;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${_label(first)} – ${_label(last)}'),
+        actions: [
+          IconButton(
+            tooltip: 'Previous week',
+            icon: const Icon(Icons.chevron_left),
+            onPressed: () => setState(() => _window = _window.previous),
+          ),
+          IconButton(
+            tooltip: 'Next week',
+            icon: const Icon(Icons.chevron_right),
+            onPressed: () => setState(() => _window = _window.next),
+          ),
+          IconButton(
+            tooltip: 'Today',
+            icon: const Icon(Icons.today),
+            onPressed: () => setState(
+                () => _window = CalendarWindow.week(anchor: DateTime.now())),
+          ),
+        ],
+      ),
+      body: Planner(
+        config: PlannerConfig(
+          labels: _window.labels(),
+          minHour: 7,
+          maxHour: 19,
+          // The window maps today to its column (null when today is off-week).
+          highlightedColumn: _window.todayColumn,
+        ),
+        entries: entries,
+      ),
+    );
+  }
+}
+
+/// A plain dated event in the host's own model — the package never sees this
+/// type; [CalendarWindow.entriesFor] maps it onto planner columns.
+class _Meeting {
+  const _Meeting(this.title, this.start, this.duration, this.color);
+
+  final String title;
+  final DateTime start;
+  final Duration duration;
+  final Color color;
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,12 @@
-import 'package:example/data.dart';
 import 'package:flutter/material.dart';
-import 'package:planner/calendar.dart';
-import 'package:planner/planner.dart';
+
+import 'examples/all_day_example.dart';
+import 'examples/basic_example.dart';
+import 'examples/custom_headers_example.dart';
+import 'examples/host_zoom_example.dart';
+import 'examples/showcase_example.dart';
+import 'examples/typed_data_example.dart';
+import 'examples/week_calendar_example.dart';
 
 void main() {
   runApp(const MyApp());
@@ -13,437 +18,114 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Planner Examples',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
       ),
-      home: const MyHomePage(title: 'Planner Demo'),
+      home: const GalleryHome(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+/// One row in the gallery: a title, a one-line description, and the page it
+/// opens. The [id] is also the suffix of the row's `ValueKey`, so finders can
+/// target a specific example.
+class _Example {
+  const _Example({
+    required this.id,
+    required this.title,
+    required this.subtitle,
+    required this.page,
+  });
 
+  final String id;
   final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  final String subtitle;
+  final Widget page;
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  // Drives zoom from the host's own toolbar (#76). The built-in on-canvas
-  // buttons are hidden via `showZoomControls: false` below, so this is the only
-  // way to zoom besides pinch / Ctrl+wheel.
-  final PlannerController _controller = PlannerController();
+/// The gallery home: a list of focused example pages, ordered basic → complex,
+/// each demonstrating one feature of the planner on its own. Tapping a row
+/// pushes that page; the final showcase combines every customization hook.
+class GalleryHome extends StatelessWidget {
+  const GalleryHome({super.key});
 
-  // The week shown, snapped to its Monday. The `dayHeaderBuilder` closes over
-  // this to turn a column index into its real date — the package itself stays
-  // date-agnostic (ADR 0001), so no `DateTime` enters its API.
-  final CalendarWindow _window = CalendarWindow.week(anchor: DateTime.now());
-
-  // The entries are immutable (#27); a move replaces the matching one in place.
-  List<PlannerEntry<ActivityMeta>> _entries = sampleEntries();
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-        // The host's own zoom toolbar (#76). It listens to the controller so the
-        // buttons disable once zoom hits a bound; the controller's read getters
-        // throw before the planner has attached, so guard on `isAttached`.
-        actions: [
-          AnimatedBuilder(
-            animation: _controller,
-            builder: (context, _) {
-              final atMin = _controller.isAttached &&
-                  _controller.zoom <= _controller.minZoom;
-              final atMax = _controller.isAttached &&
-                  _controller.zoom >= _controller.maxZoom;
-              return Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    key: const ValueKey('demo-zoom-out'),
-                    tooltip: 'Zoom out',
-                    icon: const Icon(Icons.zoom_out),
-                    onPressed: atMin ? null : _controller.zoomOut,
-                  ),
-                  IconButton(
-                    key: const ValueKey('demo-zoom-in'),
-                    tooltip: 'Zoom in',
-                    icon: const Icon(Icons.zoom_in),
-                    onPressed: atMax ? null : _controller.zoomIn,
-                  ),
-                ],
-              );
-            },
-          ),
-        ],
-      ),
-      body: Planner<ActivityMeta>(
-        controller: _controller,
-        config: PlannerConfig<ActivityMeta>(
-          // Week-style headers, one label per column. The builder below ignores
-          // the painted label and renders its own multi-part header instead.
-          labels: _window.labels(),
-          minHour: 0,
-          maxHour: 23,
-          // Hand zoom to the host toolbar above.
-          showZoomControls: false,
-          // Show the all-day band so the custom chips have somewhere to live.
-          showAllDayBand: true,
-          // Emphasize today's column ("today" style); null off-week.
-          highlightedColumn: _window.todayColumn,
-          onEntryMove: (entry) => setState(() {
-            _entries = [
-              for (final e in _entries) e.id == entry.id ? entry : e,
-            ];
-          }),
-          onEntryEdit: (entry) => debugPrint('edit: ${entry.title}'),
-          onEntryCreate: (time) => debugPrint(
-              'create at day ${time.day} ${time.hour}:${time.minutes}'),
-          onEntryDelete: (entry) => debugPrint('delete: ${entry.title}'),
-          // Presentation-only: the host decides what a long-press does (#66).
-          onEntryLongPress: (entry) => debugPrint('long-press: ${entry.title}'),
-        ),
-        entries: _entries,
-        // #79 — a branded, multi-part header per column. It reads the real date
-        // from the closed-over CalendarWindow; `isHighlighted` flags today.
-        dayHeaderBuilder: (context, columnIndex, label, isHighlighted) =>
-            _DayHeader(
-          key: ValueKey('day-header-$columnIndex'),
-          date: _window.dateAt(columnIndex),
-          highlighted: isHighlighted,
-        ),
-        // #78 — fully custom timed-event widgets, reading the typed `entry.data`
-        // and shedding detail by on-screen pixel height.
-        entryBuilder: _buildPopBlock,
-        // #80 — fully custom all-day chips, same typed payload.
-        allDayEntryBuilder: _buildAllDayChip,
-      ),
-    );
-  }
-
-  /// The "Pop Block" (#78): a fully custom timed-event widget that reads the
-  /// typed [PlannerEntry.data] (#77) and **sheds detail by pixel height** —
-  /// `layout.size.height` is the event's live on-screen height, so as you zoom
-  /// the same event reveals more. Thresholds: place ≥52, status ≥56, time ≥60,
-  /// avatar stack ≥92.
-  Widget _buildPopBlock(
-    BuildContext context,
-    PlannerEntry<ActivityMeta> entry,
-    PlannerEntryLayout layout,
-  ) =>
-      _PopBlock(
-        key: ValueKey('pop-block-${entry.id}'),
-        entry: entry,
-        layout: layout,
-      );
-
-  /// A fully custom all-day chip (#80). Reuses the typed payload for its accent
-  /// colour; `layout.allDay` is `true` here, so a single builder wired to both
-  /// hooks could branch on it instead.
-  Widget _buildAllDayChip(
-    BuildContext context,
-    PlannerEntry<ActivityMeta> entry,
-    PlannerEntryLayout layout,
-  ) {
-    final accent = entry.data?.type.color ?? entry.color;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 3),
-      child: Container(
-        key: ValueKey('all-day-chip-${entry.id}'),
-        decoration: BoxDecoration(
-          color: accent,
-          borderRadius: BorderRadius.circular(10),
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        alignment: Alignment.centerLeft,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.event, size: 11, color: Colors.white),
-            const SizedBox(width: 4),
-            Flexible(
-              child: Text(
-                entry.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 10,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// A branded, multi-part day/column header (#79): the weekday in a small caps
-/// style above a large day number, tinted when it's today. Built from a real
-/// `DateTime` the host recovered from its `CalendarWindow`.
-class _DayHeader extends StatelessWidget {
-  const _DayHeader({super.key, required this.date, required this.highlighted});
-
-  final DateTime date;
-  final bool highlighted;
-
-  static const _weekdays = [
-    'MON',
-    'TUE',
-    'WED',
-    'THU',
-    'FRI',
-    'SAT',
-    'SUN',
+  static const List<_Example> _examples = [
+    _Example(
+      id: 'basic',
+      title: 'Basic',
+      subtitle: 'Minimal planner with the default look and onEntry* callbacks.',
+      page: BasicExample(),
+    ),
+    _Example(
+      id: 'typed-data',
+      title: 'Typed data + entryBuilder',
+      subtitle:
+          'Carry a typed payload (#77) and draw a custom event card (#78).',
+      page: TypedDataExample(),
+    ),
+    _Example(
+      id: 'custom-headers',
+      title: 'Custom headers',
+      subtitle: 'A CalendarWindow + dayHeaderBuilder with a "today" highlight.',
+      page: CustomHeadersExample(),
+    ),
+    _Example(
+      id: 'all-day',
+      title: 'All-day band',
+      subtitle: 'Enable the all-day band and draw custom chips (#48 / #80).',
+      page: AllDayExample(),
+    ),
+    _Example(
+      id: 'host-zoom',
+      title: 'Host zoom toolbar',
+      subtitle:
+          'Drive zoom from your own chrome via a PlannerController (#76).',
+      page: HostZoomExample(),
+    ),
+    _Example(
+      id: 'week-calendar',
+      title: 'Week calendar',
+      subtitle: 'A real week with prev/next navigation built on calendar.dart.',
+      page: WeekCalendarExample(),
+    ),
+    _Example(
+      id: 'showcase',
+      title: 'Showcase',
+      subtitle: 'Every customization hook wired together on one screen (#81).',
+      page: ShowcaseExample(),
+    ),
   ];
 
   @override
   Widget build(BuildContext context) {
-    final fg = highlighted ? Colors.white : Colors.black87;
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 3, vertical: 4),
-      decoration: BoxDecoration(
-        color: highlighted ? const Color(0xFF3A7BD5) : Colors.transparent,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      // OverflowBox + ClipRect lets the stacked text lay out at its natural
-      // height and be trimmed rather than throw an overflow when a cell is short
-      // (mirrors how the package lays the header row out).
-      child: ClipRect(
-        child: OverflowBox(
-          minHeight: 0,
-          maxHeight: double.infinity,
-          alignment: Alignment.center,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                _weekdays[date.weekday - 1],
-                style: TextStyle(
-                  fontSize: 9,
-                  letterSpacing: 1.5,
-                  fontWeight: FontWeight.w600,
-                  color: highlighted ? Colors.white70 : Colors.black54,
-                ),
-              ),
-              Text(
-                '${date.day}',
-                style: TextStyle(
-                  fontSize: 16,
-                  height: 1.1,
-                  fontWeight: FontWeight.bold,
-                  color: fg,
-                ),
-              ),
-            ],
+    return Scaffold(
+      appBar: AppBar(title: const Text('Planner Examples')),
+      body: ListView(
+        children: [
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              'A gallery of focused examples, basic to advanced. Each page shows '
+              'one feature of the planner on its own; the final Showcase combines '
+              'them all.',
+            ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-/// The Pop Block widget itself: a dark card with a type-coloured left bar and a
-/// hard-offset shadow, revealing more of the entry's metadata as it grows.
-class _PopBlock extends StatelessWidget {
-  const _PopBlock({super.key, required this.entry, required this.layout});
-
-  final PlannerEntry<ActivityMeta> entry;
-  final PlannerEntryLayout layout;
-
-  @override
-  Widget build(BuildContext context) {
-    final meta = entry.data;
-    final h = layout.size.height;
-    final accent = meta?.type.color ?? entry.color;
-
-    final showPlace = h >= 52 && (meta?.place.isNotEmpty ?? false);
-    final showStatus = h >= 56 && (meta?.status.isNotEmpty ?? false);
-    final showTime = h >= 60;
-    final showAvatars = h >= 92 && (meta?.attendees.isNotEmpty ?? false);
-
-    return Padding(
-      padding: const EdgeInsets.all(2),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: const Color(0xFF1F2430),
-          borderRadius: BorderRadius.circular(6),
-          boxShadow: const [
-            BoxShadow(color: Color(0x55000000), offset: Offset(3, 3)),
+          const Divider(height: 1),
+          for (final example in _examples) ...[
+            ListTile(
+              key: ValueKey('gallery-tile-${example.id}'),
+              title: Text(example.title),
+              subtitle: Text(example.subtitle),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => example.page),
+              ),
+            ),
+            const Divider(height: 1),
           ],
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(6),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // The type-coloured left bar.
-              Container(width: 4, color: accent),
-              Expanded(
-                child: ClipRect(
-                  child: OverflowBox(
-                    minHeight: 0,
-                    maxHeight: double.infinity,
-                    alignment: Alignment.topLeft,
-                    child: Padding(
-                      padding: const EdgeInsets.all(4),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  entry.title,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 11,
-                                  ),
-                                ),
-                              ),
-                              if (showStatus)
-                                _StatusBadge(text: meta!.status, color: accent),
-                            ],
-                          ),
-                          if (showTime)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 2),
-                              child: Row(
-                                children: [
-                                  const Icon(Icons.schedule,
-                                      size: 11, color: Colors.white60),
-                                  const SizedBox(width: 3),
-                                  Text(
-                                    _timeRange(entry.time),
-                                    style: const TextStyle(
-                                      color: Colors.white60,
-                                      fontSize: 9,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          if (showPlace)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 2),
-                              child: Text(
-                                meta!.place,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
-                                  color: Colors.white54,
-                                  fontSize: 9,
-                                ),
-                              ),
-                            ),
-                          if (showAvatars)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 4),
-                              child: _AvatarStack(
-                                key: ValueKey('pop-avatars-${entry.id}'),
-                                initials: meta!.attendees,
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+        ],
       ),
     );
   }
-
-  /// `HH:MM–HH:MM` for the entry's start and computed end time.
-  static String _timeRange(PlannerTime time) {
-    String hhmm(int totalMinutes) {
-      final h = (totalMinutes ~/ 60) % 24;
-      final m = totalMinutes % 60;
-      return '${h.toString().padLeft(2, '0')}:${m.toString().padLeft(2, '0')}';
-    }
-
-    final start = time.hour * 60 + time.minutes;
-    return '${hhmm(start)}–${hhmm(start + time.duration)}';
-  }
-}
-
-/// A small status pill shown once the card clears the 56px tier.
-class _StatusBadge extends StatelessWidget {
-  const _StatusBadge({required this.text, required this.color});
-
-  final String text;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.25),
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: Text(
-        text,
-        style:
-            TextStyle(color: color, fontSize: 8, fontWeight: FontWeight.w600),
-      ),
-    );
-  }
-}
-
-/// The attendee avatar stack, shown only in the tallest (≥92px) tier.
-class _AvatarStack extends StatelessWidget {
-  const _AvatarStack({super.key, required this.initials});
-
-  final List<String> initials;
-
-  @override
-  Widget build(BuildContext context) {
-    const maxShown = 3;
-    final shown = initials.take(maxShown).toList();
-    final extra = initials.length - shown.length;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (final i in shown)
-          Padding(
-            padding: const EdgeInsets.only(right: 2),
-            child: _avatar(i, const Color(0xFF3A7BD5)),
-          ),
-        if (extra > 0) _avatar('+$extra', const Color(0xFF55607A)),
-      ],
-    );
-  }
-
-  Widget _avatar(String text, Color color) => Container(
-        width: 16,
-        height: 16,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-        child: Text(
-          text,
-          style: const TextStyle(color: Colors.white, fontSize: 7),
-        ),
-      );
 }

--- a/example/lib/widgets/all_day_chip.dart
+++ b/example/lib/widgets/all_day_chip.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+import '../data.dart';
+
+/// A fully custom all-day chip for an [Planner.allDayEntryBuilder] (#80): a
+/// rounded pill filled with the entry's type accent and a small event icon.
+///
+/// Reuses the same typed [PlannerEntry.data] ([ActivityMeta], #77) as the timed
+/// [PopBlock] for its colour. The supplied [PlannerEntryLayout] carries
+/// `allDay: true`, so a host could wire one builder to both the timed and
+/// all-day hooks and branch on it; this example keeps them as two focused
+/// widgets.
+///
+/// Shared across the all-day and showcase example pages.
+class AllDayChip extends StatelessWidget {
+  const AllDayChip({super.key, required this.entry});
+
+  final PlannerEntry<ActivityMeta> entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = entry.data?.type.color ?? entry.color;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 3),
+      child: Container(
+        decoration: BoxDecoration(
+          color: accent,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        alignment: Alignment.centerLeft,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.event, size: 11, color: Colors.white),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                entry.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/day_header.dart
+++ b/example/lib/widgets/day_header.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+/// A branded, multi-part day/column header for a [Planner.dayHeaderBuilder]
+/// (#79): the weekday in a small-caps style above a large day number, tinted
+/// when it's today.
+///
+/// The package stays date-agnostic (ADR 0001) — its builder hands back only a
+/// column index, label and `isHighlighted` flag — so the host recovers the real
+/// [DateTime] from its own `CalendarWindow` and passes it here for display.
+///
+/// Shared across the custom-headers and showcase example pages.
+class DayHeader extends StatelessWidget {
+  const DayHeader({super.key, required this.date, required this.highlighted});
+
+  final DateTime date;
+  final bool highlighted;
+
+  static const _weekdays = [
+    'MON',
+    'TUE',
+    'WED',
+    'THU',
+    'FRI',
+    'SAT',
+    'SUN',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = highlighted ? Colors.white : Colors.black87;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 3, vertical: 4),
+      decoration: BoxDecoration(
+        color: highlighted ? const Color(0xFF3A7BD5) : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      // OverflowBox + ClipRect lets the stacked text lay out at its natural
+      // height and be trimmed rather than throw an overflow when a cell is short
+      // (mirrors how the package lays the header row out).
+      child: ClipRect(
+        child: OverflowBox(
+          minHeight: 0,
+          maxHeight: double.infinity,
+          alignment: Alignment.center,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                _weekdays[date.weekday - 1],
+                style: TextStyle(
+                  fontSize: 9,
+                  letterSpacing: 1.5,
+                  fontWeight: FontWeight.w600,
+                  color: highlighted ? Colors.white70 : Colors.black54,
+                ),
+              ),
+              Text(
+                '${date.day}',
+                style: TextStyle(
+                  fontSize: 16,
+                  height: 1.1,
+                  fontWeight: FontWeight.bold,
+                  color: fg,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/pop_block.dart
+++ b/example/lib/widgets/pop_block.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:planner/planner.dart';
+
+import '../data.dart';
+
+/// A fully custom timed-event widget for an [Planner.entryBuilder] (#78): a dark
+/// card with a type-coloured left bar and a hard-offset shadow that **sheds
+/// detail by pixel height**.
+///
+/// [PlannerEntryLayout.size]`.height` is the event's live on-screen height, so
+/// as the grid zooms the same event reveals more: place ≥52, status ≥56, time
+/// ≥60, the attendee avatar stack ≥92. It reads the typed [PlannerEntry.data]
+/// ([ActivityMeta], #77) for its accent colour and metadata — no cast, no
+/// side-map keyed by id.
+///
+/// Shared across the typed-data and showcase example pages.
+class PopBlock extends StatelessWidget {
+  const PopBlock({super.key, required this.entry, required this.layout});
+
+  final PlannerEntry<ActivityMeta> entry;
+  final PlannerEntryLayout layout;
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = entry.data;
+    final h = layout.size.height;
+    final accent = meta?.type.color ?? entry.color;
+
+    final showPlace = h >= 52 && (meta?.place.isNotEmpty ?? false);
+    final showStatus = h >= 56 && (meta?.status.isNotEmpty ?? false);
+    final showTime = h >= 60;
+    final showAvatars = h >= 92 && (meta?.attendees.isNotEmpty ?? false);
+
+    return Padding(
+      padding: const EdgeInsets.all(2),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: const Color(0xFF1F2430),
+          borderRadius: BorderRadius.circular(6),
+          boxShadow: const [
+            BoxShadow(color: Color(0x55000000), offset: Offset(3, 3)),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(6),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // The type-coloured left bar.
+              Container(width: 4, color: accent),
+              Expanded(
+                child: ClipRect(
+                  child: OverflowBox(
+                    minHeight: 0,
+                    maxHeight: double.infinity,
+                    alignment: Alignment.topLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.all(4),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  entry.title,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 11,
+                                  ),
+                                ),
+                              ),
+                              if (showStatus)
+                                _StatusBadge(text: meta!.status, color: accent),
+                            ],
+                          ),
+                          if (showTime)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 2),
+                              child: Row(
+                                children: [
+                                  const Icon(Icons.schedule,
+                                      size: 11, color: Colors.white60),
+                                  const SizedBox(width: 3),
+                                  // Flexible + ellipsis so a narrow (overlap-
+                                  // split) column clips the time rather than
+                                  // overflowing the row.
+                                  Flexible(
+                                    child: Text(
+                                      _timeRange(entry.time),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: const TextStyle(
+                                        color: Colors.white60,
+                                        fontSize: 9,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          if (showPlace)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 2),
+                              child: Text(
+                                meta!.place,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  color: Colors.white54,
+                                  fontSize: 9,
+                                ),
+                              ),
+                            ),
+                          if (showAvatars)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: _AvatarStack(
+                                key: ValueKey('pop-avatars-${entry.id}'),
+                                initials: meta!.attendees,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// `HH:MM–HH:MM` for the entry's start and computed end time.
+  static String _timeRange(PlannerTime time) {
+    String hhmm(int totalMinutes) {
+      final h = (totalMinutes ~/ 60) % 24;
+      final m = totalMinutes % 60;
+      return '${h.toString().padLeft(2, '0')}:${m.toString().padLeft(2, '0')}';
+    }
+
+    final start = time.hour * 60 + time.minutes;
+    return '${hhmm(start)}–${hhmm(start + time.duration)}';
+  }
+}
+
+/// A small status pill shown once the [PopBlock] clears the 56px tier.
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.text, required this.color});
+
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        style:
+            TextStyle(color: color, fontSize: 8, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}
+
+/// The attendee avatar stack, shown only in the [PopBlock]'s tallest (≥92px)
+/// tier.
+class _AvatarStack extends StatelessWidget {
+  const _AvatarStack({super.key, required this.initials});
+
+  final List<String> initials;
+
+  @override
+  Widget build(BuildContext context) {
+    const maxShown = 3;
+    final shown = initials.take(maxShown).toList();
+    final extra = initials.length - shown.length;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final i in shown)
+          Padding(
+            padding: const EdgeInsets.only(right: 2),
+            child: _avatar(i, const Color(0xFF3A7BD5)),
+          ),
+        if (extra > 0) _avatar('+$extra', const Color(0xFF55607A)),
+      ],
+    );
+  }
+
+  Widget _avatar(String text, Color color) => Container(
+        width: 16,
+        height: 16,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        child: Text(
+          text,
+          style: const TextStyle(color: Colors.white, fontSize: 7),
+        ),
+      );
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,5 @@
 name: example
-description: A new Flutter project.
+description: A gallery of focused examples for the planner package, from a minimal planner to every customization hook.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -2,8 +2,8 @@
 //
 // This used to be the default Flutter *counter* test (asserting a '0' -> '1'
 // FloatingActionButton flow) left over from `flutter create`. The example app
-// has no counter — it renders a Planner demo — so that test failed if ever run.
-// It now verifies the example actually boots into the planner.
+// has no counter — it boots a gallery of example pages (#90) — so that test
+// failed if ever run. It now verifies the gallery boots and navigates.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -13,15 +13,46 @@ import 'package:example/data.dart';
 import 'package:example/main.dart';
 
 void main() {
-  testWidgets('example app boots into the Planner demo', (tester) async {
+  testWidgets('example app boots into the gallery of examples', (tester) async {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
 
-    // The demo renders a single typed Planner inside a 'Planner Demo' scaffold.
-    expect(find.byType(Planner<ActivityMeta>), findsOneWidget);
-    expect(find.text('Planner Demo'), findsOneWidget);
+    // The home is the gallery list, not a planner.
+    expect(find.text('Planner Examples'), findsOneWidget);
+    expect(find.byKey(const ValueKey('gallery-tile-basic')), findsOneWidget);
+
+    // The Showcase row is last and lazily built; scroll it into view to confirm
+    // the full list is present.
+    final showcase = find.byKey(const ValueKey('gallery-tile-showcase'));
+    await tester.scrollUntilVisible(showcase, 120);
+    expect(showcase, findsOneWidget);
 
     // Guard against the old counter template creeping back in.
     expect(find.byType(FloatingActionButton), findsNothing);
+  });
+
+  testWidgets('tapping the Basic row opens a planner page', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('gallery-tile-basic')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Planner), findsOneWidget);
+  });
+
+  testWidgets('tapping the Showcase row opens the all-hooks demo',
+      (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    final tile = find.byKey(const ValueKey('gallery-tile-showcase'));
+    await tester.scrollUntilVisible(tile, 120);
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+
+    // The showcase renders a single typed Planner inside a 'Planner Demo' page.
+    expect(find.byType(Planner<ActivityMeta>), findsOneWidget);
+    expect(find.text('Planner Demo'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
Restructure the example app from one 418-line all-in-one screen into a **gallery home** that navigates to **7 focused example pages**, ordered basic → complex. Each page demonstrates a single feature in isolation; the final Showcase wires every customization hook together.

## Linked issue
Closes #90

## Changes
- **Gallery home** — [`example/lib/main.dart`](example/lib/main.dart) is now a `ListView` of titled/described rows that `Navigator.push` to each page, with a short intro.
- **Example pages** ([`example/lib/examples/`](example/lib/examples/)):
  1. `basic_example.dart` — minimal `Planner`, default look, `onEntry*` callbacks
  2. `typed_data_example.dart` — `PlannerEntry<ActivityMeta>` + `entryBuilder` (detail-shedding card)
  3. `custom_headers_example.dart` — `CalendarWindow` + `dayHeaderBuilder` + `highlightedColumn`
  4. `all_day_example.dart` — `showAllDayBand: true` + `allDayEntryBuilder` chips
  5. `host_zoom_example.dart` — `PlannerController` toolbar + `showZoomControls: false`
  6. `week_calendar_example.dart` — `package:planner/calendar.dart`: week prev/next, `entriesFor`, `todayColumn`
  7. `showcase_example.dart` — the relocated all-hooks demo
- **Shared public widgets** extracted to [`example/lib/widgets/`](example/lib/widgets/): `PopBlock`, `DayHeader`, `AllDayChip` (reused across pages).
- **Docs/meta** — real `pubspec.yaml` description (replaces "A new Flutter project."); [`example/README.md`](example/README.md) now indexes the examples + carries the minimal snippet.
- **Integration scenarios** — the scenarios that boot the real app now open the Showcase page first via a shared `openShowcase()` helper in `planner_harness.dart`. The Showcase preserves the `ValueKey`s the suite pins (`pop-block-*`, `pop-avatars-*`, `day-header-*`, `all-day-chip-*`, `demo-zoom-*`) and the `Planner Demo` title.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` — clean
- [x] `flutter analyze` (root + `example/`) — no issues
- [x] `flutter test` — root **250 pass**; `example/` widget tests **3 pass** (gallery boots; tapping Basic and Showcase navigate)
- [x] `flutter test integration_test -d windows` — **51 pass** (full suite, incl. the three rerouted-through-the-gallery scenarios)

This is a user-visible change, so the user-facing flows are covered end-to-end: the integration suite drives the real app and now navigates the gallery into the Showcase, and a widget test verifies the gallery → page navigation.

## Notes / screenshots
- The issue named **two** scenarios to update; **three** actually boot the real app, so `context_menu_scenarios.dart` was rerouted too (otherwise the suite would break).
- The issue referenced `showcaseEntries()`; the function merged in #89 is `sampleEntries()`, so that name is used.
- Fixed a **pre-existing** overflow in the Pop Block time row — confirmed it fails on `develop`'s example widget test under the Ahem font at narrow overlap-split columns. Wrapped the time text in `Flexible` + ellipsis; no change on real devices (integration suite unaffected).
- Screenshot thumbnails in the README are deferred to #93 (screenshot infra), per the tracking issue #88.