### PR TITLE
docs: slim, screenshot-led README + split reference into docs/ pages (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,36 @@
 # planner
 
 A Flutter widget that renders a scrollable, zoomable day-grid of events on a
-custom-painted canvas. Show several labelled columns side by side, each split into
-hours, and let users pan, zoom, and drag events to move or resize them.
+custom-painted canvas. Show several labelled columns side by side, each split
+into hours, and let users pan, zoom, and drag events to move or resize them. It
+is **column-based, not date-based** — a "day" is an index into the `labels` you
+provide, so it works for days, rooms, machines or any lanes; optional
+[calendar helpers](docs/calendar.md) add real dates on top.
 
-> **Note on the model:** `planner` is column-based, not date-based. A "day" is an
-> *index* into the `labels` list you provide — there are no real calendar dates in
-> the core. This keeps it a flexible scheduler for any set of columns (days, rooms,
-> machines, lanes …). For an ordinary date-based week calendar, the optional
-> [calendar helpers](#building-a-date-based-week-calendar) map dates ↔ columns on
-> top of this model; the core stays date-agnostic by design (see
-> [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md)).
+<p align="center">
+  <img src="docs/screenshots/basic.png" alt="A basic planner with the default look" width="420">
+  <img src="docs/screenshots/showcase.png" alt="A customized planner with branded headers, custom event cards and an all-day band" width="420">
+</p>
 
-<!-- TODO: add a screenshot or GIF of the widget here, e.g. -->
-<!-- ![planner demo](doc/demo.gif) -->
+> Screenshots are generated from the example app; see [#93](https://github.com/pebble-world/planner/issues/93).
 
 ## Features
 
 - Multiple labelled columns with an hour grid drawn on a single `CustomPaint`.
-- 2D panning (drag the empty canvas) plus single-axis pan via the date row / hour
-  gutter, and mouse-wheel scroll with `Shift` / `Ctrl` modifiers.
-- Zoom the time axis with pinch, `Ctrl`+wheel, or the built-in +/- buttons; finer
-  grid lines fade in as you zoom. Drive and observe zoom from your own chrome with
-  a `PlannerController` (see [Driving zoom from a host toolbar](#driving-zoom-from-a-host-toolbar)).
-- Desktop drag-to-edit: press an event to move it or drag its top/bottom edge to
-  resize, with hover cursors as cues. Touch keeps one-finger drag for panning and
-  exposes a long-press hook (`onEntryLongPress`) for host-defined event actions.
-- Create / edit / delete via double-tap or a right-click context menu.
-- Per-event accessibility semantics (edit / delete / move) for screen readers.
-- Customizable colors and text styles for the grid, labels, events, and menu.
-- **Fully custom widgets** via opt-in builders: branded day/column headers
-  (`dayHeaderBuilder`), real-widget events that shed detail by pixel height
-  (`entryBuilder`), and custom all-day chips (`allDayEntryBuilder`) — each reads
-  a typed `PlannerEntry<T>.data` payload. See
-  [Fully custom widgets (builders)](#fully-custom-widgets-builders).
-
-See [Interactions](#interactions) below for the full mouse and touch gesture map.
+- 2D panning, single-axis pan via the date row / hour gutter, and mouse-wheel
+  scroll with `Shift` / `Ctrl` modifiers ([interactions](docs/interactions.md)).
+- Zoom the time axis with pinch, `Ctrl`+wheel, or the built-in +/- buttons — or
+  drive it from your own chrome with a [`PlannerController`](docs/controller.md).
+- Desktop drag-to-edit (move a body, resize an edge) with hover cursors; touch
+  keeps one-finger drag for panning and exposes an `onEntryLongPress` hook.
+- Create / edit / delete via double-tap or a right-click context menu, with
+  per-event accessibility semantics for screen readers.
+- Customizable colors and text styles, a "today"-style
+  [column highlight](docs/interactions.md#highlighting-a-column-today-style), and
+  a localizable [context menu](docs/interactions.md#localizing-the-context-menu).
+- **Fully custom widgets** via opt-in [builders](docs/builders.md): branded
+  day/column headers, real-widget events that shed detail by pixel height, and
+  custom all-day chips — each reading a typed `PlannerEntry<T>.data` payload.
 
 ## Getting started
 
@@ -43,11 +38,8 @@ Add the package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  planner:
-    git: https://github.com/pebble-world/planner.git
+  planner: ^0.3.0
 ```
-
-(Once published, this becomes `planner: ^<version>` from pub.dev.)
 
 Then import it:
 
@@ -107,433 +99,42 @@ class CalendarPage extends StatelessWidget {
 }
 ```
 
-A complete, runnable demo lives in [`example/`](example/lib/main.dart).
-
-### Core types
-
-| Type | Purpose |
-|------|---------|
-| `Planner` | The widget. Takes a `config`, a list of `entries`, and an optional `controller`. |
-| `PlannerConfig` | Sizing (`blockWidth`, `blockHeight`, `minHour`, `maxHour` — the inclusive last hour, default `23`, …), colors, text styles, an optional `hourLabelFormatter`, the optional column highlight (`highlightedColumn`, `highlightColumnColor`), the zoom controls (`showZoomControls`, `zoomButtonColor`, `zoomButtonIconColor`), the wheel `scrollStep`, and the `onEntry*` callbacks. `labels` is required. |
-| `PlannerController` | Optional handle to drive/observe zoom from outside the widget (e.g. your own toolbar) — see [Driving zoom from a host toolbar](#driving-zoom-from-a-host-toolbar). |
-| `PlannerEntry<T>` | One event: `id`, `time`, `title`, `content`, `color`, optional text styles, and an optional typed `data` payload (`T?`) for your own metadata — see [Fully custom widgets (builders)](#fully-custom-widgets-builders). |
-| `PlannerTime` | `day` (index into `labels`), `hour`, `minutes`, and `duration` (in minutes). |
-| `PlannerEntryBuilder<T>` / `PlannerEntryLayout` | Build a custom widget for a timed event or all-day chip; `PlannerEntryLayout` carries the on-screen `size` (for detail-shedding), overlap column, and drag state. |
-| `PlannerDayHeaderBuilder` | Build a custom widget for a day/column header. |
-
-### Callbacks
-
-| Callback | Fires when |
-|----------|-----------|
-| `onEntryCreate(PlannerTime)` | An empty slot is double-tapped or "Create Event" is chosen. |
-| `onEntryEdit(PlannerEntry)` | An event is double-tapped or "Edit Event" is chosen. |
-| `onEntryDelete(PlannerEntry)` | "Delete Event" is chosen from the context menu. |
-| `onEntryMove(PlannerEntry)` | A drag-move or handle-resize finishes; the entry's `time` is already updated. |
-| `onEntryLongPress(PlannerEntry)` | An event is long-pressed — the touch hook for host-defined actions (see [Interactions](#interactions)). |
-
-> Your callbacks own the data. Update your own list of entries (and call
-> `setState`) in response — the widget reports interactions but does not persist them.
-
-### Driving zoom from a host toolbar
-
-By default zoom lives entirely inside the widget (pinch, `Ctrl`+wheel, the
-built-in +/- buttons). To drive it from your own chrome — a toolbar, a slider,
-keyboard shortcuts — construct a `PlannerController`, hand it to the `Planner`,
-and (usually) hide the on-canvas buttons with `showZoomControls: false`:
-
-```dart
-class ZoomablePlanner extends StatefulWidget {
-  const ZoomablePlanner({super.key});
-  @override
-  State<ZoomablePlanner> createState() => _ZoomablePlannerState();
-}
-
-class _ZoomablePlannerState extends State<ZoomablePlanner> {
-  final _zoom = PlannerController();
-
-  @override
-  void dispose() {
-    _zoom.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        // A host toolbar that listens to the controller so it can disable
-        // a button once the zoom hits a bound.
-        AnimatedBuilder(
-          animation: _zoom,
-          builder: (context, _) => Row(
-            children: [
-              IconButton(
-                icon: const Icon(Icons.remove),
-                onPressed: !_zoom.isAttached || _zoom.zoom <= _zoom.minZoom
-                    ? null
-                    : _zoom.zoomOut,
-              ),
-              IconButton(
-                icon: const Icon(Icons.add),
-                onPressed: !_zoom.isAttached || _zoom.zoom >= _zoom.maxZoom
-                    ? null
-                    : _zoom.zoomIn,
-              ),
-            ],
-          ),
-        ),
-        Expanded(
-          child: Planner(
-            controller: _zoom,
-            config: PlannerConfig(
-              labels: const ['Mon', 'Tue', 'Wed'],
-              showZoomControls: false, // the host owns the controls now
-            ),
-            entries: const [],
-          ),
-        ),
-      ],
-    );
-  }
-}
-```
-
-`PlannerController` is a `ChangeNotifier` and deals only with zoom (plus scroll
-read-back):
-
-| Member | Purpose |
-|--------|---------|
-| `zoomIn([factor = 1.1])` / `zoomOut([factor = 0.9])` | Multiply the current zoom; clamped to `minZoom`/`maxZoom`. |
-| `zoomTo(target)` | Set an absolute zoom; clamped to `minZoom`/`maxZoom`. |
-| `zoom`, `minZoom`, `maxZoom` | Read the current zoom and its bounds. |
-| `dayScroll`, `timeScroll` | Read the current day-axis / time-axis scroll offset. |
-| `isAttached` | Whether it's bound to a mounted `Planner`. |
-
-It attaches to the planner's internal zoom/scroll state — the single source of
-truth — so the controller, pinch, `Ctrl`+wheel and the built-in buttons all move
-the *same* zoom; there's no duplicated state to keep in sync. The read getters
-throw while not `isAttached` (before the `Planner` mounts or after it's gone), so
-read them in response to a notification or guard with `isAttached`; the zoom
-methods are no-ops then. Dispose the controller like any other `ChangeNotifier`.
-
-### Fully custom widgets (builders)
-
-By default the planner paints everything on a canvas. Three opt-in **builders**
-let you replace any of those surfaces with real Flutter widgets — branded
-headers, rich event cards, custom chips — while the package stays the engine
-(geometry, scroll, zoom, hit-testing, overlap, accessibility). Each builder is
-**visual-only**: the widget overlay is wrapped in `IgnorePointer` /
-`ExcludeSemantics`, so every gesture and accessibility action still falls through
-to the canvas and fires the usual `onEntry*` callbacks. Everything is opt-in —
-pass `null` (the default) and the painted look is unchanged.
-
-#### Typed metadata: `PlannerEntry<T>.data`
-
-To render a rich widget you usually need your app's own data on each event —
-type, place, attendees, status. Make the entry generic and hang it on `data`:
-
-```dart
-class ActivityMeta {
-  const ActivityMeta({required this.type, this.place = '', this.attendees = const []});
-  final String type;
-  final String place;
-  final List<String> attendees;
-}
-
-final entry = PlannerEntry<ActivityMeta>(
-  id: '1',
-  time: PlannerTime(day: 0, hour: 9, duration: 60),
-  title: 'Stand-up',
-  content: '',
-  color: Colors.teal,
-  data: const ActivityMeta(type: 'meeting', place: 'Room A', attendees: ['AM', 'BK']),
-);
-```
-
-`T` threads through `Planner<T>`, `PlannerConfig<T>` and the `onEntry*`
-callbacks, so the builder (and your callbacks) read `entry.data` already typed —
-no cast, no side-map keyed by `id`. An untyped `PlannerEntry(...)` infers
-`T == dynamic` and behaves exactly as before, so this is non-breaking.
-
-#### `entryBuilder` — custom timed-event widgets
-
-When set, the planner layers one widget per on-screen event over the canvas,
-positioned and sized at the event's live on-screen rect so it tracks scroll,
-zoom and drag in lockstep with the grid. The `PlannerEntryLayout` carries the
-on-screen facts — crucially `size.height`, so a card can **shed detail by pixel
-height** as the user zooms:
-
-```dart
-Planner<ActivityMeta>(
-  config: PlannerConfig<ActivityMeta>(labels: const ['Mon', 'Tue', 'Wed']),
-  entries: entries,
-  entryBuilder: (context, entry, layout) {
-    final meta = entry.data;
-    return Card(
-      color: entry.color,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(entry.title),
-          // Only show the place when the event is tall enough on screen.
-          if (layout.size.height >= 52 && meta != null) Text(meta.place),
-          // …and the avatar stack only when it's taller still.
-          if (layout.size.height >= 92 && meta != null)
-            Row(children: [for (final a in meta.attendees) CircleAvatar(child: Text(a))]),
-        ],
-      ),
-    );
-  },
-)
-```
-
-Tapping, double-tapping, dragging or right-clicking the custom widget still
-fires `onEntryEdit` / `onEntryMove` / `onEntryLongPress` (the overlay is
-`IgnorePointer`). Overlapping events are placed side-by-side automatically via
-`layout.columnIndex` / `layout.columnCount`, and `layout.dragType` reflects a
-live move/resize.
-
-#### `dayHeaderBuilder` — custom day/column headers
-
-Supplies one widget per column header — e.g. a multi-part branded header with the
-weekday, day number and a "today" tint. The signature carries **no `DateTime`**
-(the core stays date-agnostic — ADR 0001); a consumer using the
-[calendar helpers](#building-a-date-based-week-calendar) closes over their
-`CalendarWindow` to recover the date:
-
-```dart
-final window = CalendarWindow.week(anchor: DateTime.now());
-
-Planner(
-  config: PlannerConfig(labels: window.labels()),
-  entries: entries,
-  dayHeaderBuilder: (context, columnIndex, label, isHighlighted) {
-    final date = window.dateAt(columnIndex); // map index → real date
-    return Container(
-      color: isHighlighted ? Colors.blue : null, // `isHighlighted` == highlightedColumn
-      child: Column(children: [Text('${date.day}'), Text(label)]),
-    );
-  },
-)
-```
-
-Headers reposition on a day-axis pan and a horizontal drag across them still pans
-the day axis.
-
-#### `allDayEntryBuilder` — custom all-day chips
-
-The all-day twin of `entryBuilder` — same `PlannerEntryBuilder<T>` signature, applied
-to the all-day band (needs `showAllDayBand: true`). The `PlannerEntryLayout` carries
-`allDay: true`, so one builder can serve both surfaces and branch on it:
-
-```dart
-Planner<ActivityMeta>(
-  config: PlannerConfig<ActivityMeta>(labels: const ['Mon', 'Tue'], showAllDayBand: true),
-  entries: entries, // some with PlannerTime(..., allDay: true)
-  allDayEntryBuilder: (context, entry, layout) => Container(
-    decoration: BoxDecoration(color: entry.color, borderRadius: BorderRadius.circular(10)),
-    child: Text(entry.title),
-  ),
-)
-```
-
-A complete demo wiring **all four** hooks together (host zoom toolbar, branded
-headers, detail-shedding event cards, and all-day chips) lives in
-[`example/lib/main.dart`](example/lib/main.dart).
-
-### Localizing the context menu
-
-The context-menu item labels default to English but are plain `String`s on
-`PlannerConfig`, so you can translate or rename them:
-
-```dart
-PlannerConfig(
-  labels: const ['Lun', 'Mar', 'Mer'],
-  contextMenuCreateLabel: 'Créer un événement',
-  contextMenuEditLabel: 'Modifier l’événement',
-  contextMenuDeleteLabel: 'Supprimer l’événement',
-);
-```
-
-| Field | Defaults to | Item |
-|-------|-------------|------|
-| `contextMenuCreateLabel` | `'Create Event'` | Shown on an empty grid cell. |
-| `contextMenuEditLabel` | `'Edit Event'` | Shown on an existing event. |
-| `contextMenuDeleteLabel` | `'Delete Event'` | Shown on an existing event. |
-
-### Highlighting a column ("today" style)
-
-`planner` is column-based, not date-based (see the note above), so it has no idea
-which column is "today". To emphasize one — a calendar's current day, the active
-room, the selected lane — set `highlightedColumn` to its **index** into `labels`;
-the grid fills that column behind the lines and events:
-
-```dart
-final labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-
-PlannerConfig(
-  labels: labels,
-  // A calendar consumer owns the date↔index mapping and passes the index:
-  highlightedColumn: 2, // e.g. DateTime.now().weekday - 1
-  highlightColumnColor: Colors.amber.withOpacity(0.15), // optional
-);
-```
-
-`highlightedColumn` defaults to `null` (no highlight); an out-of-range index
-highlights nothing. `highlightColumnColor` defaults to a subtle translucent white
-wash that reads on the default dark background — override it for a different tint
-(or a darker wash on a light background).
-
-| Field | Defaults to | Purpose |
-|-------|-------------|---------|
-| `highlightedColumn` | `null` | Index into `labels` of the column to emphasize. |
-| `highlightColumnColor` | translucent white | Fill painted across that column. |
-
-## Building a date-based week calendar
-
-The core widget is date-agnostic, but most calendars want real `DateTime`s. The
-optional, **non-core** helpers in `package:planner/calendar.dart` own the
-`date ↔ column-index` mapping for you, so the common week-calendar case stays a few
-lines without `DateTime` ever entering the widget API. Import it explicitly — it is
-**not** part of the main `planner.dart` barrel:
-
-```dart
-import 'package:planner/planner.dart';
-import 'package:planner/calendar.dart'; // opt-in calendar helpers
-```
-
-A `CalendarWindow` is a window of N consecutive days. Hold one in your state, derive
-the widget inputs from it, and step weeks with `next` / `previous`:
-
-```dart
-class WeekCalendar extends StatefulWidget {
-  const WeekCalendar({super.key, required this.meetings});
-  final List<Meeting> meetings; // your own dated event model
-
-  @override
-  State<WeekCalendar> createState() => _WeekCalendarState();
-}
-
-class _WeekCalendarState extends State<WeekCalendar> {
-  // The current week, snapped to its Monday.
-  CalendarWindow window = CalendarWindow.week(anchor: DateTime.now());
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Row(children: [
-          IconButton(
-            onPressed: () => setState(() => window = window.previous),
-            icon: const Icon(Icons.chevron_left),
-          ),
-          IconButton(
-            onPressed: () => setState(() => window = window.next),
-            icon: const Icon(Icons.chevron_right),
-          ),
-        ]),
-        Expanded(
-          child: Planner(
-            config: PlannerConfig(
-              labels: window.labels(), // e.g. ['Mon 8', 'Tue 9', … ] via intl
-              highlightedColumn: window.todayColumn, // "today", or null off-week
-            ),
-            // Map your dated events into the window; ones outside it are dropped.
-            entries: window.entriesFor(
-              widget.meetings,
-              start: (m) => m.startsAt,
-              duration: (m) => m.length,
-              build: (m, time) => PlannerEntry(
-                id: m.id,
-                time: time,
-                title: m.title,
-                content: '',
-                color: m.color,
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-```
-
-`labels()` defaults to a localized `EEE d` (e.g. `Mon 8`) via `intl`; pass your own
-`String Function(DateTime)` for a different format or locale. `todayColumn` returns
-`null` when today isn't in the window, which `highlightedColumn` already treats as
-"no highlight".
-
-| `CalendarWindow` member | Purpose |
-|-------------------------|---------|
-| `CalendarWindow({start, dayCount})` / `.week({anchor, firstWeekday, dayCount})` | A window of `dayCount` days from `start`, or the week containing `anchor`. |
-| `dateAt(i)` / `indexOf(date)` / `offsetOf(date)` / `contains(date)` | Map between dates and column indices. |
-| `dates` / `next` / `previous` | The column dates; step one window forward / back. |
-| `labels([format])` | Column headers for `PlannerConfig.labels` (default `intl` `EEE d`). |
-| `todayColumn` | Index for `PlannerConfig.highlightedColumn` (today, or `null`). |
-| `timeFor(start, {duration, end})` | A `PlannerTime` for a dated event, or `null` if outside the window. |
-| `entriesFor(events, {start, build, duration, end})` | Build the `PlannerEntry` list from your own dated events. |
-
-## Interactions
-
-The widget reports user actions through the `onEntry*` callbacks; it never mutates
-your data itself. The gesture set adapts to the input device: a precise pointer
-(mouse) gets immediate drag-to-edit, while touch reserves one-finger drag for
-panning and surfaces event actions through a long-press.
-
-### Mouse / desktop
-
-| Gesture | Result |
-|---------|--------|
-| Drag the empty canvas | Pan both axes (day + time) at once. |
-| Drag the date row | Pan the day axis only. |
-| Drag the hour gutter | Pan the time axis only. |
-| Press an event body + drag | Move the event immediately (no long-press); fires `onEntryMove` on release. |
-| Press an event's top/bottom edge + drag | Resize the event; fires `onEntryMove` on release. |
-| Hover an event | Cursor hints the action: `move` over the body, `resizeUpDown` over an edge. |
-| Mouse wheel | Scroll the time axis. |
-| `Shift` + wheel | Scroll the day axis. |
-| `Ctrl` + wheel | Zoom the time axis. |
-| +/- buttons | Zoom the time axis (hide with `showZoomControls: false`). |
-| Double-click an event | `onEntryEdit`. |
-| Double-click an empty slot | `onEntryCreate`. |
-| Right-click an event | Context menu → Edit / Delete (`onEntryEdit` / `onEntryDelete`). |
-| Right-click an empty slot | Context menu → Create (`onEntryCreate`). |
-| Long-press an event | `onEntryLongPress` — the same hook touch uses. |
-
-One wheel notch always advances the same amount of *time* regardless of zoom; tune
-the base step with `scrollStep`.
-
-### Touch
-
-| Gesture | Result |
-|---------|--------|
-| One-finger drag | Pan both axes (day + time) at once. |
-| Two-finger pinch | Zoom the time axis. |
-| Double-tap an event | `onEntryEdit`. |
-| Double-tap an empty slot | `onEntryCreate`. |
-| Long-press an event | `onEntryLongPress` with that entry. |
-| Long-press an empty slot | Nothing. |
-
-Touch has no right-click and reserves one-finger drag for panning, so **long-press
-is how a touch user acts on an event**. The widget stays presentation-only: it
-hands the pressed `PlannerEntry` to `onEntryLongPress` and takes no action of its
-own (no built-in selection, highlight, or menu), so the host decides the response —
-show an action sheet, a selection UI, a delete confirmation, or start a move flow.
-To move an event by touch, drive it from this callback; immediate drag-move/resize
-is a desktop-only affordance.
-
-### Accessibility
-
-The event canvas is a single `CustomPaint`, so each event also exposes a semantics
-node for screen readers: activate to edit, dismiss to delete, and increase/decrease
-to nudge it an hour later/earlier (`onEntryMove`). Only the actions whose callback
-you wire are offered.
+Your callbacks own the data: update your own list of entries (and call
+`setState`) in response — the widget reports interactions but does not persist
+them.
+
+## Examples
+
+A gallery of runnable examples lives in [`example/`](example/lib/main.dart),
+ordered basic → advanced. Each page demonstrates one feature on its own; the
+final Showcase combines them all.
+
+| Preview | Example | What it shows |
+|---------|---------|---------------|
+| <img src="docs/screenshots/basic.png" alt="Basic" width="200"> | [Basic](example/lib/examples/basic_example.dart) | A minimal planner with the default look and `onEntry*` callbacks. |
+| <img src="docs/screenshots/typed-data.png" alt="Typed data" width="200"> | [Typed data + entryBuilder](example/lib/examples/typed_data_example.dart) | A typed `PlannerEntry<T>.data` payload read back in a custom event card. |
+| <img src="docs/screenshots/custom-headers.png" alt="Custom headers" width="200"> | [Custom headers](example/lib/examples/custom_headers_example.dart) | A `CalendarWindow` + `dayHeaderBuilder` with a "today" highlight. |
+| <img src="docs/screenshots/all-day.png" alt="All-day band" width="200"> | [All-day band](example/lib/examples/all_day_example.dart) | Enabling the all-day band and drawing custom chips. |
+| <img src="docs/screenshots/host-zoom.png" alt="Host zoom" width="200"> | [Host zoom toolbar](example/lib/examples/host_zoom_example.dart) | Driving zoom from your own chrome via a `PlannerController`. |
+| <img src="docs/screenshots/week-calendar.png" alt="Week calendar" width="200"> | [Week calendar](example/lib/examples/week_calendar_example.dart) | A real week with prev/next navigation built on `calendar.dart`. |
+| <img src="docs/screenshots/showcase.png" alt="Showcase" width="200"> | [Showcase](example/lib/examples/showcase_example.dart) | Every customization hook wired together on one screen. |
+
+The thumbnails are generated by the screenshot target ([#93](https://github.com/pebble-world/planner/issues/93)).
+
+## Documentation
+
+| Guide | Covers |
+|-------|--------|
+| [Core concepts](docs/core-concepts.md) | The column-based time model, the core types, and the `onEntry*` callbacks. |
+| [Builders](docs/builders.md) | Typed `PlannerEntry<T>.data`, and the `entryBuilder` / `dayHeaderBuilder` / `allDayEntryBuilder` widget hooks. |
+| [Calendar](docs/calendar.md) | A date-based week calendar with `CalendarWindow` from `package:planner/calendar.dart`. |
+| [Controller](docs/controller.md) | Driving and observing zoom from a host toolbar with `PlannerController`. |
+| [Interactions](docs/interactions.md) | The mouse / touch / accessibility map, context-menu localization, and column highlighting. |
 
 ## Additional information
 
-- **Roadmap & known issues:** [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md).
-- **Issues / contributions:** https://github.com/pebble-world/planner/issues — PRs welcome.
+- **Changelog:** [CHANGELOG.md](CHANGELOG.md).
+- **Issues / contributions:** <https://github.com/pebble-world/planner/issues> — PRs welcome.
 
 ## License
 

--- a/docs/builders.md
+++ b/docs/builders.md
@@ -1,0 +1,135 @@
+# Fully custom widgets (builders)
+
+By default the planner paints everything on a canvas. Three opt-in **builders**
+let you replace any of those surfaces with real Flutter widgets — branded
+headers, rich event cards, custom chips — while the package stays the engine
+(geometry, scroll, zoom, hit-testing, overlap, accessibility). Each builder is
+**visual-only**: the widget overlay is wrapped in `IgnorePointer` /
+`ExcludeSemantics`, so every gesture and accessibility action still falls through
+to the canvas and fires the usual `onEntry*` callbacks. Everything is opt-in —
+pass `null` (the default) and the painted look is unchanged.
+
+Runnable versions of everything here live in the example gallery:
+[`typed_data_example.dart`](../example/lib/examples/typed_data_example.dart),
+[`custom_headers_example.dart`](../example/lib/examples/custom_headers_example.dart),
+[`all_day_example.dart`](../example/lib/examples/all_day_example.dart), and the
+combined [`showcase_example.dart`](../example/lib/examples/showcase_example.dart).
+
+## Typed metadata: `PlannerEntry<T>.data`
+
+To render a rich widget you usually need your app's own data on each event —
+type, place, attendees, status. Make the entry generic and hang it on `data`:
+
+```dart
+class ActivityMeta {
+  const ActivityMeta({required this.type, this.place = '', this.attendees = const []});
+  final String type;
+  final String place;
+  final List<String> attendees;
+}
+
+final entry = PlannerEntry<ActivityMeta>(
+  id: '1',
+  time: PlannerTime(day: 0, hour: 9, duration: 60),
+  title: 'Stand-up',
+  content: '',
+  color: Colors.teal,
+  data: const ActivityMeta(type: 'meeting', place: 'Room A', attendees: ['AM', 'BK']),
+);
+```
+
+`T` threads through `Planner<T>`, `PlannerConfig<T>` and the `onEntry*`
+callbacks, so the builder (and your callbacks) read `entry.data` already typed —
+no cast, no side-map keyed by `id`. An untyped `PlannerEntry(...)` infers
+`T == dynamic` and behaves exactly as before, so this is non-breaking.
+
+## `entryBuilder` — custom timed-event widgets
+
+When set, the planner layers one widget per on-screen event over the canvas,
+positioned and sized at the event's live on-screen rect so it tracks scroll,
+zoom and drag in lockstep with the grid. The `PlannerEntryLayout` carries the
+on-screen facts — crucially `size.height`, so a card can **shed detail by pixel
+height** as the user zooms:
+
+```dart
+Planner<ActivityMeta>(
+  config: PlannerConfig<ActivityMeta>(labels: const ['Mon', 'Tue', 'Wed']),
+  entries: entries,
+  entryBuilder: (context, entry, layout) {
+    final meta = entry.data;
+    return Card(
+      color: entry.color,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(entry.title),
+          // Only show the place when the event is tall enough on screen.
+          if (layout.size.height >= 52 && meta != null) Text(meta.place),
+          // …and the avatar stack only when it's taller still.
+          if (layout.size.height >= 92 && meta != null)
+            Row(children: [for (final a in meta.attendees) CircleAvatar(child: Text(a))]),
+        ],
+      ),
+    );
+  },
+)
+```
+
+Tapping, double-tapping, dragging or right-clicking the custom widget still
+fires `onEntryEdit` / `onEntryMove` / `onEntryLongPress` (the overlay is
+`IgnorePointer`). Overlapping events are placed side-by-side automatically via
+`layout.columnIndex` / `layout.columnCount`, and `layout.dragType` reflects a
+live move/resize.
+
+## `dayHeaderBuilder` — custom day/column headers
+
+Supplies one widget per column header — e.g. a multi-part branded header with the
+weekday, day number and a "today" tint. The signature carries **no `DateTime`**
+(the core stays date-agnostic — [ADR 0001](decisions/0001-time-model-day-index.md));
+a consumer using the [calendar helpers](calendar.md) closes over their
+`CalendarWindow` to recover the date:
+
+```dart
+final window = CalendarWindow.week(anchor: DateTime.now());
+
+Planner(
+  config: PlannerConfig(labels: window.labels()),
+  entries: entries,
+  dayHeaderBuilder: (context, columnIndex, label, isHighlighted) {
+    final date = window.dateAt(columnIndex); // map index → real date
+    return Container(
+      color: isHighlighted ? Colors.blue : null, // `isHighlighted` == highlightedColumn
+      child: Column(children: [Text('${date.day}'), Text(label)]),
+    );
+  },
+)
+```
+
+Headers reposition on a day-axis pan and a horizontal drag across them still pans
+the day axis.
+
+## `allDayEntryBuilder` — custom all-day chips
+
+The all-day twin of `entryBuilder` — same `PlannerEntryBuilder<T>` signature,
+applied to the all-day band (needs `showAllDayBand: true`). The
+`PlannerEntryLayout` carries `allDay: true`, so one builder can serve both
+surfaces and branch on it:
+
+```dart
+Planner<ActivityMeta>(
+  config: PlannerConfig<ActivityMeta>(labels: const ['Mon', 'Tue'], showAllDayBand: true),
+  entries: entries, // some with PlannerTime(..., allDay: true)
+  allDayEntryBuilder: (context, entry, layout) => Container(
+    decoration: BoxDecoration(color: entry.color, borderRadius: BorderRadius.circular(10)),
+    child: Text(entry.title),
+  ),
+)
+```
+
+A demo wiring **all four** hooks together (host zoom toolbar, branded headers,
+detail-shedding event cards, and all-day chips) lives in the
+[Showcase example](../example/lib/examples/showcase_example.dart).
+
+---
+
+**More docs:** [Core concepts](core-concepts.md) · [Builders](builders.md) · [Calendar](calendar.md) · [Controller](controller.md) · [Interactions](interactions.md) · [README](../README.md)

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -1,0 +1,97 @@
+# Building a date-based week calendar
+
+The [core widget is date-agnostic](core-concepts.md#the-time-model-columns-not-dates),
+but most calendars want real `DateTime`s. The optional, **non-core** helpers in
+`package:planner/calendar.dart` own the `date ↔ column-index` mapping for you, so
+the common week-calendar case stays a few lines without `DateTime` ever entering
+the widget API. Import it explicitly — it is **not** part of the main
+`planner.dart` barrel:
+
+```dart
+import 'package:planner/planner.dart';
+import 'package:planner/calendar.dart'; // opt-in calendar helpers
+```
+
+A `CalendarWindow` is a window of N consecutive days. Hold one in your state,
+derive the widget inputs from it, and step weeks with `next` / `previous`:
+
+```dart
+class WeekCalendar extends StatefulWidget {
+  const WeekCalendar({super.key, required this.meetings});
+  final List<Meeting> meetings; // your own dated event model
+
+  @override
+  State<WeekCalendar> createState() => _WeekCalendarState();
+}
+
+class _WeekCalendarState extends State<WeekCalendar> {
+  // The current week, snapped to its Monday.
+  CalendarWindow window = CalendarWindow.week(anchor: DateTime.now());
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(children: [
+          IconButton(
+            onPressed: () => setState(() => window = window.previous),
+            icon: const Icon(Icons.chevron_left),
+          ),
+          IconButton(
+            onPressed: () => setState(() => window = window.next),
+            icon: const Icon(Icons.chevron_right),
+          ),
+        ]),
+        Expanded(
+          child: Planner(
+            config: PlannerConfig(
+              labels: window.labels(), // e.g. ['Mon 8', 'Tue 9', … ] via intl
+              highlightedColumn: window.todayColumn, // "today", or null off-week
+            ),
+            // Map your dated events into the window; ones outside it are dropped.
+            entries: window.entriesFor(
+              widget.meetings,
+              start: (m) => m.startsAt,
+              duration: (m) => m.length,
+              build: (m, time) => PlannerEntry(
+                id: m.id,
+                time: time,
+                title: m.title,
+                content: '',
+                color: m.color,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+`labels()` defaults to a localized `EEE d` (e.g. `Mon 8`) via `intl`; pass your
+own `String Function(DateTime)` for a different format or locale. `todayColumn`
+returns `null` when today isn't in the window, which `highlightedColumn` already
+treats as "no highlight".
+
+A runnable version with prev/next/today navigation is the
+[Week calendar example](../example/lib/examples/week_calendar_example.dart).
+
+## `CalendarWindow` API
+
+| Member | Purpose |
+|--------|---------|
+| `CalendarWindow({start, dayCount})` / `.week({anchor, firstWeekday, dayCount})` | A window of `dayCount` days from `start`, or the week containing `anchor`. |
+| `dateAt(i)` / `indexOf(date)` / `offsetOf(date)` / `contains(date)` | Map between dates and column indices. |
+| `dates` / `next` / `previous` | The column dates; step one window forward / back. |
+| `labels([format])` | Column headers for `PlannerConfig.labels` (default `intl` `EEE d`). |
+| `todayColumn` | Index for `PlannerConfig.highlightedColumn` (today, or `null`). |
+| `timeFor(start, {duration, end})` | A `PlannerTime` for a dated event, or `null` if outside the window. |
+| `entriesFor(events, {start, build, duration, end})` | Build the `PlannerEntry` list from your own dated events. |
+
+To recover the date inside a [`dayHeaderBuilder`](builders.md#dayheaderbuilder--custom-daycolumn-headers),
+close over the window and call `window.dateAt(columnIndex)`.
+
+---
+
+**More docs:** [Core concepts](core-concepts.md) · [Builders](builders.md) · [Calendar](calendar.md) · [Controller](controller.md) · [Interactions](interactions.md) · [README](../README.md)

--- a/docs/controller.md
+++ b/docs/controller.md
@@ -1,0 +1,90 @@
+# Driving zoom from a host toolbar
+
+By default zoom lives entirely inside the widget (pinch, `Ctrl`+wheel, the
+built-in +/- buttons). To drive it from your own chrome — a toolbar, a slider,
+keyboard shortcuts — construct a `PlannerController`, hand it to the `Planner`,
+and (usually) hide the on-canvas buttons with `showZoomControls: false`:
+
+```dart
+class ZoomablePlanner extends StatefulWidget {
+  const ZoomablePlanner({super.key});
+  @override
+  State<ZoomablePlanner> createState() => _ZoomablePlannerState();
+}
+
+class _ZoomablePlannerState extends State<ZoomablePlanner> {
+  final _zoom = PlannerController();
+
+  @override
+  void dispose() {
+    _zoom.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // A host toolbar that listens to the controller so it can disable
+        // a button once the zoom hits a bound.
+        AnimatedBuilder(
+          animation: _zoom,
+          builder: (context, _) => Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.remove),
+                onPressed: !_zoom.isAttached || _zoom.zoom <= _zoom.minZoom
+                    ? null
+                    : _zoom.zoomOut,
+              ),
+              IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: !_zoom.isAttached || _zoom.zoom >= _zoom.maxZoom
+                    ? null
+                    : _zoom.zoomIn,
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Planner(
+            controller: _zoom,
+            config: PlannerConfig(
+              labels: const ['Mon', 'Tue', 'Wed'],
+              showZoomControls: false, // the host owns the controls now
+            ),
+            entries: const [],
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+A runnable version is the
+[Host zoom example](../example/lib/examples/host_zoom_example.dart).
+
+## `PlannerController` API
+
+`PlannerController` is a `ChangeNotifier` and deals only with zoom (plus scroll
+read-back):
+
+| Member | Purpose |
+|--------|---------|
+| `zoomIn([factor = 1.1])` / `zoomOut([factor = 0.9])` | Multiply the current zoom; clamped to `minZoom`/`maxZoom`. |
+| `zoomTo(target)` | Set an absolute zoom; clamped to `minZoom`/`maxZoom`. |
+| `zoom`, `minZoom`, `maxZoom` | Read the current zoom and its bounds. |
+| `dayScroll`, `timeScroll` | Read the current day-axis / time-axis scroll offset. |
+| `isAttached` | Whether it's bound to a mounted `Planner`. |
+
+It attaches to the planner's internal zoom/scroll state — the single source of
+truth — so the controller, pinch, `Ctrl`+wheel and the built-in buttons all move
+the *same* zoom; there's no duplicated state to keep in sync. The read getters
+throw while not `isAttached` (before the `Planner` mounts or after it's gone), so
+read them in response to a notification or guard with `isAttached`; the zoom
+methods are no-ops then. Dispose the controller like any other `ChangeNotifier`.
+
+---
+
+**More docs:** [Core concepts](core-concepts.md) · [Builders](builders.md) · [Calendar](calendar.md) · [Controller](controller.md) · [Interactions](interactions.md) · [README](../README.md)

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,0 +1,52 @@
+# Core concepts
+
+The types you wire together to render a planner, and how the time model works.
+See the [README](../README.md) for the quick start, and the other guides for
+each feature: [builders](builders.md), [calendar](calendar.md),
+[controller](controller.md), [interactions](interactions.md).
+
+## The time model: columns, not dates
+
+`planner` is **column-based, not date-based**. A "day" is an *index* into the
+`labels` list you provide — there are no real calendar dates in the core. This
+keeps it a flexible scheduler for any set of columns (days, rooms, machines,
+lanes …), not just a week.
+
+For an ordinary date-based week calendar, the optional
+[calendar helpers](calendar.md) map dates ↔ column indices on top of this model;
+the core stays date-agnostic by design (see
+[ADR 0001](decisions/0001-time-model-day-index.md)). No `DateTime` ever enters
+the widget API.
+
+## Core types
+
+| Type | Purpose |
+|------|---------|
+| `Planner` | The widget. Takes a `config`, a list of `entries`, and optional `controller` / builders. |
+| `PlannerConfig` | Sizing (`blockWidth`, `blockHeight`, `minHour`, `maxHour` — the inclusive last hour, default `23`, …), colors, text styles, an optional `hourLabelFormatter`, the optional column highlight (`highlightedColumn`, `highlightColumnColor`), the zoom controls (`showZoomControls`, `zoomButtonColor`, `zoomButtonIconColor`), the wheel `scrollStep`, the all-day band (`showAllDayBand`), and the `onEntry*` callbacks. `labels` is required. |
+| `PlannerController` | Optional handle to drive/observe zoom from outside the widget — see [Controller](controller.md). |
+| `PlannerEntry<T>` | One event: `id`, `time`, `title`, `content`, `color`, optional text styles, and an optional typed `data` payload (`T?`) for your own metadata — see [Builders](builders.md). |
+| `PlannerTime` | `day` (index into `labels`), optional `endDay` (a column-spanning event), `hour`, `minutes`, `duration` (minutes), and `allDay`. |
+| `PlannerEntryBuilder<T>` / `PlannerEntryLayout` | Build a custom widget for a timed event or all-day chip; `PlannerEntryLayout` carries the on-screen `size` (for detail-shedding), overlap column, and drag state — see [Builders](builders.md). |
+| `PlannerDayHeaderBuilder` | Build a custom widget for a day/column header — see [Builders](builders.md). |
+
+## Callbacks
+
+The widget reports interactions through `PlannerConfig`'s `onEntry*` callbacks;
+it never mutates your data itself.
+
+| Callback | Fires when |
+|----------|-----------|
+| `onEntryCreate(PlannerTime)` | An empty slot is double-tapped or "Create Event" is chosen. |
+| `onEntryEdit(PlannerEntry)` | An event is double-tapped or "Edit Event" is chosen. |
+| `onEntryDelete(PlannerEntry)` | "Delete Event" is chosen from the context menu. |
+| `onEntryMove(PlannerEntry)` | A drag-move or handle-resize finishes; the entry's `time` is already updated. |
+| `onEntryLongPress(PlannerEntry)` | An event is long-pressed — the touch hook for host-defined actions (see [Interactions](interactions.md)). |
+
+> Your callbacks own the data. Update your own list of entries (and call
+> `setState`) in response — the widget reports interactions but does not persist
+> them.
+
+---
+
+**More docs:** [Core concepts](core-concepts.md) · [Builders](builders.md) · [Calendar](calendar.md) · [Controller](controller.md) · [Interactions](interactions.md) · [README](../README.md)

--- a/docs/interactions.md
+++ b/docs/interactions.md
@@ -1,0 +1,108 @@
+# Interactions
+
+The widget reports user actions through the `onEntry*` callbacks; it never
+mutates your data itself. The gesture set adapts to the input device: a precise
+pointer (mouse) gets immediate drag-to-edit, while touch reserves one-finger drag
+for panning and surfaces event actions through a long-press.
+
+## Mouse / desktop
+
+| Gesture | Result |
+|---------|--------|
+| Drag the empty canvas | Pan both axes (day + time) at once. |
+| Drag the date row | Pan the day axis only. |
+| Drag the hour gutter | Pan the time axis only. |
+| Press an event body + drag | Move the event immediately (no long-press); fires `onEntryMove` on release. |
+| Press an event's top/bottom edge + drag | Resize the event; fires `onEntryMove` on release. |
+| Hover an event | Cursor hints the action: `move` over the body, `resizeUpDown` over an edge. |
+| Mouse wheel | Scroll the time axis. |
+| `Shift` + wheel | Scroll the day axis. |
+| `Ctrl` + wheel | Zoom the time axis. |
+| +/- buttons | Zoom the time axis (hide with `showZoomControls: false`; see [Controller](controller.md)). |
+| Double-click an event | `onEntryEdit`. |
+| Double-click an empty slot | `onEntryCreate`. |
+| Right-click an event | Context menu → Edit / Delete (`onEntryEdit` / `onEntryDelete`). |
+| Right-click an empty slot | Context menu → Create (`onEntryCreate`). |
+| Long-press an event | `onEntryLongPress` — the same hook touch uses. |
+
+One wheel notch always advances the same amount of *time* regardless of zoom;
+tune the base step with `scrollStep`.
+
+## Touch
+
+| Gesture | Result |
+|---------|--------|
+| One-finger drag | Pan both axes (day + time) at once. |
+| Two-finger pinch | Zoom the time axis. |
+| Double-tap an event | `onEntryEdit`. |
+| Double-tap an empty slot | `onEntryCreate`. |
+| Long-press an event | `onEntryLongPress` with that entry. |
+| Long-press an empty slot | Nothing. |
+
+Touch has no right-click and reserves one-finger drag for panning, so
+**long-press is how a touch user acts on an event**. The widget stays
+presentation-only: it hands the pressed `PlannerEntry` to `onEntryLongPress` and
+takes no action of its own (no built-in selection, highlight, or menu), so the
+host decides the response — show an action sheet, a selection UI, a delete
+confirmation, or start a move flow. To move an event by touch, drive it from this
+callback; immediate drag-move/resize is a desktop-only affordance.
+
+## Accessibility
+
+The event canvas is a single `CustomPaint`, so each event also exposes a
+semantics node for screen readers: activate to edit, dismiss to delete, and
+increase/decrease to nudge it an hour later/earlier (`onEntryMove`). Only the
+actions whose callback you wire are offered.
+
+## Localizing the context menu
+
+The context-menu item labels default to English but are plain `String`s on
+`PlannerConfig`, so you can translate or rename them:
+
+```dart
+PlannerConfig(
+  labels: const ['Lun', 'Mar', 'Mer'],
+  contextMenuCreateLabel: 'Créer un événement',
+  contextMenuEditLabel: 'Modifier l’événement',
+  contextMenuDeleteLabel: 'Supprimer l’événement',
+);
+```
+
+| Field | Defaults to | Item |
+|-------|-------------|------|
+| `contextMenuCreateLabel` | `'Create Event'` | Shown on an empty grid cell. |
+| `contextMenuEditLabel` | `'Edit Event'` | Shown on an existing event. |
+| `contextMenuDeleteLabel` | `'Delete Event'` | Shown on an existing event. |
+
+## Highlighting a column ("today" style)
+
+`planner` is [column-based, not date-based](core-concepts.md#the-time-model-columns-not-dates),
+so it has no idea which column is "today". To emphasize one — a calendar's
+current day, the active room, the selected lane — set `highlightedColumn` to its
+**index** into `labels`; the grid fills that column behind the lines and events:
+
+```dart
+final labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+PlannerConfig(
+  labels: labels,
+  // A calendar consumer owns the date↔index mapping and passes the index:
+  highlightedColumn: 2, // e.g. DateTime.now().weekday - 1
+  highlightColumnColor: Colors.amber.withValues(alpha: 0.15), // optional
+);
+```
+
+`highlightedColumn` defaults to `null` (no highlight); an out-of-range index
+highlights nothing. `highlightColumnColor` defaults to a subtle translucent white
+wash that reads on the default dark background — override it for a different tint
+(or a darker wash on a light background). For a real week calendar,
+[`CalendarWindow.todayColumn`](calendar.md) supplies the index directly.
+
+| Field | Defaults to | Purpose |
+|-------|-------------|---------|
+| `highlightedColumn` | `null` | Index into `labels` of the column to emphasize. |
+| `highlightColumnColor` | translucent white | Fill painted across that column. |
+
+---
+
+**More docs:** [Core concepts](core-concepts.md) · [Builders](builders.md) · [Calendar](calendar.md) · [Controller](controller.md) · [Interactions](interactions.md) · [README](../README.md)


### PR DESCRIPTION
## Summary
Restructure `README.md` from a 544-line dense reference into a scannable, screenshot-led landing page, and move the long reference into five cross-linked `docs/` guides. This is the pub.dev entry point for the upcoming 0.3.0 release.

The README now reads: description → screenshots → features → getting started → minimal usage → **Examples** (links the gallery + each example with a thumbnail and one-liner) → **Documentation** (blurbs linking the guides) → changelog / issues / license.

## Linked issue
Closes #91

## Changes
- **`README.md`** — slimmed to a landing page; install snippet switched from the `git:` source to `planner: ^0.3.0`; the short `CalendarPage` usage snippet kept.
- **Five new `docs/` guides**, with the reference content moved out of the README (no duplicated long sections), cross-linked to each other, the README, and each one's matching example page:
  - [`docs/core-concepts.md`](docs/core-concepts.md) — the column-based time model, core types table, callbacks table.
  - [`docs/builders.md`](docs/builders.md) — typed `PlannerEntry<T>.data`, `entryBuilder`, `dayHeaderBuilder`, `allDayEntryBuilder`.
  - [`docs/calendar.md`](docs/calendar.md) — date-based week calendar + `CalendarWindow` API table.
  - [`docs/controller.md`](docs/controller.md) — driving zoom from a host toolbar + `PlannerController` table.
  - [`docs/interactions.md`](docs/interactions.md) — mouse/touch/accessibility tables, context-menu localization, column highlighting.
- Screenshot/thumbnail image links wired to `docs/screenshots/*.png` (produced by #93; pub.dev resolves the relative paths via the existing `repository:` field).
- Dropped the `PROJECT_OVERVIEW.md` references (the new README structure omits them; the file itself is retired in #92) — replaced the model-note pointer with `docs/core-concepts.md` / ADR 0001.
- Minor: the column-highlight snippet uses `withValues(alpha:)` instead of deprecated `withOpacity`.

## Test plan
This is a documentation-only change (Markdown), so the verification is link/anchor resolution plus confirming the repo stays green:
- [x] `dart format --output=none --set-exit-if-changed .` — clean
- [x] `flutter analyze` (root + `example/`) — no issues
- [x] `flutter test` — **250 pass**
- [x] **Internal links verified** by script: all **87** relative links across the README + 5 docs pages resolve, and all `#anchor` fragments match real headings.
- [x] **Screenshot links present but pending** — the 7 `docs/screenshots/*.png` (`basic`, `showcase`, `typed-data`, `custom-headers`, `all-day`, `host-zoom`, `week-calendar`) are the only unresolved targets; they are produced by #93, as the issue's acceptance criteria anticipates ("wired when step 5 lands").
- No integration/e2e test: the change is Markdown docs, not user-visible app behavior, so a real-app run cannot exercise it — the link/anchor verification above is the doc-specific check.

## Notes
- #93 should generate the 7 PNGs named above; this PR makes the per-example thumbnails (optional in #93) a concrete target.