### PR TITLE
docs: point README repo-internal links at main (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ custom-painted canvas. Show several labelled columns side by side, each split
 into hours, and let users pan, zoom, and drag events to move or resize them. It
 is **column-based, not date-based** — a "day" is an index into the `labels` you
 provide, so it works for days, rooms, machines or any lanes; optional
-[calendar helpers](doc/calendar.md) add real dates on top.
+[calendar helpers](https://github.com/pebble-world/planner/blob/main/doc/calendar.md) add real dates on top.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/basic.png" alt="A basic planner with the default look" width="420">
@@ -18,17 +18,17 @@ provide, so it works for days, rooms, machines or any lanes; optional
 
 - Multiple labelled columns with an hour grid drawn on a single `CustomPaint`.
 - 2D panning, single-axis pan via the date row / hour gutter, and mouse-wheel
-  scroll with `Shift` / `Ctrl` modifiers ([interactions](doc/interactions.md)).
+  scroll with `Shift` / `Ctrl` modifiers ([interactions](https://github.com/pebble-world/planner/blob/main/doc/interactions.md)).
 - Zoom the time axis with pinch, `Ctrl`+wheel, or the built-in +/- buttons — or
-  drive it from your own chrome with a [`PlannerController`](doc/controller.md).
+  drive it from your own chrome with a [`PlannerController`](https://github.com/pebble-world/planner/blob/main/doc/controller.md).
 - Desktop drag-to-edit (move a body, resize an edge) with hover cursors; touch
   keeps one-finger drag for panning and exposes an `onEntryLongPress` hook.
 - Create / edit / delete via double-tap or a right-click context menu, with
   per-event accessibility semantics for screen readers.
 - Customizable colors and text styles, a "today"-style
-  [column highlight](doc/interactions.md#highlighting-a-column-today-style), and
-  a localizable [context menu](doc/interactions.md#localizing-the-context-menu).
-- **Fully custom widgets** via opt-in [builders](doc/builders.md): branded
+  [column highlight](https://github.com/pebble-world/planner/blob/main/doc/interactions.md#highlighting-a-column-today-style), and
+  a localizable [context menu](https://github.com/pebble-world/planner/blob/main/doc/interactions.md#localizing-the-context-menu).
+- **Fully custom widgets** via opt-in [builders](https://github.com/pebble-world/planner/blob/main/doc/builders.md): branded
   day/column headers, real-widget events that shed detail by pixel height, and
   custom all-day chips — each reading a typed `PlannerEntry<T>.data` payload.
 
@@ -105,19 +105,19 @@ them.
 
 ## Examples
 
-A gallery of runnable examples lives in [`example/`](example/lib/main.dart),
+A gallery of runnable examples lives in [`example/`](https://github.com/pebble-world/planner/blob/main/example/lib/main.dart),
 ordered basic → advanced. Each page demonstrates one feature on its own; the
 final Showcase combines them all.
 
 | Preview | Example | What it shows |
 |---------|---------|---------------|
-| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/basic.png" alt="Basic" width="200"> | [Basic](example/lib/examples/basic_example.dart) | A minimal planner with the default look and `onEntry*` callbacks. |
-| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/typed-data.png" alt="Typed data" width="200"> | [Typed data + entryBuilder](example/lib/examples/typed_data_example.dart) | A typed `PlannerEntry<T>.data` payload read back in a custom event card. |
-| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/custom-headers.png" alt="Custom headers" width="200"> | [Custom headers](example/lib/examples/custom_headers_example.dart) | A `CalendarWindow` + `dayHeaderBuilder` with a "today" highlight. |
-| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/all-day.png" alt="All-day band" width="200"> | [All-day band](example/lib/examples/all_day_example.dart) | Enabling the all-day band and drawing custom chips. |
-| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/host-zoom.png" alt="Host zoom" width="200"> | [Host zoom toolbar](example/lib/examples/host_zoom_example.dart) | Driving zoom from your own chrome via a `PlannerController`. |
-| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/week-calendar.png" alt="Week calendar" width="200"> | [Week calendar](example/lib/examples/week_calendar_example.dart) | A real week with prev/next navigation built on `calendar.dart`. |
-| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/showcase.png" alt="Showcase" width="200"> | [Showcase](example/lib/examples/showcase_example.dart) | Every customization hook wired together on one screen. |
+| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/basic.png" alt="Basic" width="200"> | [Basic](https://github.com/pebble-world/planner/blob/main/example/lib/examples/basic_example.dart) | A minimal planner with the default look and `onEntry*` callbacks. |
+| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/typed-data.png" alt="Typed data" width="200"> | [Typed data + entryBuilder](https://github.com/pebble-world/planner/blob/main/example/lib/examples/typed_data_example.dart) | A typed `PlannerEntry<T>.data` payload read back in a custom event card. |
+| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/custom-headers.png" alt="Custom headers" width="200"> | [Custom headers](https://github.com/pebble-world/planner/blob/main/example/lib/examples/custom_headers_example.dart) | A `CalendarWindow` + `dayHeaderBuilder` with a "today" highlight. |
+| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/all-day.png" alt="All-day band" width="200"> | [All-day band](https://github.com/pebble-world/planner/blob/main/example/lib/examples/all_day_example.dart) | Enabling the all-day band and drawing custom chips. |
+| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/host-zoom.png" alt="Host zoom" width="200"> | [Host zoom toolbar](https://github.com/pebble-world/planner/blob/main/example/lib/examples/host_zoom_example.dart) | Driving zoom from your own chrome via a `PlannerController`. |
+| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/week-calendar.png" alt="Week calendar" width="200"> | [Week calendar](https://github.com/pebble-world/planner/blob/main/example/lib/examples/week_calendar_example.dart) | A real week with prev/next navigation built on `calendar.dart`. |
+| <img src="https://raw.githubusercontent.com/pebble-world/planner/main/doc/screenshots/showcase.png" alt="Showcase" width="200"> | [Showcase](https://github.com/pebble-world/planner/blob/main/example/lib/examples/showcase_example.dart) | Every customization hook wired together on one screen. |
 
 The thumbnails are generated by the screenshot target ([#93](https://github.com/pebble-world/planner/issues/93)).
 
@@ -125,20 +125,20 @@ The thumbnails are generated by the screenshot target ([#93](https://github.com/
 
 | Guide | Covers |
 |-------|--------|
-| [Core concepts](doc/core-concepts.md) | The column-based time model, the core types, and the `onEntry*` callbacks. |
-| [Builders](doc/builders.md) | Typed `PlannerEntry<T>.data`, and the `entryBuilder` / `dayHeaderBuilder` / `allDayEntryBuilder` widget hooks. |
-| [Calendar](doc/calendar.md) | A date-based week calendar with `CalendarWindow` from `package:planner/calendar.dart`. |
-| [Controller](doc/controller.md) | Driving and observing zoom from a host toolbar with `PlannerController`. |
-| [Interactions](doc/interactions.md) | The mouse / touch / accessibility map, context-menu localization, and column highlighting. |
+| [Core concepts](https://github.com/pebble-world/planner/blob/main/doc/core-concepts.md) | The column-based time model, the core types, and the `onEntry*` callbacks. |
+| [Builders](https://github.com/pebble-world/planner/blob/main/doc/builders.md) | Typed `PlannerEntry<T>.data`, and the `entryBuilder` / `dayHeaderBuilder` / `allDayEntryBuilder` widget hooks. |
+| [Calendar](https://github.com/pebble-world/planner/blob/main/doc/calendar.md) | A date-based week calendar with `CalendarWindow` from `package:planner/calendar.dart`. |
+| [Controller](https://github.com/pebble-world/planner/blob/main/doc/controller.md) | Driving and observing zoom from a host toolbar with `PlannerController`. |
+| [Interactions](https://github.com/pebble-world/planner/blob/main/doc/interactions.md) | The mouse / touch / accessibility map, context-menu localization, and column highlighting. |
 
 ## Additional information
 
-- **Changelog:** [CHANGELOG.md](CHANGELOG.md).
+- **Changelog:** [CHANGELOG.md](https://github.com/pebble-world/planner/blob/main/CHANGELOG.md).
 - **Issues / contributions:** <https://github.com/pebble-world/planner/issues> — PRs welcome.
 
 ## License
 
-[MIT](LICENSE) © yvan vander sanden
+[MIT](https://github.com/pebble-world/planner/blob/main/LICENSE) © yvan vander sanden
 
 This package vendors third-party source code under its own license; see
-[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+[THIRD_PARTY_NOTICES.md](https://github.com/pebble-world/planner/blob/main/THIRD_PARTY_NOTICES.md).


### PR DESCRIPTION
## Summary

pub.dev resolves **relative** Markdown links in the README against the repo's GitHub default branch (`develop`), so the published package page linked visitors to develop's *unreleased* docs — inconsistent with the released version they were viewing. This converts the README's repo-internal Markdown links to absolute `main` URLs, matching what #102 already did for the screenshot `<img>` tags.

`main` only advances at release time, so the published page now always points at docs consistent with the latest release. `develop` stays the GitHub default branch, so the develop-centric PR flow is untouched.

## Linked issue

Closes #105

## Changes

- README repo-internal links now use absolute `https://github.com/pebble-world/planner/blob/main/<path>` URLs, covering `doc/*.md` (incl. the two `interactions.md` heading anchors), `example/*.dart`, `CHANGELOG.md`, `LICENSE`, and `THIRD_PARTY_NOTICES.md`.
- Untouched: the screenshot `<img>` tags (already absolute since #102) and the `#93` issue links (already absolute).

## Test plan

- [x] `flutter analyze` clean (no issues found)
- [x] All 16 linked targets verified to exist on `origin/main` (`git cat-file -e origin/main:<path>`) — no 404s
- [x] Both `interactions.md` heading anchors (`#highlighting-a-column-today-style`, `#localizing-the-context-menu`) verified against the headings on `main`
- [ ] No unit/widget/integration tests — change is documentation-only (Markdown links, no Dart or app-visible behavior), so per the workflow an integration test isn't warranted. Real pub.dev render is verifiable only at next publish; acceptance criteria note the README is frozen per version and this lands with the next release.