### PR TITLE
chore: automate pub.dev publishing via GitHub Actions (OIDC, tag-triggered) (#106)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to pub.dev
+
+# Automated publishing via pub.dev's GitHub Actions OIDC integration (no stored
+# tokens/secrets). The release signal is a pushed version tag on `main`, not a
+# PR or a `main` merge: a merge to `main` is not necessarily a release, whereas
+# a deliberate `vX.Y.Z` tag is the explicit "publish this version" intent. See
+# issue #106.
+#
+# One-time setup on pub.dev (owner action, outside this repo):
+#   pub.dev -> planner -> Admin -> Automated publishing -> enable GitHub Actions,
+#   repository `pebble-world/planner`, tag pattern `v{{version}}`.
+# pub.dev validates the tag matches the pubspec version, so a mismatched or
+# accidental tag will not publish.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    environment: pub.dev
+    permissions:
+      # Required for pub.dev OIDC: the pub client exchanges this token for a
+      # short-lived publishing credential. No secrets are stored in the repo.
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # Safety net before the upload (issue #106 acceptance criterion). The
+      # publish step re-runs package validation itself, but failing fast on a
+      # broken analyze/test surfaces the problem before anything is uploaded.
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test
+
+      - name: Publish to pub.dev
+        # --force skips the interactive confirmation; OIDC credentials are
+        # auto-detected from the `id-token: write` permission above.
+        run: flutter pub publish --force

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,42 @@ the full setup, the per-scenario map, and how to add a test.
 New work is started with the issue → branch → PR flow: every substantive change
 is tied to a GitHub issue and a focused branch. See the open
 [issues](https://github.com/pebble-world/planner/issues) for what's planned.
+
+## Releasing
+
+Releases publish to [pub.dev](https://pub.dev/packages/planner) automatically
+from GitHub Actions using pub.dev's OIDC integration — no tokens or secrets are
+stored in the repo. The trigger is a **pushed version tag**, not a PR or a merge
+to `main`: a merge to `main` is not necessarily a release, whereas a deliberate
+`vX.Y.Z` tag is the explicit "publish this version" signal.
+
+The flow:
+
+1. Finalize the version on `develop`: bump `version:` in
+   [`pubspec.yaml`](pubspec.yaml) and date the matching `CHANGELOG.md` entry.
+2. Open the `develop → main` release PR and merge it once `verify` and
+   `integration-windows` are green.
+3. Sync local `main`, then tag the merge commit and push the tag:
+
+   ```sh
+   git checkout main && git pull
+   git tag vX.Y.Z        # must match pubspec.yaml's version
+   git push origin vX.Y.Z
+   ```
+
+4. The [`publish` workflow](.github/workflows/publish.yml) runs on the tag:
+   it re-checks `flutter analyze` + `flutter test` as a safety net, then runs
+   `flutter pub publish --force`. pub.dev verifies the tag matches the pubspec
+   version (tag pattern `v{{version}}`), so a mismatched or accidental tag will
+   not publish — an extra guardrail that doubles as the "did you mean to
+   publish?" check.
+5. After it finishes, confirm the new version on the
+   [pub.dev page](https://pub.dev/packages/planner) (screenshots render, links
+   resolve once analysis settles a few minutes after publish).
+
+### One-time setup (maintainer, outside this repo)
+
+Automated publishing must be enabled once on pub.dev by a package owner:
+**pub.dev → `planner` → Admin → Automated publishing → enable GitHub Actions**,
+repository `pebble-world/planner`, tag pattern `v{{version}}`. This cannot be
+done from the repo; until it is enabled, tag pushes will fail to publish.


### PR DESCRIPTION
## Summary

Replaces the manual interactive `flutter pub publish` with a secrets-free,
tag-triggered GitHub Actions workflow using pub.dev's OIDC integration. Pushing
a `vX.Y.Z` tag (after the `develop -> main` release PR merges) publishes the
package automatically.

The trigger is the **tag**, not a PR or a `main` merge: a merge to `main` is not
necessarily a release, whereas a deliberate `vX.Y.Z` tag is the explicit publish
intent. pub.dev validates that the tag matches the pubspec version, which
doubles as a "did you mean to publish?" guardrail.

## Linked issue

Closes #106

## Changes

- **`.github/workflows/publish.yml`** (new) — runs on `v[0-9]+.[0-9]+.[0-9]+`
  tag pushes with `permissions: id-token: write` and `environment: pub.dev`.
  Steps: checkout -> `subosito/flutter-action` -> `flutter pub get` ->
  `flutter analyze` -> `flutter test` (the safety-net validation the issue's
  acceptance criteria require) -> `flutter pub publish --force` (OIDC
  auto-detected; no stored tokens/secrets). A custom Flutter job is used rather
  than the `dart-lang` reusable publish workflow, which assumes a Dart-only
  package — `planner` has `sdk: flutter` deps. Action versions are pinned to
  match the existing `ci.yml`.
- **`CONTRIBUTING.md`** — new "Releasing" section documenting the tag-triggered
  flow and the one-time pub.dev *Admin -> Automated publishing* setup.

## Prerequisite (maintainer, outside this repo)

Automated publishing must be enabled once on pub.dev by a package owner:
**pub.dev -> `planner` -> Admin -> Automated publishing -> enable GitHub
Actions**, repository `pebble-world/planner`, tag pattern `v{{version}}`. This
cannot be done from the repo; until enabled, tag pushes will not publish. (Also
documented in CONTRIBUTING.md.)

## Test plan

- [x] `flutter analyze` clean (No issues found)
- [x] unit/widget tests pass (`flutter test` — 250 tests)
- [x] `flutter pub publish --dry-run` validates the package (only warning is the
  expected "checked-in file is modified in git" for the in-progress doc edit)
- [x] `dart format --output=none --set-exit-if-changed .` clean
- [x] `publish.yml` is valid YAML; structure mirrors the existing `ci.yml`
  (no `actionlint` available locally)
- [ ] **No integration/e2e test — infeasible.** The workflow can only be
  exercised by actually publishing to pub.dev via owner-gated OIDC, an
  un-fakeable third-party system; it cannot be driven end-to-end against a fake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)